### PR TITLE
[FOR-1842] Add support for userID param on `tokenizeEBTCard`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To send the PAN number, we can use ForageSDK to perform the request.
 func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
-    userID: String,
+    customerID: String,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
 )
 ```
@@ -131,7 +131,7 @@ ForageSDK.shared.tokenizeEBTCard(
     merchantAccount: merchantID,
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
-    userID: UUID.init().uuidString) { result in
+    customerID: UUID.init().uuidString) { result in
         // handle callback here
     }
 ```

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-    userID: String?
+    userID: String
 )
 ```
 
@@ -129,7 +129,9 @@ func tokenizeEBTCard(
 ForageSDK.shared.tokenizeEBTCard(
     bearerToken: bearerToken,
     merchantAccount: merchantID,
-    userID: userID) { result in
+    // NOTE: The following line is for testing purposes only and should not be used in production.
+    // Please replace this line with a real hashed customer ID value.
+    userID: UUID.init().uuidString) { result in
         // handle callback here
     }
 ```

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ To send the PAN number, we can use ForageSDK to perform the request.
 func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
-    completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-    userID: String
+    userID: String,
+    completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ To send the PAN number, we can use ForageSDK to perform the request.
 func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
-    completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
+    completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
+    userID: String?
 )
 ```
 
@@ -127,7 +128,8 @@ func tokenizeEBTCard(
 
 ForageSDK.shared.tokenizeEBTCard(
     bearerToken: bearerToken,
-    merchantAccount: merchantID) { result in
+    merchantAccount: merchantID,
+    userID: userID) { result in
         // handle callback here
     }
 ```

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -15,5 +15,7 @@ class ClientSharedData {
     var merchantID: String = ""
     var bearerToken: String = ""
     var paymentReference: [FundingType : String] = [:]
-    var userID: String? = "test-ios-user-id"
+    // NOTE: The following line is for testing purposes only and should not be used in production.
+    // Please replace this line with a real hashed customer ID value.
+    var userID: String = UUID.init().uuidString
 }

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -17,5 +17,5 @@ class ClientSharedData {
     var paymentReference: [FundingType : String] = [:]
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
-    var userID: String = UUID.init().uuidString
+    var customerID: String = UUID.init().uuidString
 }

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -15,4 +15,5 @@ class ClientSharedData {
     var merchantID: String = ""
     var bearerToken: String = ""
     var paymentReference: [FundingType : String] = [:]
+    var userID: String? = "test-ios-user-id"
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/Address.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/Address.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Address: Codable {
+public struct Address: Codable {
     let city: String
     let country: String
     let line1: String?

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
@@ -16,5 +16,5 @@ struct CreatePaymentRequest {
     let metadata: [String:String]
     let deliveryAddress: Address
     let isDelivery: Bool
-    let userID: String?
+    let userID: String
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
@@ -16,4 +16,5 @@ struct CreatePaymentRequest {
     let metadata: [String:String]
     let deliveryAddress: Address
     let isDelivery: Bool
+    let userID: String?
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
@@ -16,5 +16,5 @@ struct CreatePaymentRequest {
     let metadata: [String:String]
     let deliveryAddress: Address
     let isDelivery: Bool
-    let userID: String
+    let customerID: String
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForageBalanceModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForageBalanceModel.swift
@@ -22,19 +22,3 @@ public struct ForageBalanceModel: Codable {
         case updated
     }
 }
-
-internal struct MessageResponse: Codable {
-    let contentId: String
-    let messageType: String
-    let status: String
-    let failed: Bool
-    let errors: [String]
-    
-    private enum CodingKeys : String, CodingKey {
-        case contentId = "content_id"
-        case messageType = "message_type"
-        case status
-        case failed
-        case errors
-    }
-}

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForageCaptureModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForageCaptureModel.swift
@@ -7,15 +7,6 @@
 
 import UIKit
 
-public struct ForageAddress: Codable {
-    public let city: String
-    public let country: String
-    public let line1: String?
-    public let line2: String?
-    public let zipcode: String
-    public let state: String
-}
-
 public enum ForageOrderStatus: String, Codable {
     case draft
     case processing
@@ -31,7 +22,7 @@ public struct ForageCaptureModel: Codable {
     public let amount: String
     public let description: String
     public let paymentMethodIdentifier: String
-    public let deliveryAddress: ForageAddress
+    public let deliveryAddress: Address
     public let isDelivery: Bool
     public let createdDate: String
     public let updatedDate: String

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
@@ -21,10 +21,12 @@ public struct ForagePANModel: Codable {
     public let paymentMethodIdentifier: String
     public let type: String
     public let card: ForageCard
+    public let userID: String?
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"
         case type
         case card
+        case userID = "user_id"
     }
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
@@ -21,7 +21,7 @@ public struct ForagePANModel: Codable {
     public let paymentMethodIdentifier: String
     public let type: String
     public let card: ForageCard
-    public let userID: String?
+    public let userID: String
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
@@ -27,6 +27,6 @@ public struct ForagePANModel: Codable {
         case paymentMethodIdentifier = "ref"
         case type
         case card
-        case customerID = "user_id"
+        case customerID = "customer_id"
     }
 }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForagePANModel.swift
@@ -21,12 +21,12 @@ public struct ForagePANModel: Codable {
     public let paymentMethodIdentifier: String
     public let type: String
     public let card: ForageCard
-    public let userID: String
+    public let customerID: String
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"
         case type
         case card
-        case userID = "user_id"
+        case customerID = "user_id"
     }
 }

--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -38,7 +38,7 @@ extension SampleAPI: ServiceProtocol {
                     "state": model.deliveryAddress.state,
                 ],
                 "is_delivery": model.isDelivery,
-                "user_id": model.userID ?? ""
+                "user_id": model.userID
             ]
             
             let httpHeaders: HTTPHeaders = [

--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -38,7 +38,7 @@ extension SampleAPI: ServiceProtocol {
                     "state": model.deliveryAddress.state,
                 ],
                 "is_delivery": model.isDelivery,
-                "user_id": model.userID
+                "customer_id": model.customerID
             ]
             
             let httpHeaders: HTTPHeaders = [

--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -37,13 +37,15 @@ extension SampleAPI: ServiceProtocol {
                     "zipcode": model.deliveryAddress.zipcode,
                     "state": model.deliveryAddress.state,
                 ],
-                "is_delivery": model.isDelivery
+                "is_delivery": model.isDelivery,
+                "user_id": model.userID ?? ""
             ]
             
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": model.merchantAccount,
                 "IDEMPOTENCY-KEY": UUID.init().uuidString,
-                "authorization": "Bearer \(ClientSharedData.shared.bearerToken)"
+                "authorization": "Bearer \(ClientSharedData.shared.bearerToken)",
+                "API-VERSION": "2023-03-31"
             ]
             
             return .requestParametersAndHeaders(

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -132,6 +132,17 @@ class CardNumberView: UIView {
         return label
     }()
     
+    private let userIDLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        label.numberOfLines = 0
+        label.accessibilityIdentifier = "lbl_userID"
+        label.isAccessibilityElement = true
+        return label
+    }()
+    
     private let errorLabel: UILabel = {
         let label = UILabel()
         label.text = ""
@@ -149,7 +160,8 @@ class CardNumberView: UIView {
         if isCardValid {
             ForageSDK.shared.tokenizeEBTCard(
                 bearerToken: ClientSharedData.shared.bearerToken,
-                merchantAccount: ClientSharedData.shared.merchantID) { result in
+                merchantAccount: ClientSharedData.shared.merchantID,
+                userID: ClientSharedData.shared.userID) { result in
                     self.printResult(result: result)
                 }
         }
@@ -177,6 +189,7 @@ class CardNumberView: UIView {
                 self.typeLabel.text = "type=\(response.type)"
                 self.tokenLabel.text = "token=\(response.card.token)"
                 self.last4Label.text = "last4=\(response.card.last4)"
+                self.userIDLabel.text = "userID=\(response.userID ?? "nil")"
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)
@@ -186,6 +199,7 @@ class CardNumberView: UIView {
                 self.typeLabel.text = ""
                 self.tokenLabel.text = ""
                 self.last4Label.text = ""
+                self.userIDLabel.text = ""
                 self.updateButtonState(isEnabled: false, button: self.nextButton)
             }
             
@@ -203,6 +217,7 @@ class CardNumberView: UIView {
         contentView.addSubview(typeLabel)
         contentView.addSubview(tokenLabel)
         contentView.addSubview(last4Label)
+        contentView.addSubview(userIDLabel)
         contentView.addSubview(errorLabel)
         contentView.addSubview(sendPanButton)
         contentView.addSubview(nextButton)
@@ -286,8 +301,17 @@ class CardNumberView: UIView {
             padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
-        errorLabel.anchor(
+        userIDLabel.anchor(
             top: last4Label.safeAreaLayoutGuide.bottomAnchor,
+            leading: contentView.safeAreaLayoutGuide.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
+        )
+        
+        errorLabel.anchor(
+            top: errorLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -132,13 +132,13 @@ class CardNumberView: UIView {
         return label
     }()
     
-    private let userIDLabel: UILabel = {
+    private let customerIDLabel: UILabel = {
         let label = UILabel()
         label.text = ""
         label.textColor = .black
         label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
         label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_userID"
+        label.accessibilityIdentifier = "lbl_customerID"
         label.isAccessibilityElement = true
         return label
     }()
@@ -161,7 +161,7 @@ class CardNumberView: UIView {
             ForageSDK.shared.tokenizeEBTCard(
                 bearerToken: ClientSharedData.shared.bearerToken,
                 merchantAccount: ClientSharedData.shared.merchantID,
-                userID: ClientSharedData.shared.userID) { result in
+                customerID: ClientSharedData.shared.customerID) { result in
                     self.printResult(result: result)
                 }
         }
@@ -189,7 +189,7 @@ class CardNumberView: UIView {
                 self.typeLabel.text = "type=\(response.type)"
                 self.tokenLabel.text = "token=\(response.card.token)"
                 self.last4Label.text = "last4=\(response.card.last4)"
-                self.userIDLabel.text = "userID=\(response.userID)"
+                self.customerIDLabel.text = "customerID=\(response.customerID ?? "NO CUST ID")"
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)
@@ -199,7 +199,7 @@ class CardNumberView: UIView {
                 self.typeLabel.text = ""
                 self.tokenLabel.text = ""
                 self.last4Label.text = ""
-                self.userIDLabel.text = ""
+                self.customerIDLabel.text = ""
                 self.updateButtonState(isEnabled: false, button: self.nextButton)
             }
             
@@ -217,7 +217,7 @@ class CardNumberView: UIView {
         contentView.addSubview(typeLabel)
         contentView.addSubview(tokenLabel)
         contentView.addSubview(last4Label)
-        contentView.addSubview(userIDLabel)
+        contentView.addSubview(customerIDLabel)
         contentView.addSubview(errorLabel)
         contentView.addSubview(sendPanButton)
         contentView.addSubview(nextButton)
@@ -301,7 +301,7 @@ class CardNumberView: UIView {
             padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
-        userIDLabel.anchor(
+        customerIDLabel.anchor(
             top: last4Label.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -189,7 +189,7 @@ class CardNumberView: UIView {
                 self.typeLabel.text = "type=\(response.type)"
                 self.tokenLabel.text = "token=\(response.card.token)"
                 self.last4Label.text = "last4=\(response.card.last4)"
-                self.userIDLabel.text = "userID=\(response.userID ?? "nil")"
+                self.userIDLabel.text = "userID=\(response.userID)"
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)

--- a/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
@@ -219,7 +219,8 @@ class CreatePaymentView: UIView {
                 zipcode: "12345",
                 state: "LA"
             ),
-            isDelivery: false
+            isDelivery: false,
+            userID: "test-ios-user-id"
         )
         
         controller.createPayment(request: request) { result in

--- a/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
@@ -220,7 +220,7 @@ class CreatePaymentView: UIView {
                 state: "LA"
             ),
             isDelivery: false,
-            userID: ClientSharedData.shared.userID
+            customerID: ClientSharedData.shared.customerID
         )
         
         controller.createPayment(request: request) { result in

--- a/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
@@ -220,7 +220,7 @@ class CreatePaymentView: UIView {
                 state: "LA"
             ),
             isDelivery: false,
-            userID: "test-ios-user-id"
+            userID: ClientSharedData.shared.userID
         )
         
         controller.createPayment(request: request) { result in

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -24,15 +24,13 @@ protocol ForageSDKService: AnyObject {
     /// - Parameters:
     ///  - bearerToken: Authorization token.
     ///  - merchantAccount: Merchant account identifier, `merchant id`.
-    ///  - userID: A unique ID for the end customer making the payment.
+    ///  - customerID: A unique ID for the end customer making the payment. We recommend that you hash this value.
     ///  - completion: Which will return the result. See more [here](https://docs.joinforage.app/reference/create-payment-method-1)
-    ///
-    ///  - Note: If you're providing your internal user ID for `userID`, then we recommend that you hash the value before sending it on the payload. This field is optional, but omitting it causes resource action endpoints to throttle on the customer's IP.
     func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-        userID: String?)
+        userID: String)
         
     /// Check balance for a given EBT Card
     ///
@@ -71,7 +69,7 @@ extension ForageSDK: ForageSDKService {
         bearerToken: String,
         merchantAccount: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-        userID: String? = nil
+        userID: String
     ) {
         let request = ForagePANRequestModel(
             authorization: bearerToken,

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -29,7 +29,7 @@ protocol ForageSDKService: AnyObject {
     func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        userID: String,
+        customerID: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
         
     /// Check balance for a given EBT Card
@@ -68,7 +68,7 @@ extension ForageSDK: ForageSDKService {
     public func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        userID: String,
+        customerID: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
         let request = ForagePANRequestModel(
@@ -77,7 +77,7 @@ extension ForageSDK: ForageSDKService {
             panNumber: panNumber,
             type: CardType.ebt.rawValue,
             reusable: true,
-            userID: userID
+            customerID: customerID
         )
         service?.tokenizeEBTCard(request: request, completion: completion)
     }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -24,11 +24,15 @@ protocol ForageSDKService: AnyObject {
     /// - Parameters:
     ///  - bearerToken: Authorization token.
     ///  - merchantAccount: Merchant account identifier, `merchant id`.
-    ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/create-payment-method-1))
+    ///  - userID: A unique ID for the end customer making the payment.
+    ///  - completion: Which will return the result. See more [here](https://docs.joinforage.app/reference/create-payment-method-1)
+    ///
+    ///  - Note: If you're providing your internal user ID for `userID`, then we recommend that you hash the value before sending it on the payload. This field is optional, but omitting it causes resource action endpoints to throttle on the customer's IP.
     func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
+        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
+        userID: String?)
         
     /// Check balance for a given EBT Card
     ///
@@ -66,13 +70,16 @@ extension ForageSDK: ForageSDKService {
     public func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) {
+        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
+        userID: String? = nil
+    ) {
         let request = ForagePANRequestModel(
             authorization: bearerToken,
             merchantAccount: merchantAccount,
             panNumber: panNumber,
             type: CardType.ebt.rawValue,
-            reusable: true
+            reusable: true,
+            userID: userID
         )
         service?.tokenizeEBTCard(request: request, completion: completion)
     }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -29,8 +29,8 @@ protocol ForageSDKService: AnyObject {
     func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-        userID: String)
+        userID: String,
+        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
         
     /// Check balance for a given EBT Card
     ///
@@ -68,8 +68,8 @@ extension ForageSDK: ForageSDKService {
     public func tokenizeEBTCard(
         bearerToken: String,
         merchantAccount: String,
-        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void,
-        userID: String
+        userID: String,
+        completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
         let request = ForagePANRequestModel(
             authorization: bearerToken,

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -52,7 +52,7 @@ extension ForageAPI: ServiceProtocol {
                 "type": model.type,
                 "reusable": model.reusable,
                 "card": card,
-                "user_id": model.userID
+                "customer_id": model.customerID
             ]
 
             let httpHeaders: HTTPHeaders = [
@@ -112,7 +112,8 @@ extension ForageAPI: ServiceProtocol {
         case .getPayment(request: let request):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": request.merchantAccount,
-                "authorization": "Bearer \(request.bearerToken)"
+                "authorization": "Bearer \(request.bearerToken)",
+                "API-VERSION": "2023-03-31"
             ]
             
             return .requestParametersAndHeaders(

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -48,15 +48,12 @@ extension ForageAPI: ServiceProtocol {
             var card = [String: String]()
             card["number"] = model.panNumber
             
-            var bodyParameters: Parameters = [
+            let bodyParameters: Parameters = [
                 "type": model.type,
                 "reusable": model.reusable,
-                "card": card
+                "card": card,
+                "user_id": model.userID
             ]
-            
-           if let userID = model.userID {
-               bodyParameters["user_id"] = userID
-           }
 
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": model.merchantAccount,

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -99,7 +99,8 @@ extension ForageAPI: ServiceProtocol {
         case .getPaymentMethod(request: let request):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": request.merchantAccount,
-                "authorization": "Bearer \(request.bearerToken)"
+                "authorization": "Bearer \(request.bearerToken)",
+                "API-VERSION": "2023-03-31"
             ]
             
             return .requestParametersAndHeaders(

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -60,7 +60,7 @@ extension ForageAPI: ServiceProtocol {
                 "authorization": "Bearer \(model.authorization)",
                 "content-type": "application/json",
                 "accept": "application/json",
-               "API-VERSION": "2023-03-31"
+                "API-VERSION": "2023-03-31"
             ]
             
             return .requestParametersAndHeaders(

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -48,17 +48,22 @@ extension ForageAPI: ServiceProtocol {
             var card = [String: String]()
             card["number"] = model.panNumber
             
-            let bodyParameters: Parameters = [
+            var bodyParameters: Parameters = [
                 "type": model.type,
                 "reusable": model.reusable,
                 "card": card
             ]
+            
+           if let userID = model.userID {
+               bodyParameters["user_id"] = userID
+           }
 
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": model.merchantAccount,
                 "authorization": "Bearer \(model.authorization)",
                 "content-type": "application/json",
-                "accept": "application/json"
+                "accept": "application/json",
+               "API-VERSION": "2023-03-31"
             ]
             
             return .requestParametersAndHeaders(

--- a/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
@@ -14,4 +14,5 @@ internal struct ForagePANRequestModel: Codable {
     let panNumber: String
     let type: String
     let reusable: Bool
+    let userID: String?
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
@@ -14,5 +14,5 @@ internal struct ForagePANRequestModel: Codable {
     let panNumber: String
     let type: String
     let reusable: Bool
-    let userID: String
+    let customerID: String
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
@@ -14,5 +14,5 @@ internal struct ForagePANRequestModel: Codable {
     let panNumber: String
     let type: String
     let reusable: Bool
-    let userID: String?
+    let userID: String
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
@@ -39,7 +39,7 @@ public struct PaymentMethodModel: Codable {
     public let type: String
     public let balance: BalanceModel?
     public let card: ForageCard
-    public let userID: String?
+    public let userID: String
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
@@ -39,11 +39,13 @@ public struct PaymentMethodModel: Codable {
     public let type: String
     public let balance: BalanceModel?
     public let card: ForageCard
+    public let userID: String?
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"
         case type
         case card
         case balance
+        case userID = "user_id"
     }
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
@@ -39,13 +39,13 @@ public struct PaymentMethodModel: Codable {
     public let type: String
     public let balance: BalanceModel?
     public let card: ForageCard
-    public let userID: String
+    public let customerID: String?
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"
         case type
         case card
         case balance
-        case userID = "user_id"
+        case customerID = "customer_id"
     }
 }

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -19,56 +19,31 @@ final class ForageServiceTests: XCTestCase {
         forageMocks = ForageMocks()
     }
     
-    func setUpTokenizeEBTCardTest(userID: String? = nil) -> (service: LiveForageService, foragePANRequestModel: ForagePANRequestModel) {
+    func test_tokenizeEBTCard_onSuccess_checkExpectedPayload() {
         let mockSession = URLSessionMock()
-        mockSession.data = userID == nil ? forageMocks.tokenizeSuccessWithoutUserID : forageMocks.tokenizeSuccessWithUserID
+        mockSession.data = forageMocks.tokenizeSuccess
         mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
-        
+
         let foragePANRequestModel = ForagePANRequestModel(
-            authorization: "authToken123",
-            merchantAccount: "merchantID123",
-            panNumber: "5076801234123412",
-            type: "ebt",
-            reusable: true,
-            userID: userID
+           authorization: "authToken123",
+           merchantAccount: "merchantID123",
+           panNumber: "5076801234123412",
+           type: "ebt",
+           reusable: true,
+           customerID: "test-ios-customer-id"
         )
 
-        return (service: service, foragePANRequestModel: foragePANRequestModel)
-    }
-    
-    func test_tokenizeEBTCard_onSuccess_checkExpectedPayload_withUserID() {
-        let testUserID = "test-ios-user-id"
-        let setupResult = self.setUpTokenizeEBTCardTest(userID: testUserID)
-        
-        setupResult.service.tokenizeEBTCard(request: setupResult.foragePANRequestModel) { result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(response.type, "ebt")
-                XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
-                XCTAssertEqual(response.card.last4, "3412")
-                XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
-                XCTAssertEqual(response.userID, testUserID)
-            case .failure:
-                XCTFail("Expected success")
-            }
-        }
-    }
-    
-    func test_tokenizeEBTCard_onSuccess_checkExpectedPayload_withoutUserID() {
-        let setupResult = self.setUpTokenizeEBTCardTest()
-        
-        setupResult.service.tokenizeEBTCard(request: setupResult.foragePANRequestModel) { result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(response.type, "ebt")
-                XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
-                XCTAssertEqual(response.card.last4, "3412")
-                XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
-                XCTAssertEqual(response.userID, nil)
-            case .failure:
-                XCTFail("Expected success")
-            }
+        service.tokenizeEBTCard(request: foragePANRequestModel) { result in
+           switch result {
+           case .success(let response):
+               XCTAssertEqual(response.type, "ebt")
+               XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
+               XCTAssertEqual(response.card.last4, "3412")
+               XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
+           case .failure:
+               XCTFail("Expected success")
+           }
         }
     }
     

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -31,7 +31,7 @@ final class ForageServiceTests: XCTestCase {
            panNumber: "5076801234123412",
            type: "ebt",
            reusable: true,
-           customerID: "test-ios-customer-id"
+           userID: "test-ios-customer-id"
         )
 
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in
@@ -41,6 +41,7 @@ final class ForageServiceTests: XCTestCase {
                XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
                XCTAssertEqual(response.card.last4, "3412")
                XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
+               XCTAssertEqual(response.userID, "test-ios-customer-id")
            case .failure:
                XCTFail("Expected success")
            }

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -24,27 +24,27 @@ final class ForageServiceTests: XCTestCase {
         mockSession.data = forageMocks.tokenizeSuccess
         mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
-
+        
         let foragePANRequestModel = ForagePANRequestModel(
-           authorization: "authToken123",
-           merchantAccount: "merchantID123",
-           panNumber: "5076801234123412",
-           type: "ebt",
-           reusable: true,
-           userID: "test-ios-customer-id"
+            authorization: "authToken123",
+            merchantAccount: "merchantID123",
+            panNumber: "5076801234123412",
+            type: "ebt",
+            reusable: true,
+            userID: "test-ios-customer-id"
         )
-
+        
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in
-           switch result {
-           case .success(let response):
-               XCTAssertEqual(response.type, "ebt")
-               XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
-               XCTAssertEqual(response.card.last4, "3412")
-               XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
-               XCTAssertEqual(response.userID, "test-ios-customer-id")
-           case .failure:
-               XCTFail("Expected success")
-           }
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.type, "ebt")
+                XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
+                XCTAssertEqual(response.card.last4, "3412")
+                XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
+                XCTAssertEqual(response.userID, "test-ios-customer-id")
+            case .failure:
+                XCTFail("Expected success")
+            }
         }
     }
     
@@ -72,7 +72,7 @@ final class ForageServiceTests: XCTestCase {
             }
         }
     }
-
+    
     func test_getXKey_onSuccess_checkExpectedPayload() {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.xKeySuccess
@@ -176,7 +176,7 @@ final class ForageServiceTests: XCTestCase {
             }
         }
     }
-
+    
     func test_getBalance_onSuccess_checkExpectedPayload() {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.getBalanceSuccess
@@ -192,7 +192,7 @@ final class ForageServiceTests: XCTestCase {
             merchantID: "merchantID123",
             xKey: "tok_sandbox_agCcwWZs8TMkkq89f8KHSx"
         )
-
+        
         service.checkBalance(pinCollector: vgs, request: forageRequestModel) { result in
             switch result {
             case .success(let response):
@@ -220,7 +220,7 @@ final class ForageServiceTests: XCTestCase {
             merchantID: "merchantID123",
             xKey: "tok_sandbox_agCcwWZs8TMkkq89f8KHSx"
         )
-
+        
         service.checkBalance(pinCollector: vgs, request: forageRequestModel) { result in
             switch result {
             case .success:
@@ -246,7 +246,7 @@ final class ForageServiceTests: XCTestCase {
             merchantID: "merchantID123",
             xKey: "tok_sandbox_agCcwWZs8TMkkq89f8KHSx"
         )
-
+        
         service.capturePayment(pinCollector: vgs, request: forageRequestModel) { result in
             switch result {
             case .success(let response):
@@ -278,7 +278,7 @@ final class ForageServiceTests: XCTestCase {
             merchantID: "merchantID123",
             xKey: "tok_sandbox_agCcwWZs8TMkkq89f8KHSx"
         )
-
+        
         service.checkBalance(pinCollector: vgs, request: forageRequestModel) { result in
             switch result {
             case .success:

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -31,7 +31,7 @@ final class ForageServiceTests: XCTestCase {
             panNumber: "5076801234123412",
             type: "ebt",
             reusable: true,
-            userID: "test-ios-customer-id"
+            customerID: "test-ios-customer-id"
         )
         
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in
@@ -41,7 +41,7 @@ final class ForageServiceTests: XCTestCase {
                 XCTAssertEqual(response.paymentMethodIdentifier, "d0c47b0ed5")
                 XCTAssertEqual(response.card.last4, "3412")
                 XCTAssertEqual(response.card.token, "tok_sandbox_72VEC9LasHbMYiiVWP9zms")
-                XCTAssertEqual(response.userID, "test-ios-customer-id")
+                XCTAssertEqual(response.customerID, "test-ios-customer-id")
             case .failure:
                 XCTFail("Expected success")
             }
@@ -60,7 +60,7 @@ final class ForageServiceTests: XCTestCase {
             panNumber: "5076801234123412",
             type: "ebt",
             reusable: true,
-            userID: "test-ios-user-id"
+            customerID: "test-ios-customer-id"
         )
         
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -37,7 +37,7 @@ class ForageMocks {
         return NSError(domain: response, code: 400, userInfo: nil)
     }
     
-    var tokenizeSuccessWithUserID: Data {
+    var tokenizeSuccess: Data {
         let response = """
         {
            "ref":"d0c47b0ed5",
@@ -49,23 +49,6 @@ class ForageMocks {
               "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
            },
            "user_id":"test-ios-user-id"
-        }
-"""
-        return Data(response.utf8)
-    }
-    
-    var tokenizeSuccessWithoutUserID: Data {
-        let response = """
-        {
-           "ref":"d0c47b0ed5",
-           "type":"ebt",
-           "balance":null,
-           "card":{
-              "last_4":"3412",
-              "created":"2022-11-29T03:31:52.349193-08:00",
-              "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
-           },
-           "user_id":null
         }
 """
         return Data(response.utf8)

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -37,7 +37,7 @@ class ForageMocks {
         return NSError(domain: response, code: 400, userInfo: nil)
     }
     
-    var tokenizeSuccess: Data {
+    var tokenizeSuccessWithUserID: Data {
         let response = """
         {
            "ref":"d0c47b0ed5",
@@ -47,7 +47,25 @@ class ForageMocks {
               "last_4":"3412",
               "created":"2022-11-29T03:31:52.349193-08:00",
               "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
-           }
+           },
+           "user_id":"test-ios-user-id"
+        }
+"""
+        return Data(response.utf8)
+    }
+    
+    var tokenizeSuccessWithoutUserID: Data {
+        let response = """
+        {
+           "ref":"d0c47b0ed5",
+           "type":"ebt",
+           "balance":null,
+           "card":{
+              "last_4":"3412",
+              "created":"2022-11-29T03:31:52.349193-08:00",
+              "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
+           },
+           "user_id":null
         }
 """
         return Data(response.utf8)

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -48,7 +48,7 @@ class ForageMocks {
               "created":"2022-11-29T03:31:52.349193-08:00",
               "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
            },
-           "user_id":"test-ios-user-id"
+           "customer_id":"test-ios-customer-id"
         }
 """
         return Data(response.utf8)


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- add ~optional~ **required** `userID` param to `tokenizeEBTCard`
- Update sample app to display `userID`
- Update `README.md` to include new `userID` param
- Attach `userID` in `createPayment()` calls in the sample app

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

We (Andres + Kimberlee and I) made userID required because of the complexity + time cost involved with making it optional.

To ensure the dev experience remains pleasant and to simplify sandboxing / trialing the SDK – we make the README snippet value for `userID = UUID.init().uuidString`.

## Test Plan

- [x] Added tests/test cases to consider request bodies and responses w/ or without `userID`s
- [x] Test sample app where `userId` is not specified + specified. Ensure requests + response contain the `user_id`, as desired (at least in `dev`).
  - Payments API v2023-03-31 needs to be released in order to reliably test my changes end-to-end.
- [x] CI / e2e tests pass
- [x] Manually tested by completing full checkout where `userID` is provided vs. not provided

Verified that as a consumer of the Android SDK, userId is truly optional

---
<!-- Describe the steps you have taken or will take to validate your change. -->

<!-- If you are making a front-end change, specify which browser/device/OS you used to test your changes -->

- [ ] Not a front-end change
- [ ] I tested my changes on a Desktop Browser(s)
- [ ] I tested my changes on a Mobile web browser(s)
<!--- Ideally, specify which browser(s) and device(s) you used to test your changes 
e.g. "Google Chrome v110.0.5481.77 on M2 Macbook Pro - macOS Version 13.0" 
Check the Google Chrome version with chrome://version

ℹ️: ~70% of SNAP recipients have an Android device
-->

<!--- 
⚠️ Warning about WebViews

Front-end changes may break in Android WebViews or iOS WKWebViews
(e.g. avoid using Web APIs like Local Storage, IndexedDB, Web Workers, File API, etc.)
-->

## How

**Depends on Payments API v 2023-03-31 being released**

**:warning: This PR can only be released once pr #38 is merged into this one (#36)
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
