### PR TITLE
[FX-57] Clear PIN when a user submits balance or capture

### DIFF
--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -13,13 +13,13 @@ enum SampleAPI {
 
 extension SampleAPI: ServiceProtocol {
     var scheme: String { return "https" }
-    
+
     var host: String { return "api.sandbox.joinforage.app" }
-    
+
     var path: String { return "/api/payments/" }
-    
+
     var method: HttpMethod { return .post }
-    
+
     var task: HttpTask {
         switch self {
         case .createPayment(request: let model):
@@ -40,14 +40,14 @@ extension SampleAPI: ServiceProtocol {
                 "is_delivery": model.isDelivery,
                 "customer_id": model.customerID
             ]
-            
+
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": model.merchantAccount,
                 "IDEMPOTENCY-KEY": UUID.init().uuidString,
                 "authorization": "Bearer \(ClientSharedData.shared.bearerToken)",
-                "API-VERSION": "2023-03-31"
+                "API-VERSION": "2023-05-15"
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: bodyParameters,
                 urlParameters: nil,

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -217,6 +217,11 @@ public class ForagePINTextField: UIView, Identifiable {
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {
         becomeFirstResponder()
     }
+    
+    // Internal Methods
+    internal func clearText() {
+        textField.cleanText()
+    }
 }
 
 extension ForagePINTextField: VGSTextFieldDelegate {

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -103,6 +103,7 @@ extension ForageSDK: ForageSDKService {
                             xKey: model.alias
                         )
                         self.service?.checkBalance(pinCollector: foragePinTextEdit.collector, request: request, completion: completion)
+                        foragePinTextEdit.clearText()
                     case .failure(let error):
                         completion(.failure(error))
                     }
@@ -138,6 +139,7 @@ extension ForageSDK: ForageSDKService {
                                 )
                                 
                                 self.service?.capturePayment(pinCollector: foragePinTextEdit.collector, request: request, completion: completion)
+                                foragePinTextEdit.clearText()
                             case .failure(let error):
                                 completion(.failure(error))
                             }

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -20,9 +20,9 @@ enum ForageAPI {
 
 extension ForageAPI: ServiceProtocol {
     var scheme: String { return "https" }
-    
+
     var host: String { return ForageSDK.shared.environment.rawValue }
-    
+
     var path: String {
         switch self {
         case .tokenizeNumber: return "/api/payment_methods/"
@@ -32,14 +32,14 @@ extension ForageAPI: ServiceProtocol {
         case .getPayment(request: let request): return "/api/payments/\(request.paymentRef)/"
         }
     }
-    
+
     var method: HttpMethod {
         switch self {
         case .tokenizeNumber: return .post
         case .xKey, .message, .getPaymentMethod, .getPayment: return .get
         }
     }
-    
+
     var task: HttpTask {
         switch self {
         case .tokenizeNumber(
@@ -47,7 +47,7 @@ extension ForageAPI: ServiceProtocol {
         ):
             var card = [String: String]()
             card["number"] = model.panNumber
-            
+
             let bodyParameters: Parameters = [
                 "type": model.type,
                 "reusable": model.reusable,
@@ -60,28 +60,28 @@ extension ForageAPI: ServiceProtocol {
                 "authorization": "Bearer \(model.authorization)",
                 "content-type": "application/json",
                 "accept": "application/json",
-                "API-VERSION": "2023-03-31"
+                "API-VERSION": "2023-05-15"
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: bodyParameters,
                 urlParameters: nil,
                 additionalHeaders: httpHeaders
             )
-            
+
         case .xKey(bearerToken: let bearerToken, merchantAccount: let merchantAccount):
             let httpHeaders: HTTPHeaders = [
                 "authorization": "Bearer \(bearerToken)",
                 "accept": "application/json",
                 "Merchant-Account": merchantAccount,
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: nil,
                 urlParameters: nil,
                 additionalHeaders: httpHeaders
             )
-            
+
         case .message(_, bearerToken: let bearerToken, merchantID: let merchantID):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": merchantID,
@@ -89,33 +89,33 @@ extension ForageAPI: ServiceProtocol {
                 "accept": "application/json",
                 "API-VERSION": "2023-02-01"
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: nil,
                 urlParameters: nil,
                 additionalHeaders: httpHeaders
             )
-            
+
         case .getPaymentMethod(request: let request):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": request.merchantAccount,
                 "authorization": "Bearer \(request.bearerToken)",
-                "API-VERSION": "2023-03-31"
+                "API-VERSION": "2023-05-15"
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: nil,
                 urlParameters: nil,
                 additionalHeaders: httpHeaders
             )
-            
+
         case .getPayment(request: let request):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": request.merchantAccount,
                 "authorization": "Bearer \(request.bearerToken)",
-                "API-VERSION": "2023-03-31"
+                "API-VERSION": "2023-05-15"
             ]
-            
+
             return .requestParametersAndHeaders(
                 bodyParameters: nil,
                 urlParameters: nil,


### PR DESCRIPTION
## What
When a user submits for balance or capture, we send the PIN to VGS and then clear the text field.

## Why
The FNS requires that this feature be baked in to each PIN submit.

## Test Plan
I tested locally with an emulator.
