### PR TITLE
Align image to the right

### DIFF
--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -127,9 +127,9 @@ public class ForagePANTextField: UIView, Identifiable {
         let image = UIImage(named: "forageLogo", in: .module, compatibleWith: nil)
         imgView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         imgView.image = image
-        imgView.contentMode = .scaleAspectFit
         imgView.translatesAutoresizingMaskIntoConstraints = false
         imgView.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        imgView.widthAnchor.constraint(equalToConstant: 110).isActive = true
         return imgView
     }()
     
@@ -192,7 +192,7 @@ public class ForagePANTextField: UIView, Identifiable {
         
         imageView.anchor(
             top: imageViewContainer.topAnchor,
-            leading: imageViewContainer.leadingAnchor,
+            leading: nil,
             bottom: imageViewContainer.bottomAnchor,
             trailing: imageViewContainer.trailingAnchor,
             centerXAnchor: nil,

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -111,9 +111,9 @@ public class ForagePINTextField: UIView, Identifiable {
         let image = UIImage(named: "forageLogo", in: .module, compatibleWith: nil)
         imgView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         imgView.image = image
-        imgView.contentMode = .scaleAspectFit
         imgView.translatesAutoresizingMaskIntoConstraints = false
         imgView.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        imgView.widthAnchor.constraint(equalToConstant: 110).isActive = true
         return imgView
     }()
     
@@ -186,7 +186,7 @@ public class ForagePINTextField: UIView, Identifiable {
         
         imageView.anchor(
             top: imageViewContainer.topAnchor,
-            leading: imageViewContainer.leadingAnchor,
+            leading: nil,
             bottom: imageViewContainer.bottomAnchor,
             trailing: imageViewContainer.trailingAnchor,
             centerXAnchor: nil,


### PR DESCRIPTION
Related to the ticket: [SYM-77](https://linear.app/joinforage/issue/SYM-77/[ios]-add-forage-brand-to-component)

Description:
- It is a suggestion to align the image to the right for better UX

Align forage brand image to the right in the components:

| Old        | New           |
| ------------- |:-------------:|
| ![Screen Shot 2022-11-17 at 10 13 58](https://user-images.githubusercontent.com/115553362/202455919-970afe11-9089-44bc-a885-bc57cf16cdce.png) | ![Screen Shot 2022-11-17 at 10 06 30](https://user-images.githubusercontent.com/115553362/202454377-0b21f8d4-3a1a-42d5-9b29-368f4dc951f9.png) |
| ![Screen Shot 2022-11-17 at 10 13 12](https://user-images.githubusercontent.com/115553362/202455768-cb1fc2b9-45be-4387-ab61-faf5288c81ee.png)     | ![Screen Shot 2022-11-17 at 10 07 36](https://user-images.githubusercontent.com/115553362/202454623-747badaa-ca04-4183-8425-a5582aac84e1.png)      |



