### PR TITLE
[SYM-81] Polling for capture payment

### DIFF
--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -14,7 +14,7 @@ enum SampleAPI {
 extension SampleAPI: ServiceProtocol {
     var scheme: String { return "https" }
     
-    var host: String { return "api.sandbox.joinforage.app" }
+    var host: String { return "api.dev.joinforage.app" }
     
     var path: String { return "/api/payments/" }
     

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -12,6 +12,7 @@ enum ForageAPI {
     case xKey(bearerToken: String)
     case message(request: MessageResponseModel, bearerToken: String, merchantID: String)
     case retrieveBalance(request: ForageRequestModel)
+    case retrieveCapturedPayment(request: ForageRequestModel)
 }
 
 extension ForageAPI: ServiceProtocol {
@@ -25,13 +26,14 @@ extension ForageAPI: ServiceProtocol {
         case .xKey: return "/iso_server/encryption_alias/"
         case .message(request: let response, _, _): return "/api/message/\(response.contentId)/"
         case .retrieveBalance(request: let request): return "/api/payment_methods/\(request.paymentMethodReference)/"
+        case .retrieveCapturedPayment(request: let request): return "/api/payments/\(request.paymentReference)/"
         }
     }
     
     var method: HttpMethod {
         switch self {
         case .panNumber: return .post
-        case .xKey, .message, .retrieveBalance: return .get
+        case .xKey, .message, .retrieveBalance, .retrieveCapturedPayment: return .get
         }
     }
     
@@ -88,6 +90,18 @@ extension ForageAPI: ServiceProtocol {
             )
             
         case .retrieveBalance(request: let request):
+            let httpHeaders: HTTPHeaders = [
+                "Merchant-Account": request.merchantID,
+                "authorization": "Bearer \(request.authorization)"
+            ]
+            
+            return .requestParametersAndHeaders(
+                bodyParameters: nil,
+                urlParameters: nil,
+                additionalHeaders: httpHeaders
+            )
+            
+        case .retrieveCapturedPayment(request: let request):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": request.merchantID,
                 "authorization": "Bearer \(request.authorization)"

--- a/Sources/ForageSDK/Foundation/Network/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageService.swift
@@ -239,46 +239,22 @@ extension LiveForageService: Polling {
     func polling(_ pinType: PinType, response: VGSResponse, request: ForageRequestModel, completion: @escaping (Result<Data?, Error>) -> Void) {
         switch response {
         case .success(_, let data, _):
-            // TODO: SYM-81 - Padronize implementation for message, remove this IF-ELSE, keep only the implementation inside this IF
-            if pinType == .balance {
-                
-                self.parseVGSData(model: MessageResponseModel.self, data: data) { [weak self] messageResponse in
-                    switch messageResponse {
-                    case .success(let message):
-                        self?.pollingMessage(
-                            message: message,
-                            bearerToken: request.authorization,
-                            merchantID: request.merchantID) { pollingResult in
-                                switch pollingResult {
-                                case .success:
-                                    completion(.success(nil))
-                                case .failure(let error):
-                                    completion(.failure(error))
-                                }
+            self.parseVGSData(model: MessageResponseModel.self, data: data) { [weak self] messageResponse in
+                switch messageResponse {
+                case .success(let message):
+                    self?.pollingMessage(
+                        message: message,
+                        bearerToken: request.authorization,
+                        merchantID: request.merchantID) { pollingResult in
+                            switch pollingResult {
+                            case .success:
+                                completion(.success(nil))
+                            case .failure(let error):
+                                completion(.failure(error))
                             }
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
-                }
-                
-            } else {
-                self.parseVGSData(model: MessageBigModel.self, data: data) { [weak self] messageResponse in
-                    switch messageResponse {
-                    case .success(let message):
-                        self?.pollingMessage(
-                            message: message.message,
-                            bearerToken: request.authorization,
-                            merchantID: request.merchantID) { pollingResult in
-                                switch pollingResult {
-                                case .success:
-                                    completion(.success(nil))
-                                case .failure(let error):
-                                    completion(.failure(error))
-                                }
-                            }
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
+                        }
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
 

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponse.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponse.swift
@@ -12,10 +12,6 @@ internal enum BalanceStatus: String, Codable {
     case completed = "completed"
 }
 
-internal struct MessageBigModel: Codable {
-    let message: MessageResponseModel
-}
-
 internal struct MessageResponseModel: Codable {
     let contentId: String
     let messageType: String

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponse.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponse.swift
@@ -12,6 +12,10 @@ internal enum BalanceStatus: String, Codable {
     case completed = "completed"
 }
 
+internal struct MessageBigModel: Codable {
+    let message: MessageResponseModel
+}
+
 internal struct MessageResponseModel: Codable {
     let contentId: String
     let messageType: String


### PR DESCRIPTION
Ticket: [SYM-81](https://linear.app/joinforage/issue/SYM-81/[ios]-polling-on-capture-payment)

*This PR needs to be merged after [SYM-74](https://github.com/teamforage/forage-ios-sdk/pull/13)*

Sub-tickets:

- [x] [SYM-82](https://linear.app/joinforage/issue/SYM-82/[ios]-breakdown-capture-payment) - Break down the capture flow to use the polling implementation
- [x] [SYM-83](https://linear.app/joinforage/issue/SYM-83/[ios]-padronize-implementation-for-message) - Padronize implementation for message, waiting a deploy to update the message model same as check balance
- [x] [SYM-84](https://linear.app/joinforage/issue/SYM-84/[ios]-polling-capture) - Polling implementation for capture payment

