### PR TITLE
Adjust validation to allow invalid cards to be sent through iframe

### DIFF
--- a/Sample/SampleForageSDK/AppDelegate.swift
+++ b/Sample/SampleForageSDK/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         ForageSDK.setup(
-            ForageSDK.Config(environment: .dev)
+            ForageSDK.Config(environment: .sandbox)
         )
         
         // Override point for customization after application launch.

--- a/Sample/SampleForageSDK/Base.lproj/Main.storyboard
+++ b/Sample/SampleForageSDK/Base.lproj/Main.storyboard
@@ -29,7 +29,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="yzXZvJxXXF19L7bIRXDeISsMj7YLNK" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Jp-Qt-zxc">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Jp-Qt-zxc">
                                                 <rect key="frame" x="24" y="53" width="366" height="42"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="tf_bearer_token" label="Bearer token text field"/>
                                                 <constraints>
@@ -60,7 +60,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="9876545" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-tP-yg0">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-tP-yg0">
                                                 <rect key="frame" x="24" y="53" width="366" height="42"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="tf_merchant_id" label="Merchant Id text field"/>
                                                 <constraints>

--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -14,7 +14,7 @@ enum SampleAPI {
 extension SampleAPI: ServiceProtocol {
     var scheme: String { return "https" }
     
-    var host: String { return "api.dev.joinforage.app" }
+    var host: String { return "api.sandbox.joinforage.app" }
     
     var path: String { return "/api/payments/" }
     

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -15,6 +15,7 @@ public enum EnvironmentTarget: String {
     case sandbox = "api.sandbox.joinforage.app"
     case cert = "api.cert.joinforage.app"
     case prod = "api.joinforage.app"
+    case staging = "api.staging.joinforage.app"
     case dev = "api.dev.joinforage.app"
 }
 
@@ -25,6 +26,7 @@ private enum VaultId: String {
     case sandbox = "tntagcot4b1"
     case cert = "tntpnht7psv"
     case prod = "tntbcrncmgi"
+    case staging = "tnteykuh975"
     case dev = "tntlqkidhc6"
 }
 
@@ -76,7 +78,7 @@ public class ForageSDK {
      
     ````
       ForageSDK.setup(
-         ForageSDK.Config(environment: .dev)
+         ForageSDK.Config(environment: .sandbox)
       )
     ````
      */
@@ -91,13 +93,14 @@ public class ForageSDK {
         case .sandbox: return .sandbox
         case .cert: return .cert
         case .prod: return .prod
+        case .staging: return .staging
         case .dev: return .dev
         }
     }
     
     private func environmentVGS(_ environment: EnvironmentTarget) -> VGSCollectSDK.Environment {
         switch environment {
-        case .cert, .sandbox, .dev: return .sandbox
+        case .cert, .sandbox, .staging, .dev: return .sandbox
         case .prod: return .live
         }
     }


### PR DESCRIPTION
## What
The card input field validation was very strict and wouldn't allow non-production EBT cards to be entered.

## Why
Although this is the ideal functionality in practice, we need to allow our Merchants to pass in specific EBT cards to complete failure scenarios.

## Test Plan
Tested this change locally in the sample app.
