### PR TITLE
[FX-317] Add ForageLogger

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -5,4 +5,9 @@ ignore:
   - ../Library/*
   - ../../Library/*
   - ../../../Library/*
+  - "**/Vendor/DatadogCore/*"
+  - "**/Vendor/DatadogInternal/*"
+  - "**/Vendor/DatadogLogs/*"
+  - "DatadogPrivate-Objc/*"
+  - "**/DatadogPrivate-Objc/*"
   - Tests/*

--- a/DatadogPrivate-Objc/ObjcAppLaunchHandlerFork.m
+++ b/DatadogPrivate-Objc/ObjcAppLaunchHandlerFork.m
@@ -1,0 +1,130 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+#import <UIKit/UIKit.h>
+#import <pthread.h>
+#import <sys/sysctl.h>
+
+#import "ObjcAppLaunchHandlerFork.h"
+
+// A very long application launch time is most-likely the result of a pre-warmed process.
+// We consider 30s as a threshold for pre-warm detection.
+#define COLD_START_TIME_THRESHOLD 30
+
+/// Get the process start time from kernel.
+///
+/// The time interval is related to the 1 January 2001 00:00:00 GMT reference date.
+///
+/// - Parameter timeInterval: Pointer to time interval to hold the process start time interval.
+int fork_processStartTimeIntervalSinceReferenceDate(NSTimeInterval *timeInterval);
+
+/// `AppLaunchHandler` aims to track some times as part of the sequence
+/// described in Apple's "About the App Launch Sequence"
+///
+/// ref. https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence
+@implementation __fork_dd_private_AppLaunchHandler {
+    NSTimeInterval _processStartTime;
+    NSTimeInterval _timeToApplicationDidBecomeActive;
+    BOOL _isActivePrewarm;
+    UIApplicationDidBecomeActiveCallback _applicationDidBecomeActiveCallback;
+}
+
+/// Shared instance of the Application Launch Handler.
+static __fork_dd_private_AppLaunchHandler *_shared;
+
++ (void)load {
+    // This is called at the `DatadogPrivate` load time, keep the work minimal
+    _shared = [[self alloc] initWithProcessInfo:NSProcessInfo.processInfo
+                                       loadTime:CFAbsoluteTimeGetCurrent()];
+
+    NSNotificationCenter * __weak center = NSNotificationCenter.defaultCenter;
+    id __block __unused token = [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                    object:nil
+                                                     queue:NSOperationQueue.mainQueue
+                                                usingBlock:^(NSNotification *_){
+
+        @synchronized(_shared) {
+            NSTimeInterval time = CFAbsoluteTimeGetCurrent() - _shared->_processStartTime;
+            _shared->_timeToApplicationDidBecomeActive = time;
+            _shared->_applicationDidBecomeActiveCallback(time);
+        }
+
+        [center removeObserver:token];
+        token = nil;
+    }];
+}
+
++ (__fork_dd_private_AppLaunchHandler *)shared {
+    return _shared;
+}
+
+- (instancetype)initWithProcessInfo:(NSProcessInfo *)processInfo loadTime:(NSTimeInterval)loadTime {
+    NSTimeInterval startTime;
+    if (fork_processStartTimeIntervalSinceReferenceDate(&startTime) != 0) {
+        // fallback on the loading time
+        startTime = loadTime;
+    }
+
+    // The ActivePrewarm variable indicates whether the app was launched via pre-warming.
+    BOOL isActivePrewarm = [processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];
+    return [self initWithStartTime:startTime isActivePrewarm:isActivePrewarm];
+}
+
+- (instancetype)initWithStartTime:(NSTimeInterval)startTime isActivePrewarm:(BOOL)isActivePrewarm {
+    self = [super init];
+    if (!self) return nil;
+    _processStartTime = startTime;
+    _isActivePrewarm = isActivePrewarm;
+    _applicationDidBecomeActiveCallback = ^(NSTimeInterval _) {};
+    return self;
+}
+
+- (NSDate *)launchDate {
+    @synchronized(self) {
+        return [NSDate dateWithTimeIntervalSinceReferenceDate:_processStartTime];
+    }
+}
+
+- (NSNumber *)launchTime {
+    @synchronized(self) {
+        return _timeToApplicationDidBecomeActive > 0 ?
+            @(_timeToApplicationDidBecomeActive) : nil;
+    }
+}
+
+- (BOOL)isActivePrewarm {
+    @synchronized(self) {
+        if (_isActivePrewarm) return _isActivePrewarm;
+        return _timeToApplicationDidBecomeActive > COLD_START_TIME_THRESHOLD;
+    }
+}
+
+- (void)setApplicationDidBecomeActiveCallback:(UIApplicationDidBecomeActiveCallback)callback {
+    @synchronized(self) {
+        _applicationDidBecomeActiveCallback = callback;
+    }
+}
+
+@end
+
+int fork_processStartTimeIntervalSinceReferenceDate(NSTimeInterval *timeInterval) {
+    // Query the current process' start time:
+    // https://www.freebsd.org/cgi/man.cgi?sysctl(3)
+    // https://github.com/darwin-on-arm/xnu/blob/707bfdc4e9a46e3612e53994fffc64542d3f7e72/bsd/sys/sysctl.h#L681
+    // https://github.com/darwin-on-arm/xnu/blob/707bfdc4e9a46e3612e53994fffc64542d3f7e72/bsd/sys/proc.h#L97
+    struct kinfo_proc kip;
+    size_t kipSize = sizeof(kip);
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
+    int res = sysctl(mib, 4, &kip, &kipSize, NULL, 0);
+    if (res != 0) return res;
+
+    // The process' start time is provided relative to 1 Jan 1970
+    struct timeval startTime = kip.kp_proc.p_starttime;
+    NSTimeInterval processStartTime = startTime.tv_sec + startTime.tv_usec / USEC_PER_SEC;
+    // Convert to time since 1 Jan 2001 to align with CFAbsoluteTimeGetCurrent()
+    *timeInterval = processStartTime - kCFAbsoluteTimeIntervalSince1970;
+    return res;
+}

--- a/DatadogPrivate-Objc/ObjcExceptionHandlerFork.m
+++ b/DatadogPrivate-Objc/ObjcExceptionHandlerFork.m
@@ -1,0 +1,23 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+#import "ObjcExceptionHandlerFork.h"
+
+@implementation __fork_dd_private_ObjcExceptionHandler
+
+- (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error {
+    @try {
+        tryBlock();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:exception.userInfo];
+        return NO;
+    }
+}
+
+@end

--- a/DatadogPrivate-Objc/include/ObjcAppLaunchHandlerFork.h
+++ b/DatadogPrivate-Objc/include/ObjcAppLaunchHandlerFork.h
@@ -1,0 +1,48 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// `AppLaunchHandler` aims to track some times as part of the sequence
+/// described in Apple's "About the App Launch Sequence"
+///
+/// ref. https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence
+@interface __fork_dd_private_AppLaunchHandler : NSObject
+
+typedef void (^UIApplicationDidBecomeActiveCallback) (NSTimeInterval);
+
+/// Sole instance of the Application Launch Handler.
+@property (class, readonly) __fork_dd_private_AppLaunchHandler *shared;
+
+/// Returns the Application process launch date.
+@property (atomic, readonly) NSDate* launchDate;
+
+/// Returns the time interval in seconds between startup of the application process and the
+/// `UIApplicationDidBecomeActiveNotification`. Or `nil` If the
+/// `UIApplicationDidBecomeActiveNotification` has not been reached yet.
+@property (atomic, readonly, nullable) NSNumber* launchTime;
+
+/// Returns `true` when the application is pre-warmed.
+///
+/// System sets environment variable `ActivePrewarm` to 1 when app is pre-warmed.
+@property (atomic, readonly) BOOL isActivePrewarm;
+
+/// Sets the callback to be invoked when the application becomes active.
+///
+/// The closure get the updated handler as argument. You will not get any
+/// notification if the application became active before setting the callback
+/// 
+/// - Parameter callback: The callback closure.
+- (void)setApplicationDidBecomeActiveCallback:(UIApplicationDidBecomeActiveCallback)callback;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/DatadogPrivate-Objc/include/ObjcExceptionHandlerFork.h
+++ b/DatadogPrivate-Objc/include/ObjcExceptionHandlerFork.h
@@ -1,0 +1,18 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface __fork_dd_private_ObjcExceptionHandler : NSObject
+
+- (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error
+    NS_SWIFT_NAME(rethrowToSwift(tryBlock:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.author       = { "Rob Gormisky" => "rob@joinforage.com" }
   spec.platform     = :ios, "13.0"
   spec.source       = { :git => "https://github.com/teamforage/forage-ios-sdk.git", :tag => "3.0.6" }
-  spec.source_files = "Sources/ForageSDK/**/*.swift"
+  spec.source_files = ["Sources/ForageSDK/**/*.swift", "DatadogPrivate-Objc/**/*.{h,m}"]
   spec.dependency 'VGSCollectSDK', '~> 1.11.2'
   spec.dependency 'LaunchDarkly', '~> 8.0.1'
   spec.dependency 'BasisTheoryElements', '~> 2.7.0'

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "ForageSDK",
     platforms: [
-            .iOS(.v13),
-        ],
+        .iOS(.v13),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -33,9 +33,10 @@ let package = Package(
             from: "2.7.0"
         ),
         .package(
-            name: "Sentry", 
-            url: "https://github.com/getsentry/sentry-cocoa", 
-            from: "8.8.0"),
+            name: "Sentry",
+            url: "https://github.com/getsentry/sentry-cocoa",
+            from: "8.8.0"
+        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -46,13 +47,24 @@ let package = Package(
                 "VGSCollectSDK",
                 "LaunchDarkly",
                 "BasisTheoryElements",
-                "Sentry"
+                "Sentry",
+                "DatadogPrivateFork"
             ],
-            path: "Sources", resources: [
+            path: "Sources",
+            resources: [
                 .process("Resources/Media.xcassets")
-            ]),
+            ],
+            swiftSettings: [.define("SPM_BUILD")]
+        ),
         .testTarget(
             name: "ForageSDKTests",
-            dependencies: ["ForageSDK"]),
+            dependencies: ["ForageSDK"]
+        ),
+        
+        // Bridge Datadog's "Private" Objective C code with our Swift code.
+        .target(
+            name: "DatadogPrivateFork",
+            path: "DatadogPrivate-Objc"
+        ),
     ]
 )

--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -140,6 +140,15 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
         return sv
     }()
     
+    private lazy var logger: ForageLogger = {
+        let ddLogger = DatadogLogger(
+            ForageLoggerConfig(
+                prefix: "UIView"
+            )
+        )
+        return ddLogger
+    }()
+    
     private lazy var textField: MaskedUITextField = {
         let tf = MaskedUITextField()
         tf.translatesAutoresizingMaskIntoConstraints = false
@@ -237,6 +246,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
             action: #selector(requestFocus(_:))
         )
         addGestureRecognizer(tapGesture)
+        self.logger.notice("ForagePANTextField was initialized successfully", attributes: nil)
     }
     
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -123,6 +123,15 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         return sv
     }()
     
+    private lazy var logger: ForageLogger = {
+        let ddLogger = DatadogLogger(
+            ForageLoggerConfig(
+                prefix: "UIView"
+            )
+        )
+        return ddLogger
+    }()
+    
     private lazy var textField: VaultWrapper = {
         let vaultType = LDManager.shared.getVaultType()
         
@@ -230,6 +239,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
             action: #selector(requestFocus(_:))
         )
         addGestureRecognizer(tapGesture)
+        self.logger.notice("ForagePINTextField was initialized successfully", attributes: nil)
     }
     
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -53,10 +53,8 @@ public class ForageSDK {
         self.logger = logger
         LDManager.shared.initialize(self.environment, logger: logger)
         VGSCollectLogger.shared.disableAllLoggers()
-        
-        let isUnitTesting = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-        
-        if !isUnitTesting {
+                
+        if !isUnitTesting() {
             SentrySDK.start { options in
                 options.dsn = "https://8fcdd8dc94aa892ed8fd4cdb20db90ee@o921422.ingest.sentry.io/4505665631813632"
                 options.debug = false

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -27,6 +27,7 @@ public class ForageSDK {
     internal var service: ForageService?
     internal var panNumber: String = ""
     internal var environment: EnvironmentTarget = .sandbox
+    internal var logger: ForageLogger? = nil
     
     // Don't update! Only updated when releasing.
     public static let version = "3.0.6"
@@ -40,11 +41,19 @@ public class ForageSDK {
             return
         }
         self.environment = config.environment
-        LDManager.shared.initialize(self.environment)
-        // TODO: Maybe move this shared logger call!
+        // ForageSDK.shared.environment is not set
+        // until the end of this initialization
+        // so we have to provide the environment from the config
+        let logger = DatadogLogger(
+            ForageLoggerConfig(
+                environment: config.environment,
+                prefix: ""
+            )
+        )
+        self.logger = logger
+        LDManager.shared.initialize(self.environment, logger: logger)
         VGSCollectLogger.shared.disableAllLoggers()
         
-        self.service = LiveForageService()
         let isUnitTesting = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
         
         if !isUnitTesting {
@@ -58,6 +67,8 @@ public class ForageSDK {
                 options.enableTracing = true
             }
         }
+        let provider = Provider(logger: logger)
+        self.service = LiveForageService(provider: provider, logger: logger)
     }
     
     /**

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -39,11 +39,7 @@ public class ForageSDK {
             assertionFailure("ForageSDK missing Config setup")
             return
         }
-        
-        let environment = config.environment
-        self.environment = environment
-
-        DatadogLogger.shared.initialize(environment)
+        self.environment = config.environment
         LDManager.shared.initialize(self.environment)
         // TODO: Maybe move this shared logger call!
         VGSCollectLogger.shared.disableAllLoggers()

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -39,7 +39,11 @@ public class ForageSDK {
             assertionFailure("ForageSDK missing Config setup")
             return
         }
-        self.environment = config.environment
+        
+        let environment = config.environment
+        self.environment = environment
+
+        DatadogLogger.shared.initialize(environment)
         LDManager.shared.initialize(self.environment)
         // TODO: Maybe move this shared logger call!
         VGSCollectLogger.shared.disableAllLoggers()

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -65,6 +65,13 @@ extension ForageSDK: ForageSDKService {
         reusable: Bool? = true,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
+        _ = self.logger?
+            .setPrefix("tokenizeEBTCard")
+            .addContext(ForageLogContext(
+                customerID: customerID,
+                merchantRef: merchantAccount
+            ))
+            .notice("Called ForageSDK.shared.tokenizeEBTCard", attributes: nil)
         let request = ForagePANRequestModel(
             authorization: bearerToken,
             merchantAccount: merchantAccount,
@@ -83,6 +90,13 @@ extension ForageSDK: ForageSDKService {
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
             foragePinTextEdit.disable()
+            _ = self.logger?
+                .setPrefix("checkBalance")
+                .addContext(ForageLogContext(
+                    merchantRef: merchantAccount,
+                    paymentMethodRef: paymentMethodReference
+                ))
+                .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
             
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
@@ -123,6 +137,14 @@ extension ForageSDK: ForageSDKService {
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
             foragePinTextEdit.disable()
 
+            _ = self.logger?
+                .setPrefix("capturePayment")
+                .addContext(ForageLogContext(
+                    merchantRef: merchantAccount,
+                    paymentRef: paymentReference
+                ))
+                .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)
+            
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
                 case .success(let model):

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -72,6 +72,7 @@ extension ForageSDK: ForageSDKService {
                 merchantRef: merchantAccount
             ))
             .notice("Called ForageSDK.shared.tokenizeEBTCard", attributes: nil)
+        
         let request = ForagePANRequestModel(
             authorization: bearerToken,
             merchantAccount: merchantAccount,
@@ -89,7 +90,6 @@ extension ForageSDK: ForageSDKService {
         paymentMethodReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
-            foragePinTextEdit.disable()
             _ = self.logger?
                 .setPrefix("checkBalance")
                 .addContext(ForageLogContext(
@@ -97,6 +97,8 @@ extension ForageSDK: ForageSDKService {
                     paymentMethodRef: paymentMethodReference
                 ))
                 .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
+            
+            foragePinTextEdit.disable()
             
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
@@ -135,8 +137,6 @@ extension ForageSDK: ForageSDKService {
         paymentReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
-            foragePinTextEdit.disable()
-
             _ = self.logger?
                 .setPrefix("capturePayment")
                 .addContext(ForageLogContext(
@@ -144,6 +144,8 @@ extension ForageSDK: ForageSDKService {
                     paymentRef: paymentReference
                 ))
                 .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)
+            
+            foragePinTextEdit.disable()
             
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {

--- a/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
@@ -1,0 +1,13 @@
+//
+//  Environment.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-08-23.
+//
+
+import Foundation
+
+
+internal func isUnitTesting() -> Bool {
+    return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+}

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -33,8 +33,6 @@ public class DatadogLogger: ForageLogger {
             return
         }
 
-        // TODO: only initialize if not running locally?
-
         Datadog.initialize(
             appContext: .init(),
             trackingConsent: .granted,
@@ -51,7 +49,6 @@ public class DatadogLogger: ForageLogger {
             .sendNetworkInfo(true)
             // how do we decide whether we're in local dev or not?
             .sendLogsToDatadog(true)
-            .printLogsToConsole(true, usingFormat: .shortWith(prefix: "[forage-ios-sdk] "))
             .set(datadogReportingThreshold: .info)
             .build()
     }

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -1,0 +1,103 @@
+//
+//  File.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-07-26.
+//
+
+import Datadog
+import Foundation
+
+// TODO: move this?
+protocol ForageLogger {
+    func setCustomerID(_ customerID: String)
+    func setMerchantAccount(_ merchantAccount: String)
+    func initialize(_ environment: EnvironmentTarget)
+
+    func notice(_ message: String, attributes: [String: Encodable]?)
+    func info(_ message: String, attributes: [String: Encodable]?)
+    func warn(_ message: String, error: Error?, attributes: [String: Encodable]?)
+    func error(_ message: String, error: Error?, attributes: [String: Encodable]?)
+    func critical(_ message: String, error: Error?, attributes: [String: Encodable]?)
+}
+
+public class DatadogLogger: ForageLogger {
+    static let shared = DatadogLogger()
+    private static let DD_CLIENT_TOKEN: String = "pub1e4572ba0f5e53df108c333d5ec66c02"
+    private static var logger: Logger? = nil
+
+    private init() {}
+
+    internal func initialize(_ environment: EnvironmentTarget) {
+        if DatadogLogger.logger != nil {
+            return
+        }
+
+        // TODO: only initialize if not running locally?
+
+        Datadog.initialize(
+            appContext: .init(),
+            trackingConsent: .granted,
+            configuration: Datadog.Configuration
+                .builderUsing(clientToken: DatadogLogger.DD_CLIENT_TOKEN, environment: environment.rawValue)
+                .set(serviceName: "ios-sdk")
+                .set(endpoint: .us1)
+                .build()
+        )
+
+        Datadog.verbosityLevel = .info
+
+        DatadogLogger.logger = Logger.builder
+            .sendNetworkInfo(true)
+            // how do we decide whether we're in local dev or not?
+            .sendLogsToDatadog(true)
+            .printLogsToConsole(true, usingFormat: .shortWith(prefix: "[forage-ios-sdk] "))
+            .set(datadogReportingThreshold: .info)
+            .set(loggerName: "Forage")
+            .build()
+    }
+
+    static var sharedLogger: DatadogLogger {
+        return shared
+    }
+
+    internal func setCustomerID(_ customerID: String) {
+        setLogAttribute("customer_id", value: customerID)
+    }
+
+    internal func setMerchantAccount(_ merchantAccount: String) {
+        setLogAttribute("merchant", value: merchantAccount)
+    }
+    
+    internal func setPaymentRef(_ paymentRef: String) {
+        setLogAttribute("payment_ref", value: paymentRef)
+    }
+    
+    internal func setPaymentMethodRef(_ paymentMethodRef: String) {
+        setLogAttribute("payment_method_ref", value: paymentMethodRef)
+    }
+
+    internal func notice(_ message: String, attributes: [String: Encodable]? = nil) {
+        DatadogLogger.logger?.info(message, error: nil, attributes: attributes)
+    }
+
+    internal func info(_ message: String, attributes: [String: Encodable]? = nil) {
+        DatadogLogger.logger?.info(message, error: nil, attributes: attributes)
+    }
+
+    internal func warn(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        DatadogLogger.logger?.warn(message, error: error, attributes: attributes)
+    }
+
+    internal func error(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        DatadogLogger.logger?.error(message, error: error, attributes: attributes)
+    }
+
+    internal func critical(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        DatadogLogger.logger?.critical(message, error: error, attributes: attributes)
+    }
+    
+    private func setLogAttribute(_ key: String, value: String) {
+        DatadogLogger.logger?.addAttribute(forKey: key, value: value)
+    }
+}

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -1,11 +1,10 @@
 //
-//  File.swift
+//  ForageLogger.swift
 //
 //
 //  Created by Danilo Joksimovic on 2023-07-26.
 //
 
-import Datadog
 import Foundation
 
 internal struct ForageLogContext {
@@ -69,29 +68,42 @@ internal protocol ForageLogger {
     func critical(_ message: String, error: Error?, attributes: [String: Encodable]?)
 }
 
+/// Read this [document](https://docs.google.com/document/d/1BU609qv7qSDN-tdNaJP-sAyrgeM6REe9tvcMk5CxN3c/edit#bookmark=id.w44b8kk07o7o) for to learn more about how DatadogLogger works
 internal class DatadogLogger : ForageLogger {
     private static let DD_CLIENT_TOKEN: String = "pub1e4572ba0f5e53df108c333d5ec66c02"
-    private var logger: Logger? = nil
+    private static let DD_SERVICE_NAME: String = "ios-sdk"
+    private static let DD_SDK_INSTANCE_NAME: String = "forage"
+
+    private var logger: LoggerProtocol? = nil
     private var config: ForageLoggerConfig? = nil
-        
+    
     required internal init(_ config: ForageLoggerConfig? = ForageLoggerConfig()) {
+        if isUnitTesting() {
+            // avoid emitting logs when running unit tests
+            return
+        }
+        
         self.config = config
         guard let forageEnvironment = config?.forageEnvironment else {
-              print("forageEnvironment must be set to initialize the logger")
-              return
-          }
-        self.initDatadog(forageEnvironment)
-
-        let newLogger = Logger.builder
-            .sendNetworkInfo(true)
-        // we want to always emit to Datadog
-        // but we don't want to spam the client's console with our logs.
-            .sendLogsToDatadog(true)
-            .set(datadogReportingThreshold: .info)
-            .set(serviceName: "ios-sdk")
-            .build()
-
-        self.logger = newLogger
+            print("forageEnvironment must be set to initialize the logger")
+            return
+        }
+        
+        let datadogInstance = self.initDatadog(forageEnvironment)
+        self.logger = Logger.create(
+            with: Logger.Configuration(
+                service: "ios-sdk",
+                networkInfoEnabled: true,
+                bundleWithRumEnabled: false,
+                bundleWithTraceEnabled: false,
+                remoteLogThreshold: .info,
+                // we want to always emit to Datadog
+                // but we don't want to spam the client's console with our logs.
+                consoleLogFormat: nil
+            ),
+            in: datadogInstance
+        )
+        
         _ = self.addContext(config?.context ?? ForageLogContext())
     }
     
@@ -138,19 +150,27 @@ internal class DatadogLogger : ForageLogger {
         return self
     }
     
-    private func initDatadog(_ environment: EnvironmentTarget) {
-        if Datadog.isInitialized {
-            return
+    /// Initializes and returns a Datadog instance for the given environment. If an instance with the specified name already exists,
+    /// it returns the existing instance.
+    private func initDatadog(_ environment: EnvironmentTarget) -> DatadogCoreProtocol {
+        let instanceName = DatadogLogger.DD_SDK_INSTANCE_NAME
+        
+        if Datadog.isInitialized(instanceName: instanceName) {
+            return Datadog.sdkInstance(named: instanceName)
         }
-        Datadog.initialize(
-            appContext: .init(),
+        
+        let datadogInstance = Datadog.initialize(
+            with: Datadog.Configuration(
+                clientToken: DatadogLogger.DD_CLIENT_TOKEN,
+                env: String(describing: environment),
+                service: DatadogLogger.DD_SERVICE_NAME
+            ),
             trackingConsent: .granted,
-            configuration: Datadog.Configuration
-                .builderUsing(clientToken: DatadogLogger.DD_CLIENT_TOKEN, environment: String(describing: environment))
-                .set(serviceName: "ios-sdk")
-                .set(endpoint: .us1)
-                .build()
+            instanceName: instanceName
         )
+    
+        Logs.enable(in: datadogInstance)
+        return datadogInstance
     }
     
     private func getMessageWithPrefix(_ message: String) -> String {

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -77,7 +77,7 @@ public class DatadogLogger: ForageLogger {
     }
 
     internal func notice(_ message: String, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.info(message, error: nil, attributes: attributes)
+        DatadogLogger.logger?.notice(message, error: nil, attributes: attributes)
     }
 
     internal func info(_ message: String, attributes: [String: Encodable]? = nil) {

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -8,12 +8,26 @@
 import Datadog
 import Foundation
 
-// TODO: move this?
-protocol ForageLogger {
-    func setCustomerID(_ customerID: String)
-    func setMerchantAccount(_ merchantAccount: String)
-    func initialize(_ environment: EnvironmentTarget)
+internal struct ForageLogContext {
+    var customerID: String? = nil
+    var merchantRef: String? = nil
+    var paymentRef: String? = nil
+    var paymentMethodRef: String? = nil
+}
 
+internal struct ForageLoggerConfig {
+    let environment: EnvironmentTarget
+    let context: ForageLogContext?
+    
+    init(environment: EnvironmentTarget, context: ForageLogContext? = nil) {
+        self.environment = environment
+        self.context = context
+    }
+}
+
+protocol ForageLogger {
+    init(_ config: ForageLoggerConfig)
+    
     func notice(_ message: String, attributes: [String: Encodable]?)
     func info(_ message: String, attributes: [String: Encodable]?)
     func warn(_ message: String, error: Error?, attributes: [String: Encodable]?)
@@ -21,18 +35,63 @@ protocol ForageLogger {
     func critical(_ message: String, error: Error?, attributes: [String: Encodable]?)
 }
 
-public class DatadogLogger: ForageLogger {
-    static let shared = DatadogLogger()
+internal class DatadogLogger : ForageLogger {
     private static let DD_CLIENT_TOKEN: String = "pub1e4572ba0f5e53df108c333d5ec66c02"
-    private static var logger: Logger? = nil
-
-    private init() {}
-
-    internal func initialize(_ environment: EnvironmentTarget) {
-        if DatadogLogger.logger != nil {
+    private var logger: Logger? = nil
+    
+    required public init(_ config: ForageLoggerConfig) {
+        self.initDatadog(config.environment)
+        
+        let newLogger = Logger.builder
+            .sendNetworkInfo(true)
+        // we want to always emit to Datadog
+        // but we don't want to spam the client's console with our logs.
+            .sendLogsToDatadog(true)
+            .set(datadogReportingThreshold: .info)
+            .set(serviceName: "ios-sdk")
+            .build()
+        
+        if let logCtx = config.context {
+            let attributeMappings: [(key: String, value: Encodable?)] = [
+                ("customer_id", logCtx.customerID),
+                ("merchant_ref", logCtx.merchantRef),
+                ("payment_method_ref", logCtx.paymentMethodRef),
+                ("payment_ref", logCtx.paymentRef)
+            ]
+            
+            for (key, value) in attributeMappings {
+                if let attributeValue = value {
+                    newLogger.addAttribute(forKey: key, value: attributeValue)
+                }
+            }
+        }
+        self.logger = newLogger
+    }
+    
+    internal func notice(_ message: String, attributes: [String: Encodable]? = nil) {
+        self.logger?.notice(message, error: nil, attributes: attributes)
+    }
+    
+    internal func info(_ message: String, attributes: [String: Encodable]? = nil) {
+        self.logger?.info(message, error: nil, attributes: attributes)
+    }
+    
+    internal func warn(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        self.logger?.warn(message, error: error, attributes: attributes)
+    }
+    
+    internal func error(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        self.logger?.error(message, error: error, attributes: attributes)
+    }
+    
+    internal func critical(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
+        self.logger?.critical(message, error: error, attributes: attributes)
+    }
+    
+    private func initDatadog(_ environment: EnvironmentTarget) {
+        if Datadog.isInitialized {
             return
         }
-
         Datadog.initialize(
             appContext: .init(),
             trackingConsent: .granted,
@@ -42,58 +101,5 @@ public class DatadogLogger: ForageLogger {
                 .set(endpoint: .us1)
                 .build()
         )
-
-        Datadog.verbosityLevel = .info
-
-        DatadogLogger.logger = Logger.builder
-            .sendNetworkInfo(true)
-            // how do we decide whether we're in local dev or not?
-            .sendLogsToDatadog(true)
-            .set(datadogReportingThreshold: .info)
-            .build()
-    }
-
-    static var sharedLogger: DatadogLogger {
-        return shared
-    }
-
-    internal func setCustomerID(_ customerID: String) {
-        setLogAttribute("customer_id", value: customerID)
-    }
-
-    internal func setMerchantAccount(_ merchantAccount: String) {
-        setLogAttribute("merchant", value: merchantAccount)
-    }
-    
-    internal func setPaymentRef(_ paymentRef: String) {
-        setLogAttribute("payment_ref", value: paymentRef)
-    }
-    
-    internal func setPaymentMethodRef(_ paymentMethodRef: String) {
-        setLogAttribute("payment_method_ref", value: paymentMethodRef)
-    }
-
-    internal func notice(_ message: String, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.notice(message, error: nil, attributes: attributes)
-    }
-
-    internal func info(_ message: String, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.info(message, error: nil, attributes: attributes)
-    }
-
-    internal func warn(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.warn(message, error: error, attributes: attributes)
-    }
-
-    internal func error(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.error(message, error: error, attributes: attributes)
-    }
-
-    internal func critical(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        DatadogLogger.logger?.critical(message, error: error, attributes: attributes)
-    }
-    
-    private func setLogAttribute(_ key: String, value: String) {
-        DatadogLogger.logger?.addAttribute(forKey: key, value: value)
     }
 }

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -13,35 +13,75 @@ internal struct ForageLogContext {
     var merchantRef: String? = nil
     var paymentRef: String? = nil
     var paymentMethodRef: String? = nil
+    var vaultType: VaultType? = nil
 }
 
 internal struct ForageLoggerConfig {
-    let environment: EnvironmentTarget
-    let context: ForageLogContext?
+    var forageEnvironment: EnvironmentTarget?
+    var prefix: String?
+    var context: ForageLogContext?
     
-    init(environment: EnvironmentTarget, context: ForageLogContext? = nil) {
-        self.environment = environment
+    init(environment: EnvironmentTarget? = ForageSDK.shared.environment, prefix: String? = nil, context: ForageLogContext? = nil) {
+        self.forageEnvironment = environment
         self.context = context
+        self.prefix = prefix
     }
 }
 
-protocol ForageLogger {
-    init(_ config: ForageLoggerConfig)
+internal protocol ForageLogger {
+    init(_ config: ForageLoggerConfig?)
     
+    /// Adds additional context to the logger, providing useful information for each log message.
+    /// - Parameter newContext: The ForageLogContext to be added to the logger.
+    /// - Returns: The instance of the ForageLogger with the additional context applied. Useful for method chaining.
+    func addContext(_ newContext: ForageLogContext) -> ForageLogger
+    
+    /// Sets a prefix that will be added to each log message, useful for distinguishing log sources.
+    /// - Parameter prefix: The prefix string to be added to log messages.
+    /// - Returns: The instance of the ForageLogger with the specified prefix applied. Useful for method chaining.
+    func setPrefix(_ prefix: String) -> ForageLogger
+    
+    /// Logs noteworthy events or significant occurrences in the application.
+    /// These messages are more important than general informational messages (e.g., log.info).
+    /// They draw attention to important events that may be useful for troubleshooting or monitoring the application's behavior.
+    /// - Parameter message: The log message to be logged at the notice level.
+    /// - Parameter attributes: An optional dictionary of key-value pairs providing additional context for the log.
     func notice(_ message: String, attributes: [String: Encodable]?)
+    
+    /// Logs information to help developers understand how the application is functioning at a finer level of detail.
+    /// These logs can be helpful for debugging or gaining insights into the application's behavior.
+    /// - Parameter message: The log message to be logged at the info level.
+    /// - Parameter attributes: An optional dictionary of key-value pairs providing additional context for the log.
     func info(_ message: String, attributes: [String: Encodable]?)
+    
     func warn(_ message: String, error: Error?, attributes: [String: Encodable]?)
+    
+    /// Logs error messages that indicate a problem or failure in the application, but one that might be recoverable.
+    /// - Parameter message: The log message to be logged at the error level.
+    /// - Parameter error: An optional error object associated with the error log.
+    /// - Parameter attributes: An optional dictionary of key-value pairs providing additional context for the log.
     func error(_ message: String, error: Error?, attributes: [String: Encodable]?)
+    
+    /// Logs severe issues that lead to application failure or data corruption.
+    /// - Parameter message: The log message to be logged at the critical level.
+    /// - Parameter error: An optional error object associated with the critical log.
+    /// - Parameter attributes: An optional dictionary of key-value pairs providing additional context for the log.
     func critical(_ message: String, error: Error?, attributes: [String: Encodable]?)
 }
 
 internal class DatadogLogger : ForageLogger {
     private static let DD_CLIENT_TOKEN: String = "pub1e4572ba0f5e53df108c333d5ec66c02"
     private var logger: Logger? = nil
-    
-    required public init(_ config: ForageLoggerConfig) {
-        self.initDatadog(config.environment)
+    private var config: ForageLoggerConfig? = nil
         
+    required internal init(_ config: ForageLoggerConfig? = ForageLoggerConfig()) {
+        self.config = config
+        guard let forageEnvironment = config?.forageEnvironment else {
+              print("forageEnvironment must be set to initialize the logger")
+              return
+          }
+        self.initDatadog(forageEnvironment)
+
         let newLogger = Logger.builder
             .sendNetworkInfo(true)
         // we want to always emit to Datadog
@@ -50,42 +90,52 @@ internal class DatadogLogger : ForageLogger {
             .set(datadogReportingThreshold: .info)
             .set(serviceName: "ios-sdk")
             .build()
-        
-        if let logCtx = config.context {
-            let attributeMappings: [(key: String, value: Encodable?)] = [
-                ("customer_id", logCtx.customerID),
-                ("merchant_ref", logCtx.merchantRef),
-                ("payment_method_ref", logCtx.paymentMethodRef),
-                ("payment_ref", logCtx.paymentRef)
-            ]
-            
-            for (key, value) in attributeMappings {
-                if let attributeValue = value {
-                    newLogger.addAttribute(forKey: key, value: attributeValue)
-                }
-            }
-        }
+
         self.logger = newLogger
+        _ = self.addContext(config?.context ?? ForageLogContext())
     }
     
     internal func notice(_ message: String, attributes: [String: Encodable]? = nil) {
-        self.logger?.notice(message, error: nil, attributes: attributes)
+        self.logger?.notice(self.getMessageWithPrefix(message), error: nil, attributes: attributes)
     }
     
     internal func info(_ message: String, attributes: [String: Encodable]? = nil) {
-        self.logger?.info(message, error: nil, attributes: attributes)
+        self.logger?.info(self.getMessageWithPrefix(message), error: nil, attributes: attributes)
     }
     
     internal func warn(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        self.logger?.warn(message, error: error, attributes: attributes)
+        self.logger?.warn(self.getMessageWithPrefix(message), error: error, attributes: attributes)
     }
     
     internal func error(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        self.logger?.error(message, error: error, attributes: attributes)
+        self.logger?.error(self.getMessageWithPrefix(message), error: error, attributes: attributes)
     }
     
     internal func critical(_ message: String, error: Error? = nil, attributes: [String: Encodable]? = nil) {
-        self.logger?.critical(message, error: error, attributes: attributes)
+        self.logger?.critical(self.getMessageWithPrefix(message), error: error, attributes: attributes)
+    }
+    
+    internal func addContext(_ newContext: ForageLogContext) -> ForageLogger {
+        self.config?.context = newContext
+        let attributeMappings: [(key: String, value: Encodable?)] = [
+            ("customer_id", newContext.customerID),
+            ("merchant_ref", newContext.merchantRef),
+            ("payment_method_ref", newContext.paymentMethodRef),
+            ("payment_ref", newContext.paymentRef),
+            ("vault_type", newContext.vaultType?.rawValue)
+        ]
+        
+        for (key, value) in attributeMappings {
+            if let attributeValue = value {
+                self.logger?.addAttribute(forKey: key, value: attributeValue)
+            }
+        }
+        return self
+    }
+    
+    internal func setPrefix(_ newPrefix: String) -> ForageLogger {
+        self.config?.prefix = newPrefix
+        return self
     }
     
     private func initDatadog(_ environment: EnvironmentTarget) {
@@ -96,10 +146,17 @@ internal class DatadogLogger : ForageLogger {
             appContext: .init(),
             trackingConsent: .granted,
             configuration: Datadog.Configuration
-                .builderUsing(clientToken: DatadogLogger.DD_CLIENT_TOKEN, environment: environment.rawValue)
+                .builderUsing(clientToken: DatadogLogger.DD_CLIENT_TOKEN, environment: String(describing: environment))
                 .set(serviceName: "ios-sdk")
                 .set(endpoint: .us1)
                 .build()
         )
+    }
+    
+    private func getMessageWithPrefix(_ message: String) -> String {
+        if let prefix = self.config?.prefix {
+            return prefix.isEmpty ? message : "[\(prefix)] \(message)"
+        }
+        return message
     }
 }

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -53,7 +53,6 @@ public class DatadogLogger: ForageLogger {
             .sendLogsToDatadog(true)
             .printLogsToConsole(true, usingFormat: .shortWith(prefix: "[forage-ios-sdk] "))
             .set(datadogReportingThreshold: .info)
-            .set(loggerName: "Forage")
             .build()
     }
 

--- a/Sources/ForageSDK/Vendor/DatadogCore/BundleType.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/BundleType.swift
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A type of the bundle running the SDK.
+internal enum BundleType: String {
+    case iOSApp
+    case iOSAppExtension
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ApplicationStatePublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ApplicationStatePublisher.swift
@@ -1,0 +1,145 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if canImport(UIKit)
+import UIKit
+
+internal final class ApplicationStatePublisher: ContextValuePublisher {
+    typealias Snapshot = AppStateHistory.Snapshot
+
+    private static var currentApplicationState: UIApplication.State {
+        UIApplication.dd.managedShared?.applicationState ?? .active // fallback to most expected state
+    }
+
+    /// The default publisher queue.
+    private static let defaultQueue = DispatchQueue(
+        label: "com.datadoghq.app-state-publisher",
+        target: .global(qos: .utility)
+    )
+
+    /// The initial history value.
+    let initialValue: AppStateHistory
+
+    /// The notification center where this publisher observes following `UIApplication` notifications:
+    /// - `.didBecomeActiveNotification`
+    /// - `.willResignActiveNotification`
+    /// - `.didEnterBackgroundNotification`
+    /// - `.willEnterForegroundNotification`
+    private let notificationCenter: NotificationCenter
+
+    /// The date provider for the Application state snapshot timestamp.
+    private let dateProvider: DateProvider
+
+    /// The queue used to serialise access to the `history` and
+    /// to publish the new history.
+    private let queue: DispatchQueue
+
+    /// The current application state history.
+    ///
+    /// To mutate in the `queue` only.
+    private var history: AppStateHistory
+
+    /// The receiver for publishing the state history.
+    ///
+    /// To mutate in the `queue` only.
+    private var receiver: ContextValueReceiver<AppStateHistory>?
+
+    /// Creates a Application state publisher for publishing application state
+    /// history.
+    ///
+    /// - Parameters:
+    ///   - initialState: The initial application state.
+    ///   - queue: The queue for publishing the history.
+    ///   - dateProvider: The date provider for the Application state snapshot timestamp.
+    ///   - notificationCenter: The notification center where this publisher observes `UIApplication` notifications.
+    init(
+        initialState: AppState,
+        queue: DispatchQueue = ApplicationStatePublisher.defaultQueue,
+        dateProvider: DateProvider = SystemDateProvider(),
+        notificationCenter: NotificationCenter = .default
+    ) {
+        let initialValue = AppStateHistory(
+            initialState: initialState,
+            date: dateProvider.now
+        )
+
+        self.initialValue = initialValue
+        self.history = initialValue
+        self.queue = queue
+        self.dateProvider = dateProvider
+        self.notificationCenter = notificationCenter
+    }
+
+    /// Creates a Application state publisher for publishing application state
+    /// history.
+    ///
+    /// **Note**: It must be called on the main thread.
+    ///
+    /// - Parameters:
+    ///   - applicationState: The current shared `UIApplication` state.
+    ///   - queue: The queue for publishing the history.
+    ///   - dateProvider: The date provider for the Application state snapshot timestamp.
+    ///   - notificationCenter: The notification center where this publisher observes `UIApplication` notifications.
+    convenience init(
+        applicationState: UIApplication.State = ApplicationStatePublisher.currentApplicationState,
+        queue: DispatchQueue = ApplicationStatePublisher.defaultQueue,
+        dateProvider: DateProvider = SystemDateProvider(),
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.init(
+            initialState: AppState(applicationState),
+            queue: queue,
+            dateProvider: dateProvider,
+            notificationCenter: notificationCenter
+        )
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<AppStateHistory>) {
+        queue.async { self.receiver = receiver }
+        notificationCenter.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    @objc
+    private func applicationDidBecomeActive() {
+        append(state: .active)
+    }
+
+    @objc
+    private func applicationWillResignActive() {
+        append(state: .inactive)
+    }
+
+    @objc
+    private func applicationDidEnterBackground() {
+        append(state: .background)
+    }
+
+    @objc
+    private func applicationWillEnterForeground() {
+        append(state: .inactive)
+    }
+
+    private func append(state: AppState) {
+        let snapshot = Snapshot(state: state, date: dateProvider.now)
+        queue.async {
+            self.history.append(snapshot)
+            self.receiver?(self.history)
+        }
+    }
+
+    func cancel() {
+        notificationCenter.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+        queue.async { self.receiver = nil }
+    }
+}
+
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ApplicationVersionPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ApplicationVersionPublisher.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Publishes the application vesrion value to receiver.
+internal final class ApplicationVersionPublisher: ContextValuePublisher {
+    let initialValue: String
+
+    private var receiver: ContextValueReceiver<String>?
+
+    var version: String {
+        didSet { receiver?(version) }
+    }
+
+    init(version: String) {
+        self.initialValue = version
+        self.version = version
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<String>) {
+        self.receiver = receiver
+    }
+
+    func cancel() {
+        receiver = nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/BatteryStatusPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/BatteryStatusPublisher.swift
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if os(iOS)
+import UIKit
+
+/// The ``BatteryStatusPublisher`` publishes the battery state and level from the ``UIDevice``.
+///
+/// The publisher will enable the battery monitoring by setting the ``UIDevice/isBatteryMonitoringEnabled``
+/// to `true`. The property will be reset to it's initial value when the publisher is deallocated.
+internal final class BatteryStatusPublisher: ContextValuePublisher {
+    let initialValue: BatteryStatus?
+    let device: UIDevice
+    let isBatteryMonitoringEnabled: Bool
+    private let notificationCenter: NotificationCenter
+    private var observers: [Any]? = nil
+
+    /// Creates a battery status publisher from the given device.
+    /// 
+    /// - Parameters:
+    ///   - device: The `UIDevice` instance. `.current` by default.
+    ///   - notificationCenter: The notification center for observing the `UIDevice` battery changes,
+    init(
+        device: UIDevice = .current,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.device = device
+        self.notificationCenter = notificationCenter
+        self.isBatteryMonitoringEnabled = device.isBatteryMonitoringEnabled
+        self.initialValue = BatteryStatus(
+            state: .init(device.batteryState),
+            level: device.batteryLevel
+        )
+
+        device.isBatteryMonitoringEnabled = true
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<BatteryStatus?>) {
+        let block = { (notification: Notification) in
+            guard let device = notification.object as? UIDevice else {
+                return
+            }
+
+            let status = BatteryStatus(
+                state: .init(device.batteryState),
+                level: device.batteryLevel
+            )
+
+            receiver(status)
+        }
+
+        observers = [
+            notificationCenter.addObserver(
+                forName: UIDevice.batteryStateDidChangeNotification,
+                object: device,
+                queue: .main,
+                using: block
+            ),
+            notificationCenter.addObserver(
+                forName: UIDevice.batteryLevelDidChangeNotification,
+                object: device,
+                queue: .main,
+                using: block
+            )
+        ]
+    }
+
+    func cancel() {
+        device.isBatteryMonitoringEnabled = isBatteryMonitoringEnabled
+        observers?.forEach(notificationCenter.removeObserver)
+        observers = nil
+    }
+}
+
+extension BatteryStatus.State {
+    /// Cast `UIDevice.BatteryState` to `BatteryStatus.State`
+    ///
+    /// - Parameter state: The state to cast.
+    init(_ state: UIDevice.BatteryState) {
+        switch state {
+        case .unknown:
+            self = .unknown
+        case .unplugged:
+            self = .unplugged
+        case .charging:
+            self = .charging
+        case .full:
+            self = .full
+        @unknown default:
+            self = .unknown
+        }
+    }
+}
+
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/CarrierInfoPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/CarrierInfoPublisher.swift
@@ -1,0 +1,117 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if os(iOS) && !targetEnvironment(macCatalyst)
+
+import CoreTelephony
+
+// MARK: - iOS 12+
+
+/// Carrier info provider for iOS 12 and above.
+/// It reads `CarrierInfo?` from `CTTelephonyNetworkInfo` only when `CTCarrier` has changed (e.g. when the SIM card was swapped).
+@available(iOS 12, *)
+internal struct iOS12CarrierInfoPublisher: ContextValuePublisher {
+    let initialValue: CarrierInfo?
+
+    private let networkInfo: CTTelephonyNetworkInfo
+
+    init(networkInfo: CTTelephonyNetworkInfo = .init()) {
+        self.networkInfo = networkInfo
+        self.initialValue = CarrierInfo(networkInfo, service: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first)
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<CarrierInfo?>) {
+        // The `serviceSubscriberCellularProvidersDidUpdateNotifier` block object executes on the default priority
+        // global dispatch queue when the user’s cellular provider information changes.
+        // This occurs, for example, if a user swaps the device’s SIM card with one from another provider, while the app is running.
+        // ref.: https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide
+        networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = { key in
+            // On iOS12+ `CarrierInfo` subscribers are notified on actual change to cellular provider.
+            let info = CarrierInfo(self.networkInfo, service: key)
+            receiver(info)
+        }
+    }
+
+    func cancel() {
+        networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = nil
+    }
+}
+
+extension CarrierInfo {
+    @available(iOS 12, *)
+    init?(_ info: CTTelephonyNetworkInfo, service key: String?) {
+        guard let key = key,
+           let radioTechnology = info.serviceCurrentRadioAccessTechnology?[key],
+           let carrier = info.serviceSubscriberCellularProviders?[key]
+        else {
+            return nil // the service is not registered on any network
+        }
+
+        self.init(
+            carrierName: carrier.carrierName,
+            carrierISOCountryCode: carrier.isoCountryCode,
+            carrierAllowsVOIP: carrier.allowsVOIP,
+            radioAccessTechnology: .init(radioTechnology)
+        )
+    }
+}
+
+// MARK: - iOS 11
+
+/// Carrier info provider for iOS 11.
+/// It reads `CarrierInfo?` from `CTTelephonyNetworkInfo` each time.
+internal struct iOS11CarrierInfoReader: ContextValueReader {
+    private let networkInfo: CTTelephonyNetworkInfo
+
+    init(networkInfo: CTTelephonyNetworkInfo = .init()) {
+        self.networkInfo = networkInfo
+    }
+
+    func read(to receiver: inout CarrierInfo?) {
+        receiver = CarrierInfo(networkInfo)
+    }
+}
+
+extension CarrierInfo {
+    init?(_ info: CTTelephonyNetworkInfo) {
+        guard
+            let radioTechnology = info.currentRadioAccessTechnology,
+            let carrier = info.subscriberCellularProvider
+        else {
+            return nil // the service is not registered on any network
+        }
+
+        self.init(
+            carrierName: carrier.carrierName,
+            carrierISOCountryCode: carrier.isoCountryCode,
+            carrierAllowsVOIP: carrier.allowsVOIP,
+            radioAccessTechnology: .init(radioTechnology)
+        )
+    }
+}
+
+extension CarrierInfo.RadioAccessTechnology {
+    init(_ radioAccessTechnology: String) {
+        switch radioAccessTechnology {
+        case CTRadioAccessTechnologyGPRS: self = .GPRS
+        case CTRadioAccessTechnologyEdge: self = .Edge
+        case CTRadioAccessTechnologyWCDMA: self = .WCDMA
+        case CTRadioAccessTechnologyHSDPA: self = .HSDPA
+        case CTRadioAccessTechnologyHSUPA: self = .HSUPA
+        case CTRadioAccessTechnologyCDMA1x: self = .CDMA1x
+        case CTRadioAccessTechnologyCDMAEVDORev0: self = .CDMAEVDORev0
+        case CTRadioAccessTechnologyCDMAEVDORevA: self = .CDMAEVDORevA
+        case CTRadioAccessTechnologyCDMAEVDORevB: self = .CDMAEVDORevB
+        case CTRadioAccessTechnologyeHRPD: self = .eHRPD
+        case CTRadioAccessTechnologyLTE: self = .LTE
+        default: self = .unknown
+        }
+    }
+}
+
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ContextValuePublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ContextValuePublisher.swift
@@ -1,0 +1,219 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Defines a receiver closure for receiving new values.
+internal typealias ContextValueReceiver<Value> = (Value) -> Void
+
+// MARK: - Publisher
+
+/// Declares that a type can transmit a sequence of values over time.
+///
+/// The receiver's ``ContextValueReceiver/Value`` generic type must match the
+/// ``ContextValuePublisher/Value`` types declared by the publisher.
+///
+/// A publisher delivers elements to one ``ContextValueReceiver`` closure. After this,
+/// the publisher can call the receiver with new values. At anytime, a subcriber can cancel the
+/// subscription. Invoking `cancel()` must stop calling its downstream receiver, canceling
+/// should also eliminate any strong references it currently holds.
+///
+/// The publisher provides an `initialValue`, this parameter must be immutable, thead-safe,
+/// and it shouldn't block the caller.
+///
+/// Every ``ContextValuePublisher`` must adhere to this contract for downstream
+/// subscribers to function correctly.
+internal protocol ContextValuePublisher {
+    /// The kind of values published by this publisher.
+    associatedtype Value
+
+    /// The initial value of the publisher.
+    var initialValue: Value { get }
+
+    /// Start sending values to a receiver.
+    func publish(to receiver: @escaping ContextValueReceiver<Value>)
+
+    /// Cancels publications.
+    ///
+    /// When implementing ``ContextValueSubscription`` in support of a custom publisher,
+    /// implement `cancel()` to request that your publisher stop calling its downstream receiver.
+    /// It's not required that the publisher stop immediately, but canceling should also eliminate any
+    /// strong references it currently holds.
+    ///
+    /// After you receive one call to `cancel()`, subsequent calls shouldn't do anything. Additionally,
+    /// your implementation must be thread-safe, and it shouldn't block the caller.
+    func cancel()
+}
+
+// MARK: - Subscription
+
+/// A protocol representing the connection of a receiver to a publisher.
+///
+/// Canceling a ``ContextValueSubscription`` must be thread-safe and you can only cancel a
+/// ``ContextValueSubscription`` once.
+///
+/// Canceling a subscription frees up any resources previously allocated by attaching the
+/// ``ContextValueReceiver``.
+internal protocol ContextValueSubscription {
+    /// Cancels the subcription.
+    ///
+    /// When implementing ``ContextValueSubscription`` in support of a custom publisher,
+    /// implement `cancel()` to request that your publisher stop calling its downstream receiver.
+    /// It's not required that the publisher stop immediately, but canceling should also eliminate any
+    /// strong references it currently holds.
+    ///
+    /// After you receive one call to `cancel()`, subsequent calls shouldn't do anything. Additionally,
+    /// your implementation must be thread-safe, and it shouldn't block the caller.
+    func cancel()
+}
+
+/// Attaches a ``ContextValueReceiver`` to a ``ContextValuePublisher`` to create
+/// ``ContextValueSubscription`` instance.
+///
+/// An instance of ``ContextValueBlockSubscription`` is returned when subrcribing to a
+/// publisher ``ContextValuePublisher/subscribe``.
+///
+///     let subscription = publisher.subscribe { value in
+///         print(value)
+///     }
+///
+///     subscription.cancel()
+///
+/// After cancelling the subscription, the publisher is released.
+private class ContextValueBlockSubscription<Publisher>: ContextValueSubscription where Publisher: ContextValuePublisher {
+    private var publisher: Publisher?
+
+    /// Creates a subscription but subscribing the receiver to the publisher.
+    ///
+    /// At initialization, the publisher will start publishing to the receiver.
+    ///
+    /// - Parameters:
+    ///   - publisher: The publisher to subscribe.
+    ///   - receiver: The receiver closure.
+    init(_ publisher: Publisher, receiver: @escaping ContextValueReceiver<Publisher.Value>) {
+        self.publisher = publisher
+        self.publisher?.publish(to: receiver)
+    }
+
+    /// Cancels the publication and free up allocated memory
+    func cancel() {
+        publisher?.cancel()
+        publisher = nil
+    }
+}
+
+extension ContextValuePublisher {
+    /// Subscribes the receiver to the receiver.
+    ///
+    /// After subscription, the publisher will start invoking the receiver with new values.
+    ///
+    ///     let subscription = publisher.subscribe { value in
+    ///         print(value)
+    ///     }
+    ///
+    /// When no more values are required, the subscription can be cancelled.
+    ///
+    ///     subscription.cancel()
+    ///
+    /// - Parameter receiver: The receiver closure.
+    /// - Returns: A subscription instance.
+    func subscribe(_ receiver: @escaping ContextValueReceiver<Value>) -> ContextValueSubscription {
+        return ContextValueBlockSubscription(self, receiver: receiver)
+    }
+}
+
+// MARK: - Type-Erasure
+
+/// A publisher that performs type erasure by wrapping another publisher.
+///
+/// ``AnyContextValuePublisher`` is a concrete implementation of ``ContextValuePublisher``
+/// that has no significant properties of its own, and passes through values from its upstream
+/// publisher.
+///
+/// Use ``AnyContextValuePublisher`` to wrap a publisher whose type has details
+/// you don’t want to expose across API boundaries, such as different modules
+///
+/// You can use extension method ``ContextValuePublish/ereraseToAnyPublisher()``
+/// operator o wrap a publisher with ``AnyContextValuePublisher``.
+internal struct AnyContextValuePublisher<Value>: ContextValuePublisher {
+    /// The initial value of the publisher.
+    let initialValue: Value
+
+    private let publishBlock: (@escaping ContextValueReceiver<Value>) -> Void
+    private let cancelBlock: () -> Void
+
+    /// Creates a type-erasing publisher to wrap the provided publisher.
+    ///
+    /// - Parameter publisher: A publisher to wrap with a type-eraser.
+    init<Publisher>(_ publisher: Publisher) where Publisher: ContextValuePublisher, Publisher.Value == Value {
+        initialValue = publisher.initialValue
+        publishBlock = publisher.publish
+        cancelBlock = publisher.cancel
+    }
+
+    /// Tells a publisher that it may send more values to the subscriber.
+    func publish(to receiver: @escaping ContextValueReceiver<Value>) {
+        self.publishBlock(receiver)
+    }
+
+    /// Cancels publications.
+    ///
+    /// When implementing ``ContextValueSubscription`` in support of a custom publisher,
+    /// implement `cancel()` to request that your publisher stop calling its downstream receiver.
+    /// It's not required that the publisher stop immediately, but canceling should also eliminate any
+    /// strong references it currently holds.
+    ///
+    /// After you receive one call to `cancel()`, subsequent calls shouldn't do anything. Additionally,
+    /// your implementation must be thread-safe, and it shouldn't block the caller.
+    func cancel() {
+        self.cancelBlock()
+    }
+}
+
+extension ContextValuePublisher {
+    /// Wraps this publisher with a type eraser.
+    ///
+    /// Use ``ContextValuePublish/eraseToAnyPublisher()`` to expose an instance of
+    /// ``AnyContextValuePublisher`` to the downstream subscriber, rather than this publisher’s
+    /// actual type. This form of _type erasure_ preserves abstraction across API boundaries.
+    ///
+    /// - Returns: An ``AnyContextValuePublisher`` wrapping this publisher.
+    func eraseToAnyPublisher() -> AnyContextValuePublisher<Value> {
+        return AnyContextValuePublisher(self)
+    }
+}
+
+// MARK: - No-op
+
+/// A no-operation publisher.
+///
+/// ``NOPContextValuePublisher`` is a concrete implementation of ``ContextValuePublisher``
+/// that has no effect when invoking ``ContextValuePublisher/read``.
+///
+/// You can use ``NOContextValuePublisher`` as a placeholder.
+internal struct NOPContextValuePublisher<Value>: ContextValuePublisher {
+    /// The initial value of the reader.
+    let initialValue: Value
+
+    /// Creates a type-erasing reader to wrap the provided reader.
+    ///
+    /// - Parameter reader: A reader to wrap with a type-eraser.
+    init(initialValue: Value) {
+        self.initialValue = initialValue
+    }
+
+    init() where Value: ExpressibleByNilLiteral {
+        self.initialValue = nil
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<Value>) {
+        // no-op
+    }
+
+    func cancel() {
+        // no-op
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ContextValueReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ContextValueReader.swift
@@ -1,0 +1,120 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Defines a read closure for mutating value.
+private typealias ContextValueMutation<Value> = (inout Value) -> Void
+
+/// Declares that a type can read values on demand.
+///
+/// A reader delivers elements to the receiver callback synchronously.
+/// The receiver's ``ContextValueReceiver/Value`` generic type must match the
+/// ``ContextValueReader/Value`` types declared by the reader.
+///
+/// The reader implements the ``ContextValuePublisher/read(_:)`` method
+/// to read the value and call the receiver.
+internal protocol ContextValueReader {
+    /// The kind of values this reader reads.
+    associatedtype Value
+
+    /// Reads the value synchronously and mutate the value.
+    ///
+    /// - Parameter receiver: The value to mutate on read.
+    func read(to receiver: inout Value)
+}
+
+// MARK: - Type-Erasure
+
+/// A reader that performs type erasure by wrapping another reader.
+///
+/// ``AnyContextValueReader`` is a concrete implementation of ``ContextValueReader``
+/// that has no significant properties of its own, and passes through value to its upstream
+/// reader.
+///
+/// Use ``AnyContextValueReader`` to wrap a reader whose type has details
+/// you don’t want to expose across API boundaries, such as different modules
+///
+/// You can use extension method ``ContextValueReader/eraseToAnyReader()``
+/// operator to wrap a publisher with ``ContextValueReader``.
+internal struct AnyContextValueReader<Value>: ContextValueReader {
+    private var mutation: ContextValueMutation<Value>
+
+    /// Creates a type-erasing reader to wrap the provided reader.
+    ///
+    /// - Parameter reader: A reader to wrap with a type-eraser.
+    init<Reader>(_ reader: Reader) where Reader: ContextValueReader, Reader.Value == Value {
+        self.mutation = reader.read
+    }
+
+    /// Reads the value synchronously and mutate the value.
+    ///
+    /// - Parameter receiver: The value to mutate on read.
+    func read(to receiver: inout Value) {
+        mutation(&receiver)
+    }
+}
+
+extension ContextValueReader {
+    /// Wraps this reader with a type eraser.
+    ///
+    /// Use ``ContextValueReader/eraseToAnyReader()`` to expose an instance of
+    /// ``AnyContextValueReader`` to the downstream subscriber, rather than this reader’s
+    /// actual type. This form of _type erasure_ preserves abstraction across API boundaries.
+    ///
+    /// - Returns: An ``AnyContextValueReader`` wrapping this reader.
+    func eraseToAnyReader() -> AnyContextValueReader<Value> {
+        return AnyContextValueReader(self)
+    }
+}
+
+// MARK: - Key-path Reader
+
+/// A reader that performs key-path mutations by wrapping other readers.
+///
+/// ``KeyPathContextValueReader`` keeps an array of mutation operations by calling
+/// ``ContextValueReader/read`` to write to a value's property at given ``WritableKeyPath``.
+///
+/// Use ``KeyPathContextValueReader`` to wrap readers to mutate properties of
+/// a value.
+internal struct KeyPathContextValueReader<Value> {
+    private var mutations: [ContextValueMutation<Value>] = []
+
+    /// Appends a ``ContextValueReader`` instance to set the value's property at a given
+    /// `keyPath`.
+    ///
+    /// - Parameters:
+    ///   - reader: The reader to append.
+    ///   - keyPath: The value's writable `keyPath`.
+    mutating func append<Reader>(reader: Reader, receiver keyPath: WritableKeyPath<Value, Reader.Value>) where Reader: ContextValueReader {
+        mutations.append { value in
+            reader.read(to: &value[keyPath: keyPath])
+        }
+    }
+
+    /// Reads the value synchronously and mutate the value.
+    ///
+    /// - Parameter receiver: The value to mutate on read.
+    func read(to receiver: inout Value) {
+        mutations.forEach { mutation in
+            mutation(&receiver)
+        }
+    }
+}
+
+// MARK: - No-op
+
+/// A no-operation reader.
+///
+/// ``NOPContextValueReader`` is a concrete implementation of ``ContextValueReader``
+/// that has no effect when invoking ``ContextValueReader/read``.
+///
+/// You can use ``NOPContextValueReader`` as a placeholder.
+internal struct NOPContextValueReader<Value>: ContextValueReader {
+    func read(to receiver: inout Value) {
+        // no-op
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/DatadogContextProvider.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/DatadogContextProvider.swift
@@ -1,0 +1,170 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides thread-safe access to Datadog Context.
+///
+/// The context can be accessed asynchronously for reads and writes.
+///
+///     provider.read { context in
+///         // read value from the current context
+///     }
+///
+///     provider.write { context in
+///         // set mutable values of the context
+///     }
+///
+/// The provider performs reads concurrently but uses barrier block for
+/// write operations.
+///
+/// The context provider has the ability to a assign a value reader that complies to
+/// ``ContextValueReader`` to a specific context property. e.g.:
+///
+///     let reader = ServerOffsetReader<TimeInterval>(initialValue: 0)
+///     provider.assign(reader: reader, to: \.serverTimeOffset)
+///
+///
+/// The context provider can subscribe a context property to a publisher that complies
+/// to ``ContextValuePublisher``. e.g.:
+///
+///     let publisher = ServerOffsetPublisher<TimeInterval>(initialValue: 0)
+///     provider.subscribe(\.serverTimeOffset, to: publisher)
+///
+/// All subscriptions will be cancelled when the provider is deallocated.
+internal final class DatadogContextProvider {
+    /// The current `context`.
+    ///
+    /// The value must be accessed from the `queue` only.
+    private var context: DatadogContext {
+        didSet { receivers.forEach { $0(context) } }
+    }
+
+    /// The queue used to synchronize the access to the `DatadogContext`.
+    internal let queue = DispatchQueue(
+        label: "com.datadoghq.core-context",
+        qos: .utility
+    )
+
+    /// List of receivers to invoke when the context changes.
+    private var receivers: [ContextValueReceiver<DatadogContext>]
+
+    /// List of subscription of context values.
+    private var subscriptions: [ContextValueSubscription]
+
+    /// A reader for key-path values of the context.
+    private var reader: KeyPathContextValueReader<DatadogContext>
+
+    /// Creates a context provider to perform reads and writes on the
+    /// shared Datadog context.
+    ///
+    /// - Parameter context: The inital context value.
+    init(context: DatadogContext) {
+        self.context = context
+        self.receivers = []
+        self.subscriptions = []
+        self.reader = KeyPathContextValueReader()
+    }
+
+    deinit {
+        subscriptions.forEach { $0.cancel() }
+    }
+
+    /// Reads current context.
+    ///
+    /// **Warning:** Must be called from the `queue`.
+    private func unsafeRead() -> DatadogContext {
+        reader.read(to: &self.context)
+        return context
+    }
+
+    /// Publishes context changes to the given receiver.
+    ///
+    /// - Parameter receiver: The receiver closure.
+    func publish(to receiver: @escaping ContextValueReceiver<DatadogContext>) {
+        queue.async { self.receivers.append(receiver) }
+    }
+
+    /// Reads to the `context` synchronously, by blocking the caller thread.
+    ///
+    /// **Warning:** This method will block the caller thread by reading the context
+    /// synchronously on a concurrent queue.
+    /// 
+    /// - Returns: The current context.
+    func read() -> DatadogContext {
+        queue.sync(execute: unsafeRead)
+    }
+
+    /// Reads to the `context` asynchronously, without blocking the caller thread.
+    ///
+    /// - Parameter block: The block closure called with the current context.
+    func read(block: @escaping (DatadogContext) -> Void) {
+        queue.async { block(self.unsafeRead()) }
+    }
+
+    /// Writes to the `context` asynchronously, without blocking the caller thread.
+    ///
+    /// - Parameter block: The block closure called with the current context.
+    func write(block: @escaping (inout DatadogContext) -> Void) {
+        queue.async { block(&self.context) }
+    }
+
+    /// Subscribes a context's property to a publisher.
+    ///
+    /// The context provider can subscribe a context property to a publisher that complies
+    /// to ``ContextValuePublisher``. e.g.:
+    ///
+    ///     let publisher = ServerOffsetPublisher<TimeInterval>(initialValue: 0)
+    ///     provider.subscribe(\.serverTimeOffset, to: publisher)
+    ///
+    /// - Parameters:
+    ///   - keyPath: A context's key path that supports reading from and writing to the resulting value.
+    ///   - publisher: The context value publisher.
+    func subscribe<Publisher>(_ keyPath: WritableKeyPath<DatadogContext, Publisher.Value>, to publisher: Publisher) where Publisher: ContextValuePublisher {
+        let subscription = publisher.subscribe { value in
+            self.write { $0[keyPath: keyPath] = value }
+        }
+
+        write {
+            $0[keyPath: keyPath] = publisher.initialValue
+            self.subscriptions.append(subscription)
+        }
+    }
+
+    /// Assigns a value reader to a context property.
+    ///
+    /// The context provider has the ability to a assign a value reader that complies to
+    /// ``ContextValueReader`` to a specific context property. e.g.:
+    ///
+    ///     let reader = ServerOffsetReader<TimeInterval>()
+    ///     provider.assign(reader: reader, to: \.serverTimeOffset)
+    ///
+    /// - Parameters:
+    ///   - reader: The value reader.
+    ///   - keyPath: A context's key path that supports reading from and writing to the resulting value.
+    func assign<Reader>(reader: Reader, to keyPath: WritableKeyPath<DatadogContext, Reader.Value>) where Reader: ContextValueReader {
+        queue.async {
+            self.reader.append(reader: reader, receiver: keyPath)
+        }
+    }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func replace(context newContext: DatadogContext) {
+        queue.async {
+            self.context = newContext
+        }
+    }
+#endif
+}
+
+extension DatadogContextProvider: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/LaunchTimePublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/LaunchTimePublisher.swift
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if SPM_BUILD
+import DatadogPrivateFork
+#endif
+
+
+internal struct LaunchTimePublisher: ContextValuePublisher {
+    private typealias AppLaunchHandler = __fork_dd_private_AppLaunchHandler
+
+    let initialValue: LaunchTime?
+
+    init() {
+        initialValue = LaunchTime(
+            launchTime: AppLaunchHandler.shared.launchTime?.doubleValue,
+            launchDate: AppLaunchHandler.shared.launchDate,
+            isActivePrewarm: AppLaunchHandler.shared.isActivePrewarm
+        )
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<LaunchTime?>) {
+        let launchDate = AppLaunchHandler.shared.launchDate
+        let isActivePrewarm = AppLaunchHandler.shared.isActivePrewarm
+
+        AppLaunchHandler.shared.setApplicationDidBecomeActiveCallback { launchTime in
+            let value = LaunchTime(
+                launchTime: launchTime,
+                launchDate: launchDate,
+                isActivePrewarm: isActivePrewarm
+            )
+            receiver(value)
+        }
+    }
+
+    func cancel() {
+        AppLaunchHandler.shared.setApplicationDidBecomeActiveCallback { _ in }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/LowPowerModePublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/LowPowerModePublisher.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The low power mode publisher will publish the ``ProcessInfo/isLowPowerModeEnabled`` value
+/// by observing the `NSProcessInfoPowerStateDidChange` notification on the given
+/// notification center.
+internal final class LowPowerModePublisher: ContextValuePublisher {
+    let initialValue: Bool
+
+    private let notificationCenter: NotificationCenter
+    private var observer: Any?
+
+    /// Creates a low power mode publisher.
+    ///
+    /// - Parameters:
+    ///   - processInfo: The process for reading the initial `isLowPowerModeEnabled`.
+    ///   - notificationCenter: The notification center for observing the `NSProcessInfoPowerStateDidChange`,
+    init(
+        processInfo: ProcessInfo = .processInfo,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.initialValue = processInfo.isLowPowerModeEnabled
+        self.notificationCenter = notificationCenter
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<Bool>) {
+        self.observer = notificationCenter
+            .addObserver(
+                forName: .NSProcessInfoPowerStateDidChange,
+                object: nil,
+                queue: .main
+            ) { notification in
+                guard let processInfo = notification.object as? ProcessInfo else {
+                    return
+                }
+
+                // We suspect an iOS 15 bug (ref.: https://openradar.appspot.com/FB9741207) which leads to rare
+                // `_os_unfair_lock_recursive_abort` crash when `processInfo.isLowPowerModeEnabled` is accessed
+                // directly in the notification handler. As a workaround, we defer its access to the next run loop
+                // where underlying lock should be already released.
+                OperationQueue.main.addOperation {
+                    receiver(processInfo.isLowPowerModeEnabled)
+                }
+            }
+    }
+
+    func cancel() {
+        observer.map(notificationCenter.removeObserver)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/NetworkConnectionInfoPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/NetworkConnectionInfoPublisher.swift
@@ -1,0 +1,159 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+// MARK: - iOS 12+
+
+import Network
+
+/// Thread-safe wrapper for `NWPathMonitor`.
+///
+/// The `NWPathMonitor` provides two models of getting the `NWPath` info:
+/// * pulling the value with `monitor.currentPath`,
+/// * pushing the value with `monitor.pathUpdateHandler = { path in ... }`.
+///
+/// We found the pulling model to not be thread-safe: accessing `currentPath` properties lead to occasional crashes.
+/// The `ThreadSafeNWPathMonitor` listens to path updates and synchonizes the values on `.current` property.
+/// This adds the necessary thread-safety and keeps the convenience of pulling.
+@available(iOS 12, tvOS 12, *)
+internal struct NWPathMonitorPublisher: ContextValuePublisher {
+    private static let defaultQueue = DispatchQueue(
+        label: "com.datadoghq.nw-path-monitor-publisher",
+        target: .global(qos: .utility)
+    )
+
+    let initialValue: NetworkConnectionInfo?
+
+    private let monitor: NWPathMonitor
+    private let queue: DispatchQueue
+
+    init(
+        monitor: NWPathMonitor = .init(),
+        queue: DispatchQueue = NWPathMonitorPublisher.defaultQueue
+    ) {
+        self.monitor = monitor
+        self.queue = queue
+        self.initialValue = NetworkConnectionInfo(monitor.currentPath)
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<NetworkConnectionInfo?>) {
+        monitor.pathUpdateHandler = {
+            let info = NetworkConnectionInfo($0)
+            receiver(info)
+        }
+
+        monitor.start(queue: queue)
+    }
+
+    func cancel() {
+        monitor.cancel()
+    }
+}
+
+extension NetworkConnectionInfo {
+    @available(iOS 12, tvOS 12, *)
+    init(_ path: NWPath) {
+        self.init(
+            reachability: NetworkConnectionInfo.Reachability(path.status),
+            availableInterfaces: path.availableInterfaces.map { .init($0.type) },
+            supportsIPv4: path.supportsIPv4,
+            supportsIPv6: path.supportsIPv6,
+            isExpensive: path.isExpensive,
+            isConstrained: {
+                guard #available(iOS 13, tvOS 13, *) else {
+                    return nil
+                }
+                return path.isConstrained
+            }()
+        )
+    }
+}
+
+extension NetworkConnectionInfo.Reachability {
+    @available(iOS 12, tvOS 12, *)
+    init(_ status: NWPath.Status) {
+        switch status {
+        case .satisfied: self = .yes
+        case .requiresConnection: self = .maybe
+        case .unsatisfied: self = .no
+        @unknown default: self = .maybe
+        }
+    }
+}
+
+extension NetworkConnectionInfo.Interface {
+    @available(iOS 12, tvOS 12, *)
+    init(_ interface: NWInterface.InterfaceType) {
+        switch interface {
+        case .wifi: self = .wifi
+        case .wiredEthernet: self = .wiredEthernet
+        case .cellular: self = .cellular
+        case .loopback: self = .loopback
+        case .other: self = .other
+        @unknown default: self = .other
+        }
+    }
+}
+
+// MARK: - iOS 11
+
+import SystemConfiguration
+
+internal struct SCNetworkReachabilityReader: ContextValueReader {
+    private let reachability: SCNetworkReachability
+
+    init(reachability: SCNetworkReachability) {
+        self.reachability = reachability
+    }
+
+    init() {
+        var zero = sockaddr()
+        zero.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zero.sa_family = sa_family_t(AF_INET)
+        let reachability = SCNetworkReachabilityCreateWithAddress(nil, &zero)! // swiftlint:disable:this force_unwrapping
+        self.init(reachability: reachability)
+    }
+
+    func read(to receiver: inout NetworkConnectionInfo?) {
+        receiver = NetworkConnectionInfo(reachability)
+    }
+}
+
+extension NetworkConnectionInfo {
+    init(_ reachability: SCNetworkReachability) {
+        var retrieval = SCNetworkReachabilityFlags()
+        let flags = (SCNetworkReachabilityGetFlags(reachability, &retrieval)) ? retrieval : nil
+        self.init(
+            reachability: .init(flags),
+            availableInterfaces: NetworkConnectionInfo.Interface(flags).map { [$0] },
+            supportsIPv4: nil,
+            supportsIPv6: nil,
+            isExpensive: nil,
+            isConstrained: nil
+        )
+    }
+}
+
+extension NetworkConnectionInfo.Reachability {
+    init(_ flags: SCNetworkReachabilityFlags?) {
+        switch flags?.contains(.reachable) {
+        case .none: self = .maybe
+        case .some(true): self = .yes
+        case .some(false): self = .no
+        }
+    }
+}
+
+extension NetworkConnectionInfo.Interface {
+    @available(iOS 2.0, macCatalyst 13.0, *)
+    init?(_ flags: SCNetworkReachabilityFlags?) {
+        guard let flags = flags, flags.contains(.isWWAN) else {
+            return nil
+        }
+        self = .cellular
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ServerOffsetPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/ServerOffsetPublisher.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// List of Datadog NTP pools.
+public let DatadogNTPServers = [
+    "0.datadog.pool.ntp.org",
+    "1.datadog.pool.ntp.org",
+    "2.datadog.pool.ntp.org",
+    "3.datadog.pool.ntp.org"
+]
+
+/// Abstract the monotonic clock synchronized with the server using NTP.
+public protocol ServerDateProvider {
+    /// Start the clock synchronisation with NTP server.
+    ///
+    /// Calls the `completion` by passing it the server time offset when the synchronization succeeds.
+    func synchronize(update: @escaping (TimeInterval) -> Void)
+}
+
+internal class DatadogNTPDateProvider: ServerDateProvider {
+    let kronos: KronosClockProtocol
+
+    init(kronos: KronosClockProtocol = KronosClock()) {
+        self.kronos = kronos
+    }
+
+    func synchronize(update: @escaping (TimeInterval) -> Void) {
+        kronos.sync(
+            from: DatadogNTPServers.randomElement()!, // swiftlint:disable:this force_unwrapping
+            first: { _, offset in
+                update(offset)
+            },
+            completion: { now, offset in
+                // Kronos only notifies for the first and last samples.
+                // In case, the last sample does not return an offset, we calculate the offset
+                // from the returned `now` parameter. The `now` parameter in this callback
+                // is `Clock.now` and it can be either offset computed from prior samples or persisted
+                // in user defaults from previous app session.
+                if let offset = offset ?? now?.timeIntervalSinceNow {
+                    update(offset)
+
+                    let difference = (offset * 1_000).rounded() / 1_000
+                    DD.logger.debug(
+                        """
+                        NTP time synchronization completed.
+                        Server time will be used for signing events (\(difference)s difference with device time).
+                        """
+                    )
+                } else {
+                    update(0)
+
+                    DD.logger.error(
+                        """
+                        NTP time synchronization failed.
+                        Device time will be used for signing events.
+                        """
+                    )
+                }
+            }
+        )
+
+        // `Kronos.sync` first loads the previous state from the `UserDefaults` if any.
+        // We can invoke `Clock.now` to retrieve the stored offset.
+        if let offset = kronos.now?.timeIntervalSinceNow {
+            update(offset)
+        }
+    }
+}
+
+/// The Server Offset Publisher provides updates on time offset between the
+/// local time and one of the Datadog's NTP pool.
+///
+/// This publisher uses a modified version of the ``MobileNativeFoundation/Kronos``
+/// see. https://github.com/MobileNativeFoundation/Kronos
+///
+/// The ``KronosClockPublisher/publish`` will start syncing with one of the pool
+/// picked randomly from ``DatadogNTPServers``.
+///
+/// The time offset is defined in seconds.
+internal final class ServerOffsetPublisher: ContextValuePublisher {
+    /// The initial offset is 0.
+    let initialValue: TimeInterval = .zero
+
+    private var provider: ServerDateProvider?
+
+    /// Creates a publisher using the given `KronosClock` implementation.
+    ///
+    /// - Parameter kronos: An object complying with `KronosClockProtocol`.
+    init(provider: ServerDateProvider = DatadogNTPDateProvider()) {
+        self.provider = provider
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<TimeInterval>) {
+        provider?.synchronize(update: receiver)
+    }
+
+    func cancel() {
+        provider = nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/TrackingConsentPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/TrackingConsentPublisher.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Publishes the user consent to receiver.
+internal final class TrackingConsentPublisher: ContextValuePublisher {
+    let initialValue: TrackingConsent
+
+    private var receiver: ContextValueReceiver<TrackingConsent>?
+
+    var consent: TrackingConsent {
+        didSet { receiver?(consent) }
+    }
+
+    init(consent: TrackingConsent) {
+        self.initialValue = consent
+        self.consent = consent
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<TrackingConsent>) {
+        self.receiver = receiver
+    }
+
+    func cancel() {
+        receiver = nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/UserInfoPublisher.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Context/UserInfoPublisher.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Publishes the current `UserInfo` value to receiver.
+internal final class UserInfoPublisher: ContextValuePublisher {
+    let initialValue: UserInfo? = .empty
+
+    private var receiver: ContextValueReceiver<UserInfo>?
+
+    var current: UserInfo = .empty {
+        didSet { receiver?(current) }
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<UserInfo?>) {
+        self.receiver = receiver
+    }
+
+    func cancel() {
+        receiver = nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/DatadogCore.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/DatadogCore.swift
@@ -1,0 +1,436 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Core implementation of Datadog SDK.
+///
+/// The core provides a storage and upload mechanism for each registered Feature
+/// based on their respective configuration.
+///
+/// By complying with `DatadogCoreProtocol`, the core can
+/// provide context and writing scopes to Features for event recording.
+internal final class DatadogCore {
+    /// The root location for storing Features data in this instance of the SDK.
+    /// For each Feature a set of subdirectories is created inside `CoreDirectory` based on their storage configuration.
+    let directory: CoreDirectory
+
+    /// The storage r/w GDC queue.
+    let readWriteQueue = DispatchQueue(
+        label: "com.datadoghq.ios-sdk-read-write",
+        autoreleaseFrequency: .workItem,
+        target: .global(qos: .utility)
+    )
+
+    /// The system date provider.
+    let dateProvider: DateProvider
+
+    /// The user consent publisher.
+    let consentPublisher: TrackingConsentPublisher
+
+    /// The core SDK performance presets.
+    let performance: PerformancePreset
+
+    /// The HTTP Client for uploads.
+    let httpClient: HTTPClient
+
+    /// The on-disk data encryption.
+    let encryption: DataEncryption?
+
+    /// The user info publisher that publishes value to the
+    /// `contextProvider`
+    let userInfoPublisher = UserInfoPublisher()
+
+    /// The application version publisher.
+    let applicationVersionPublisher: ApplicationVersionPublisher
+
+    /// The message-bus instance.
+    let bus = MessageBus()
+
+    /// Registry for Features.
+    @ReadWriteLock
+    private(set) var stores: [String: (
+        storage: FeatureStorage,
+        upload: FeatureUpload
+    )] = [:]
+
+    /// Registry for Features.
+    @ReadWriteLock
+    private var features: [String: DatadogFeature] = [:]
+
+    /// The core context provider.
+    internal let contextProvider: DatadogContextProvider
+
+    /// Creates a core instance.
+    ///
+    /// - Parameters:
+    ///   - directory: The core directory for this instance of the SDK.
+    ///   - dateProvider: The system date provider.
+    ///   - initialConsent: The initial user consent.
+    ///   - performance: The core SDK performance presets.
+    ///   - httpClient: The HTTP Client for uploads.
+    ///   - encryption: The on-disk data encryption.
+    ///   - contextProvider: The core context provider.
+    ///   - applicationVersion: The application version.
+    init(
+        directory: CoreDirectory,
+        dateProvider: DateProvider,
+        initialConsent: TrackingConsent,
+    	performance: PerformancePreset,
+    	httpClient: HTTPClient,
+    	encryption: DataEncryption?,
+        contextProvider: DatadogContextProvider,
+        applicationVersion: String
+    ) {
+        self.directory = directory
+        self.dateProvider = dateProvider
+        self.performance = performance
+        self.httpClient = httpClient
+        self.encryption = encryption
+        self.contextProvider = contextProvider
+        self.applicationVersionPublisher = ApplicationVersionPublisher(version: applicationVersion)
+        self.consentPublisher = TrackingConsentPublisher(consent: initialConsent)
+
+        self.contextProvider.subscribe(\.userInfo, to: userInfoPublisher)
+        self.contextProvider.subscribe(\.version, to: applicationVersionPublisher)
+        self.contextProvider.subscribe(\.trackingConsent, to: consentPublisher)
+
+        // connect the core to the message bus.
+        // the bus will keep a weak ref to the core.
+        bus.connect(core: self)
+
+        // forward any context change on the message-bus
+        self.contextProvider.publish { [weak self] context in
+            self?.send(message: .context(context))
+        }
+    }
+
+    /// Sets current user information.
+    ///
+    /// Those will be added to logs, traces and RUM events automatically.
+    /// 
+    /// - Parameters:
+    ///   - id: User ID, if any
+    ///   - name: Name representing the user, if any
+    ///   - email: User's email, if any
+    ///   - extraInfo: User's custom attributes, if any
+    func setUserInfo(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:]
+    ) {
+        let userInfo = UserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
+
+        userInfoPublisher.current = userInfo
+    }
+
+    /// Add or override the extra info of the current user
+    ///
+    ///  - Parameters:
+    ///    - extraInfo: The user's custom attibutes to add or override
+    func addUserExtraInfo(_ newExtraInfo: [AttributeKey: AttributeValue?]) {
+        var extraInfo = userInfoPublisher.current.extraInfo
+        newExtraInfo.forEach { extraInfo[$0.key] = $0.value }
+        userInfoPublisher.current.extraInfo = extraInfo
+    }
+
+    /// Sets the tracking consent regarding the data collection for the Datadog SDK.
+    /// 
+    /// - Parameter trackingConsent: new consent value, which will be applied for all data collected from now on
+    func set(trackingConsent: TrackingConsent) {
+        if trackingConsent != consentPublisher.consent {
+            allStorages.forEach { $0.migrateUnauthorizedData(toConsent: trackingConsent) }
+            consentPublisher.consent = trackingConsent
+        }
+    }
+
+    /// Clears all data that has not already yet been uploaded Datadog servers.
+    func clearAllData() {
+        allStorages.forEach { $0.clearAllData() }
+    }
+
+    /// Adds a message receiver to the bus.
+    ///
+    /// After being added to the bus, the core will send the current context to receiver.
+    ///
+    /// - Parameters:
+    ///   - messageReceiver: The new message receiver.
+    ///   - key: The key associated with the receiver.
+    private func add(messageReceiver: FeatureMessageReceiver, forKey key: String) {
+        bus.connect(messageReceiver, forKey: key)
+        contextProvider.read { context in
+            self.bus.queue.async { messageReceiver.receive(message: .context(context), from: self) }
+        }
+    }
+
+    /// A list of storage units of currently registered Features.
+    private var allStorages: [FeatureStorage] {
+        stores.values.map { $0.storage }
+    }
+
+    /// A list of upload units of currently registered Features.
+    private var allUploads: [FeatureUpload] {
+        stores.values.map { $0.upload }
+    }
+
+    /// Awaits completion of all asynchronous operations, forces uploads (without retrying) and deinitializes
+    /// this instance of the SDK. It **blocks the caller thread**.
+    ///
+    /// Upon return, it is safe to assume that all events were stored and got uploaded. The SDK was deinitialised so this instance of core is missfunctional.
+    func flushAndTearDown() {
+        flush()
+
+        // At this point we can assume that all write operations completed and resulted with writing events to
+        // storage. We now temporarily authorize storage for making all files readable ("uploadable") and perform
+        // arbitrary uploads (without retrying on failure).
+        allStorages.forEach { $0.setIgnoreFilesAgeWhenReading(to: true) }
+        allUploads.forEach { $0.flushAndTearDown() }
+        allStorages.forEach { $0.setIgnoreFilesAgeWhenReading(to: false) }
+
+        // Deallocate all Features and their storage & upload units:
+        stores = [:]
+        features = [:]
+    }
+}
+
+extension DatadogCore: DatadogCoreProtocol {
+    /// Registers a Feature instance.
+    ///
+    /// A Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
+    /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
+    /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
+    ///
+    /// A Feature can also communicate to other Features by sending message on the bus that is managed by the core.
+    ///
+    /// - Parameter feature: The Feature instance.
+    /* public */ func register<T>(feature: T) throws where T: DatadogFeature {
+        let featureDirectories = try directory.getFeatureDirectories(forFeatureNamed: T.name)
+
+        let performancePreset: PerformancePreset
+        if let override = feature.performanceOverride {
+            performancePreset = performance.updated(with: override)
+        } else {
+            performancePreset = performance
+        }
+
+        if let feature = feature as? DatadogRemoteFeature {
+            let storage = FeatureStorage(
+                featureName: T.name,
+                queue: readWriteQueue,
+                directories: featureDirectories,
+                dateProvider: dateProvider,
+                performance: performancePreset,
+                encryption: encryption
+            )
+
+            let upload = FeatureUpload(
+                featureName: T.name,
+                contextProvider: contextProvider,
+                fileReader: storage.reader,
+                requestBuilder: feature.requestBuilder,
+                httpClient: httpClient,
+                performance: performancePreset
+            )
+
+            stores[T.name] = (
+                storage: storage,
+                upload: upload
+            )
+
+            // If there is any persisted data recorded with `.pending` consent,
+            // it should be deleted on Feature startup:
+            storage.clearUnauthorizedData()
+        }
+
+        features[T.name] = feature
+        add(messageReceiver: feature.messageReceiver, forKey: T.name)
+    }
+
+    /// Retrieves a Feature by its name and type.
+    ///
+    /// A Feature type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let feature = core.feature(named: "foo", type: Foo.self)
+    ///     let feature: Foo? = core.feature(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature's name.
+    ///   - type: The Feature instance type.
+    /// - Returns: The Feature if any.
+    /* public */ func get<T>(feature type: T.Type = T.self) -> T? where T: DatadogFeature {
+        features[T.name] as? T
+    }
+
+    /* public */ func scope(for feature: String) -> FeatureScope? {
+        guard let storage = stores[feature]?.storage else {
+            return nil
+        }
+
+        return DatadogCoreFeatureScope(
+            contextProvider: contextProvider,
+            storage: storage
+        )
+    }
+
+    /* public */ func set(feature: String, attributes: @escaping () -> FeatureBaggage) {
+        contextProvider.write { $0.featuresAttributes[feature] = attributes() }
+    }
+
+    func update(feature: String, attributes: @escaping () -> FeatureBaggage) {
+        contextProvider.write {
+            if $0.featuresAttributes[feature] != nil {
+                $0.featuresAttributes[feature]?.merge(with: attributes())
+            } else {
+                $0.featuresAttributes[feature] = attributes()
+            }
+        }
+    }
+
+    /* public */ func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
+        bus.send(message: message, else: fallback)
+    }
+}
+
+internal struct DatadogCoreFeatureScope: FeatureScope {
+    let contextProvider: DatadogContextProvider
+    let storage: FeatureStorage
+
+    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) throws -> Void) {
+        // On user thread: request SDK context.
+        contextProvider.read { context in
+            // On context thread: request writer for current tracking consent.
+            let writer = storage.writer(
+                for: bypassConsent ? .granted : context.trackingConsent,
+                forceNewBatch: forceNewBatch
+            )
+
+            // Still on context thread: send `Writer` to EWC caller. The writer implements `AsyncWriter`, so
+            // the implementation of `writer.write(value:)` will run asynchronously without blocking the context thread.
+            do {
+                try block(context, writer)
+            } catch {
+                DD.telemetry.error("Failed to execute feature scope", error: error)
+            }
+        }
+    }
+}
+
+extension DatadogContextProvider {
+    /// Creates a core context provider with the given configuration,
+    convenience init(
+        site: DatadogSite,
+        clientToken: String,
+        service: String,
+        env: String,
+        version: String,
+        variant: String?,
+        source: String,
+        sdkVersion: String,
+        ciAppOrigin: String?,
+        applicationName: String,
+        applicationBundleIdentifier: String,
+        applicationVersion: String,
+        sdkInitDate: Date,
+        device: DeviceInfo,
+        dateProvider: DateProvider,
+        serverDateProvider: ServerDateProvider
+    ) {
+        let context = DatadogContext(
+            site: site,
+            clientToken: clientToken,
+            service: service,
+            env: env,
+            version: applicationVersion,
+            variant: variant,
+            source: source,
+            sdkVersion: sdkVersion,
+            ciAppOrigin: ciAppOrigin,
+            applicationName: applicationName,
+            applicationBundleIdentifier: applicationBundleIdentifier,
+            sdkInitDate: dateProvider.now,
+            device: device,
+            // this is a placeholder waiting for the `ApplicationStatePublisher`
+            // to be initialized on the main thread, this value will be overrided
+            // as soon as the subscription is made.
+            applicationStateHistory: .active(since: dateProvider.now)
+        )
+
+        self.init(context: context)
+
+        subscribe(\.serverTimeOffset, to: ServerOffsetPublisher(provider: serverDateProvider))
+        subscribe(\.launchTime, to: LaunchTimePublisher())
+
+        if #available(iOS 12, tvOS 12, *) {
+            subscribe(\.networkConnectionInfo, to: NWPathMonitorPublisher())
+        } else {
+            assign(reader: SCNetworkReachabilityReader(), to: \.networkConnectionInfo)
+        }
+
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        if #available(iOS 12, *) {
+            subscribe(\.carrierInfo, to: iOS12CarrierInfoPublisher())
+        } else {
+            assign(reader: iOS11CarrierInfoReader(), to: \.carrierInfo)
+        }
+        #endif
+
+        #if os(iOS) && !targetEnvironment(simulator)
+        subscribe(\.batteryStatus, to: BatteryStatusPublisher())
+        subscribe(\.isLowPowerModeEnabled, to: LowPowerModePublisher())
+        #endif
+
+        #if os(iOS) || os(tvOS)
+        DispatchQueue.main.async {
+            // must be call on the main thread to read `UIApplication.State`
+            let applicationStatePublisher = ApplicationStatePublisher(dateProvider: dateProvider)
+            self.subscribe(\.applicationStateHistory, to: applicationStatePublisher)
+        }
+        #endif
+    }
+}
+
+extension DatadogCore: Flushable {
+    /// Flushes asynchronous operations related to events write, context and message bus propagation in this instance of the SDK
+    /// with **blocking the caller thread** till their completion.
+    ///
+    /// Upon return, it is safe to assume that all events are stored. No assumption on their upload should be made - to force events upload
+    /// use `flushAndTearDown()` instead.
+    func flush() {
+        // The order of flushing below must be considered cautiously and
+        // follow our design choices around SDK core's threading.
+
+        let features = features.values.compactMap { $0 as? Flushable }
+
+        // The flushing is repeated few times, to make sure that operations spawned from other operations
+        // on these queues are also awaited. Effectively, this is no different than short-time sleep() on current
+        // thread and it has the same drawbacks (including: it might become flaky). Until we find a better solution
+        // this is enough to get consistency in tests - but won't be reliable in any public "deinitialize" API.
+        for _ in 0..<5 {
+            // First, flush bus queue - because messages can lead to obtaining "event write context" (reading
+            // context & performing write) in other Features:
+            bus.flush()
+
+            // Next, flush flushable Features - finish current data collection to open "event write contexts":
+            features.forEach { $0.flush() }
+
+            // Next, flush context queue - because it indicates the entry point to "event write context" and
+            // actual writes dispatched from it:
+            contextProvider.flush()
+
+            // Last, flush read-write queue - it always comes last, no matter if the write operation is dispatched
+            // from "event write context" started on user thread OR if it happens upon receiving an "event" message
+            // in other Feature:
+            readWriteQueue.sync { }
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/MessageBus.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/MessageBus.swift
@@ -1,0 +1,135 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// The message-bus sends messages to a set of registered receivers.
+///
+/// The bus dispatches messages on a serial queue.
+internal final class MessageBus {
+    /// The message bus GDC queue.
+    let queue = DispatchQueue(
+        label: "com.datadoghq.ios-sdk-message-bus",
+        target: .global(qos: .utility)
+    )
+
+    /// A weak core reference.
+    ///
+    /// The core **must** be accessed within the queue.
+    private weak var core: DatadogCoreProtocol?
+
+    /// The message bus used to dispatch messages to registered features.
+    ///
+    /// The bus **must** be accessed within the queue.
+    private var bus: [String: FeatureMessageReceiver] = [:]
+
+    /// The current configuration.
+    ///
+    /// The message-bus wil accumulate configuration by merge. A message
+    /// with the configuration will be dispatched once after a specified delay,
+    /// 5 seconds by default.
+    ///
+    /// The configuration **must** be accessed within the queue.
+    private var configuration: ConfigurationTelemetry?
+
+    /// Creates a bus for the given core.
+    ///
+    /// The message-bus keeps a weak reference to the core.
+    /// - Parameter configurationDispatchTime: The delay to dispatch the
+    /// configuration telemetry
+    init(configurationDispatchTime: DispatchTimeInterval = .seconds(5)) {
+        queue.asyncAfter(deadline: .now() + configurationDispatchTime) {
+            guard let core = self.core, let configuration = self.configuration else {
+                return
+            }
+
+            self.bus.values.forEach {
+                $0.receive(message: .telemetry(.configuration(configuration)), from: core)
+            }
+        }
+    }
+
+    /// Connects the core to the bus.
+    ///
+    /// The message-bus keeps a weak reference to the core.
+    ///
+    /// - Parameter core: The core ference.
+    func connect(core: DatadogCoreProtocol) {
+        queue.async { self.core = core }
+    }
+
+    /// Connects a receiver with a given key.
+    ///
+    /// - Parameters:
+    ///   - receiver: The message receiver.
+    ///   - key: The key associated with the receiver.
+    func connect(_ receiver: FeatureMessageReceiver, forKey key: String) {
+        queue.async { self.bus[key] = receiver }
+    }
+
+    /// Removes the given key and its associated receiver from the bus.
+    /// 
+    /// - Parameter key: The key to remove along with its associated receiver.
+    func removeReceiver(forKey key: String) {
+        queue.async { self.bus.removeValue(forKey: key) }
+    }
+
+    /// Sends a message to receivers registered in this bus.
+    ///
+    /// If the message could not be processed by any registered feature, the fallback closure
+    /// will be invoked. Do not make any assumption on which thread the fallback is called.
+    ///
+    /// - Parameters:
+    ///   - message: The message.
+    ///   - fallback: The fallback closure to call when the message could not be
+    ///               processed by any Features on the bus.
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void = {}) {
+        if  // Configuration Telemetry Message
+            case .telemetry(let telemetry) = message,
+            case .configuration(let configuration) = telemetry {
+            return save(configuration: configuration)
+        }
+
+        queue.async {
+            guard let core = self.core else {
+                return
+            }
+
+            let receivers = self.bus.values.filter {
+                $0.receive(message: message, from: core)
+            }
+
+            if receivers.isEmpty {
+                fallback()
+            }
+        }
+    }
+
+    /// Saves to current Configuration Telemetry.
+    ///
+    /// The configuration can be partial, the bus supports accumulation of
+    /// configuration for lazy initialization of the SDK.
+    ///
+    /// - Parameter configuration: The SDK configuration.
+    private func save(configuration: ConfigurationTelemetry) {
+        queue.async {
+            // merge with the current configuration if any
+            self.configuration = self.configuration.map {
+                $0.merged(with: configuration)
+            } ?? configuration
+        }
+    }
+}
+
+extension MessageBus: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/DataBlock.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/DataBlock.swift
@@ -1,0 +1,229 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Block size binary type
+internal typealias BlockSize = UInt32
+
+/// Default max data length in block (safety check) - 10 MB
+private let MAX_DATA_LENGTH: UInt64 = 10 * 1_024 * 1_024
+
+/// Block type supported in data stream
+internal enum BlockType: UInt16 {
+    /// Represents an event
+    case event = 0x00
+    /// Represents an event metadata associated with the previous event.
+    /// This block is optional and may be omitted.
+    case eventMetadata = 0x01
+}
+
+/// Reported errors while manipulating data blocks.
+internal enum DataBlockError: Error {
+    case readOperationFailed(streamStatus: Stream.Status, streamError: Error?)
+    case invalidDataType(got: UInt16)
+    case invalidByteSequence(expected: Int, got: Int)
+    case bytesLengthExceedsLimit(limit: UInt64)
+    case dataAllocationFailure
+    case endOfStream
+}
+
+/// A data block in defined by its type and a byte sequence.
+///
+/// A block can be serialized in data stream by following TLV format.
+internal struct DataBlock {
+    /// Type describing the data block.
+    let type: BlockType
+
+    /// The data.
+    var data: Data
+
+    /// Returns a Data block in Type-Length-Value format.
+    ///
+    /// A block follow TLV with bytes aligned such as:
+    ///
+    ///     +-  2 bytes -+-   4 bytes   -+- n bytes -|
+    ///     | block type | data size (n) |    data   |
+    ///     +------------+---------------+-----------+
+    /// - Parameter maxLength: Maximum data length of a block.
+    /// - Returns: a data block in TLV.
+    func serialize(maxLength: UInt64 = MAX_DATA_LENGTH) throws -> Data {
+        var buffer = Data()
+        // T
+        withUnsafeBytes(of: type.rawValue) { buffer.append(contentsOf: $0) }
+        // L
+        guard let length = BlockSize(exactly: data.count), length <= maxLength else {
+            throw DataBlockError.bytesLengthExceedsLimit(limit: maxLength)
+        }
+        withUnsafeBytes(of: length) { buffer.append(contentsOf: $0) }
+        // V
+        buffer += data
+        return buffer
+    }
+}
+
+/// A block reader can read TLV formatted blocks from a data input.
+///
+/// This class provides methods to iteratively retrieve a sequence of
+/// `DataBlock`.
+internal final class DataBlockReader {
+    /// The input data stream.
+    private let stream: InputStream
+
+    /// Maximum data length of a block.
+    private let maxBlockLength: UInt64
+
+    /// Reads block from an input stream.
+    ///
+    /// At initilization, the reader will open the stream, it will be closed
+    /// when the reader instance is deallocated.
+    ///
+    /// - Parameter stream: The input stream
+    init(
+        input stream: InputStream,
+        maxBlockLength: UInt64 = MAX_DATA_LENGTH
+    ) {
+        self.maxBlockLength = maxBlockLength
+        self.stream = stream
+        stream.open()
+    }
+
+    deinit {
+        stream.close()
+    }
+
+    /// Reads the next data block started at current index in data input.
+    ///
+    /// This method returns `nil` when the entire data was traversed but no more
+    /// block could be found.
+    ///
+    /// - Throws: `DataBlockError` while reading the input stream.
+    /// - Returns: The next block or nil if none could be found.
+    func next() throws -> DataBlock? {
+        // look for the next known block
+        while true {
+            do {
+                return try readBlock()
+            } catch DataBlockError.invalidDataType {
+                continue
+            } catch DataBlockError.endOfStream {
+                // Some streams won't return false for hasBytesAvailable until a read is attempted
+                return nil
+            } catch {
+                throw error
+            }
+        }
+    }
+
+    /// Reads all data blocks from current index in the stream.
+    ///
+    /// - Throws: `DataBlockError` while reading the input stream.
+    /// - Returns: The block sequence found in the input
+    func all(maxDataLength: UInt64 = MAX_DATA_LENGTH) throws -> [DataBlock] {
+        var blocks: [DataBlock] = []
+
+        while let block = try next() {
+            blocks.append(block)
+        }
+
+        return blocks
+    }
+
+    /// Reads `length` bytes from stream.
+    ///
+    /// - Parameter length: The number of byte to read
+    /// - Throws: `DataBlockError` while reading the input stream.
+    /// - Returns: Data bytes from stream.
+    private func read(length: Int) throws -> Data {
+        guard length > 0 else {
+            return Data()
+        }
+
+        // Load from stream directly to data without unnecessary copies
+        var data = Data(count: length)
+        let count: Int = try data.withUnsafeMutableBytes {
+            guard let buffer = $0.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                throw DataBlockError.dataAllocationFailure
+            }
+            return stream.read(buffer, maxLength: length)
+        }
+
+        if count < 0 {
+            throw DataBlockError.readOperationFailed(
+                streamStatus: stream.streamStatus,
+                streamError: stream.streamError
+            )
+        }
+
+        if count == 0 {
+            throw DataBlockError.endOfStream
+        }
+
+        guard count == length else {
+            throw DataBlockError.invalidByteSequence(expected: length, got: count)
+        }
+
+        return data
+    }
+
+    /// Reads a block.
+    private func readBlock() throws -> DataBlock {
+        // read an entire block before inferring the data type
+        // to leave the stream in a usuable state if an unkown
+        // type was encountered.
+        let type = try readType()
+        let data = try readData()
+
+        guard let type = BlockType(rawValue: type) else {
+            throw DataBlockError.invalidDataType(got: type)
+        }
+
+        return DataBlock(type: type, data: data)
+    }
+
+    /// Reads a block type.
+    private func readType() throws -> BlockType.RawValue {
+        let data = try read(length: MemoryLayout<BlockType.RawValue>.size)
+        return data.withUnsafeBytes { $0.load(as: BlockType.RawValue.self) }
+    }
+
+    /// Reads block data.
+    private func readData() throws -> Data {
+        let data = try read(length: MemoryLayout<BlockSize>.size)
+        let size = data.withUnsafeBytes { $0.load(as: BlockSize.self) }
+
+        // even if `Int` is able to represent all `BlockSize` on 64 bit
+        // arch, we make sure to avoid overflow and get the exact data
+        // length.
+        // Additionally check that length hasn't been corrupted and
+        // we don't try to generate a huge buffer.
+        guard let length = Int(exactly: size), length <= maxBlockLength else {
+            throw DataBlockError.bytesLengthExceedsLimit(limit: maxBlockLength)
+        }
+
+        return try read(length: length)
+    }
+}
+extension DataBlockError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .readOperationFailed(let status, let error):
+            let error = error.map { "\($0)" } ?? "(null)"
+            return "DataBlock read operation failed with stream status: \(status.rawValue), error: \(error)"
+        case .invalidDataType(let type):
+            return "Invalid DataBlock type: \(type)"
+        case .invalidByteSequence(let expected, let got):
+            return "Invalid bytes sequence in DataBlock: expected \(expected) bytes but got \(got)"
+        case .bytesLengthExceedsLimit(let limit):
+            return "DataBlock length exceeds limit of \(limit) bytes"
+        case .dataAllocationFailure:
+            return "Allocation failure while reading stream"
+        case .endOfStream:
+            return "Reach end of stream while reading data blocks"
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/DataEncryption.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/DataEncryption.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Interface that allows storing data in encrypted format. Encryption/decryption round should
+/// return exactly the same data as it given for the encryption originally (even if decryption
+/// happens in another process/app launch).
+public protocol DataEncryption {
+    /// Encrypts given `Data` with user-chosen encryption.
+    ///
+    /// - Parameter data: Data to encrypt.
+    /// - Returns: The encrypted data.
+    func encrypt(data: Data) throws -> Data
+
+    /// Decrypts given `Data` with user-chosen encryption.
+    ///
+    /// Beware that data to decrypt could be encrypted in a previous app launch, so
+    /// implementation should be aware of the case when decryption could fail (for example,
+    /// key used for encryption is different from key used for decryption, if they are unique
+    /// for every app launch).
+    ///
+    /// - Parameter data: Data to decrypt.
+    /// - Returns: The decrypted data.
+    func decrypt(data: Data) throws -> Data
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Directories.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Directories.swift
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Indicates the main directory for a given instance of the SDK.
+/// Each instance of `DatadogCore` creates its own `CoreDirectory` to manage data for registered Features.
+/// The core directory is created under `/Library/Caches` and uses a name that identifies the certain instance
+/// of the SDK (`<sdk-instance-uuid>`):
+///
+/// ```
+/// /Library/Cache/com.datadoghq/v2/<sdk-instance-uuid>/
+/// ```
+///
+/// Note: System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working
+/// under heavy space pressure. This is intentional for Datadog SDK to have its data purged when system needs more memory
+/// for other apps.
+internal struct CoreDirectory {
+    /// A known OS location the core directory is created within:`/Library/Cache`.
+    let osDirectory: Directory
+    /// The core directory specific to this instance of the SDK: `/Library/Cache/com.datadoghq/v2/<sdk-instance-uuid>`.
+    let coreDirectory: Directory
+
+    /// Obtains subdirectories for managing Feature data (creates if don't exist).
+    ///
+    /// - Parameter name: The given Feature name.
+    /// - Returns: The Feature's directories
+    func getFeatureDirectories(forFeatureNamed name: String) throws -> FeatureDirectories {
+        return FeatureDirectories(
+            unauthorized: try coreDirectory.createSubdirectory(path: "\(name)/intermediate-v2"),
+            authorized: try coreDirectory.createSubdirectory(path: "\(name)/v2")
+        )
+    }
+}
+
+internal extension CoreDirectory {
+    /// Creates the core directory.
+    /// 
+    /// - Parameters:
+    ///   - osDirectory: the root OS directory (`/Library/Caches`) to create core directory inside.
+    ///   - instancenName: The core instance name.
+    ///   - site: The cor instance site.
+    init(in osDirectory: Directory, instancenName: String, site: DatadogSite) throws {
+        let sdkInstanceUUID = sha256("\(instancenName)\(site)")
+        let path = "com.datadoghq/v2/\(sdkInstanceUUID)"
+
+        self.init(
+            osDirectory: osDirectory,
+            coreDirectory: try osDirectory.createSubdirectory(path: path)
+        )
+    }
+}
+
+/// Bundles directories for managing data in single Feature.
+internal struct FeatureDirectories {
+    /// Data directory for storing unauthorized data collected without knowing the tracking consent value.
+    /// Due to the consent change, data in this directory may be either moved to `authorized` folder or entirely deleted.
+    let unauthorized: Directory
+    /// Data directory for storing authorized data collected when tracking consent is granted.
+    /// Consent change does not impact data already stored in this folder.
+    /// Data in this folder gets uploaded to the server.
+    let authorized: Directory
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/EventGenerator.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/EventGenerator.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Event generator that generates events from the given data blocks.
+internal struct EventGenerator: Sequence, IteratorProtocol {
+    private let dataBlocks: [DataBlock]
+    private var index: Int
+
+    init(dataBlocks: [DataBlock], index: Int = 0) {
+        self.dataBlocks = dataBlocks
+        self.index = index
+    }
+
+    /// Returns the next event.
+    ///
+    /// Data format
+    /// ```
+    /// [EVENT 1 METADATA] [EVENT 1] [EVENT 2 METADATA] [EVENT 2] [EVENT 3]
+    /// ```
+    ///
+    /// - Returns: The next event or `nil` if there are no more events.
+    /// - Note: a `DataBlock` with `.event` type marks the beginning of the event.
+    ///         It is either followed by another `DataBlock` with `.event` type or
+    ///         by a `DataBlock` with `.metadata` type.
+    mutating func next() -> Event? {
+        guard index < dataBlocks.count else {
+            return nil
+        }
+
+        var metadata: DataBlock? = nil
+        // If the next block is an event metadata, read it.
+        if dataBlocks[index].type == .eventMetadata {
+            metadata = dataBlocks[index]
+            index += 1
+        }
+
+        // If this is the last block, return nil.
+        // there cannot be a metadata block without an event block.
+        guard index < dataBlocks.count else {
+            return nil
+        }
+
+        // If the next block is an event, read it.
+        guard dataBlocks[index].type == .event else {
+            // this is safeguard against corrupted data.
+            // if there was a metadata block, it will be skipped.
+            return next()
+        }
+        let event = dataBlocks[index]
+        index += 1
+
+        return Event(data: event.data, metadata: metadata?.data)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/FeatureStorage.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/FeatureStorage.swift
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal struct FeatureStorage {
+    /// The name of this Feature, used to distinguish storage instances in telemetry and logs.
+    let featureName: String
+    /// Queue for performing all I/O operations (writes, reads and files management).
+    let queue: DispatchQueue
+    /// Directories for managing data in this Feature.
+    let directories: FeatureDirectories
+    /// Orchestrates files collected in `.granted` consent.
+    let authorizedFilesOrchestrator: FilesOrchestratorType
+    /// Orchestrates files collected in `.pending` consent.
+    let unauthorizedFilesOrchestrator: FilesOrchestratorType
+    /// Encryption algorithm applied to persisted data.
+    let encryption: DataEncryption?
+
+    func writer(for trackingConsent: TrackingConsent, forceNewBatch: Bool) -> Writer {
+        switch trackingConsent {
+        case .granted:
+            return AsyncWriter(
+                execute: FileWriter(orchestrator: authorizedFilesOrchestrator, encryption: encryption, forceNewFile: forceNewBatch),
+                on: queue
+            )
+        case .notGranted:
+            return NOPWriter()
+        case .pending:
+            return AsyncWriter(
+                execute: FileWriter(orchestrator: unauthorizedFilesOrchestrator, encryption: encryption, forceNewFile: forceNewBatch),
+                on: queue
+            )
+        }
+    }
+
+    var reader: Reader {
+        DataReader(
+            readWriteQueue: queue,
+            fileReader: FileReader(
+                orchestrator: authorizedFilesOrchestrator,
+                encryption: encryption
+            )
+        )
+    }
+
+    func migrateUnauthorizedData(toConsent consent: TrackingConsent) {
+        queue.async {
+            do {
+                switch consent {
+                case .notGranted:
+                    try directories.unauthorized.deleteAllFiles()
+                case .granted:
+                    try directories.unauthorized.moveAllFiles(to: directories.authorized)
+                case .pending:
+                    break
+                }
+            } catch {
+                DD.telemetry.error(
+                    "Failed to migrate unauthorized data in \(featureName) after consent change to to \(consent)",
+                    error: error
+                )
+            }
+        }
+    }
+
+    func clearUnauthorizedData() {
+        queue.async {
+            do {
+                try directories.unauthorized.deleteAllFiles()
+            } catch {
+                DD.telemetry.error("Failed clear unauthorized data in \(featureName)", error: error)
+            }
+        }
+    }
+
+    func clearAllData() {
+        queue.async {
+            do {
+                try directories.unauthorized.deleteAllFiles()
+                try directories.authorized.deleteAllFiles()
+            } catch {
+                DD.telemetry.error("Failed clear all data in \(featureName)", error: error)
+            }
+        }
+    }
+
+    func setIgnoreFilesAgeWhenReading(to value: Bool) {
+        queue.sync {
+            authorizedFilesOrchestrator.ignoreFilesAgeWhenReading = value
+            unauthorizedFilesOrchestrator.ignoreFilesAgeWhenReading = value
+        }
+    }
+}
+
+extension FeatureStorage {
+    init(
+        featureName: String,
+        queue: DispatchQueue,
+        directories: FeatureDirectories,
+        dateProvider: DateProvider,
+        performance: PerformancePreset,
+        encryption: DataEncryption?
+    ) {
+        let authorizedFilesOrchestrator = FilesOrchestrator(
+            directory: directories.authorized,
+            performance: performance,
+            dateProvider: dateProvider,
+            metricsData: {
+                guard let trackName = BatchMetric.trackValue(for: featureName) else {
+                    DD.logger.error("Can't determine track name for feature named '\(featureName)'")
+                    return nil
+                }
+                return FilesOrchestrator.MetricsData(trackName: trackName, uploaderPerformance: performance)
+            }()
+        )
+        let unauthorizedFilesOrchestrator = FilesOrchestrator(
+            directory: directories.unauthorized,
+            performance: performance,
+            dateProvider: dateProvider,
+            metricsData: nil // do not send metrics for unauthorized orchestrator
+        )
+
+        self.init(
+            featureName: featureName,
+            queue: queue,
+            directories: directories,
+            authorizedFilesOrchestrator: authorizedFilesOrchestrator,
+            unauthorizedFilesOrchestrator: unauthorizedFilesOrchestrator,
+            encryption: encryption
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Files/Directory.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Files/Directory.swift
@@ -1,0 +1,117 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// An abstraction over file system directory where SDK stores its files.
+internal struct Directory {
+    let url: URL
+
+    /// Creates subdirectory with given path under system caches directory.
+    /// RUMM-2169: Use `Directory.cache().createSubdirectory(path:)` instead.
+    init(withSubdirectoryPath path: String) throws {
+        self.init(url: try Directory.cache().createSubdirectory(path: path).url)
+    }
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    /// Creates subdirectory with given path by creating intermediate directories if needed.
+    /// If directory already exists at given `path` it will be used, without being altered.
+    func createSubdirectory(path: String) throws -> Directory {
+        let subdirectoryURL = url.appendingPathComponent(path, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: subdirectoryURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            throw InternalError(description: "Cannot create subdirectory in `/Library/Caches/` folder.")
+        }
+        return Directory(url: subdirectoryURL)
+    }
+
+    /// Returns directory at given path or throws if it doesn't exist or given `path` is not a directory.
+    func subdirectory(path: String) throws -> Directory {
+        let directoryURL = url.appendingPathComponent(path, isDirectory: true)
+        var isDirectory = ObjCBool(false)
+        let exists = FileManager.default.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory)
+
+        if exists && isDirectory.boolValue {
+            return Directory(url: directoryURL)
+        } else {
+            throw InternalError(description: "Path doesn't exist or is not a directory: \(directoryURL)")
+        }
+    }
+
+    /// Creates file with given name.
+    func createFile(named fileName: String) throws -> File {
+        let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
+        guard FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil) == true else {
+            throw InternalError(description: "Cannot create file at path: \(fileURL.path)")
+        }
+        return File(url: fileURL)
+    }
+
+    /// Checks if a file with given `fileName` exists in this directory.
+    func hasFile(named fileName: String) -> Bool {
+        let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
+        return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    /// Returns file with given name or throws an error if file does not exist.
+    func file(named fileName: String) throws -> File {
+        let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
+        guard hasFile(named: fileName) else {
+            throw InternalError(description: "File does not exist at path: \(fileURL.path)")
+        }
+        return File(url: fileURL)
+    }
+
+    /// Returns all files of this directory.
+    func files() throws -> [File] {
+        return try FileManager.default
+            .contentsOfDirectory(at: url, includingPropertiesForKeys: [.isRegularFileKey, .canonicalPathKey])
+            .map { url in File(url: url) }
+    }
+
+    /// Deletes all files in this directory.
+    func deleteAllFiles() throws {
+        // Instead of iterating over all files and removing them one by one, we create a temporary
+        // empty directory and replace source directory content with (empty) temporary folder.
+        // This makes the deletion atomic, and is more performant in benchmarks.
+        let temporaryDirectory = try Directory(withSubdirectoryPath: "com.datadoghq/\(UUID().uuidString)")
+        try retry(times: 3, delay: 0.001) {
+            _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryDirectory.url)
+        }
+        if FileManager.default.fileExists(atPath: temporaryDirectory.url.path) {
+            try FileManager.default.removeItem(at: temporaryDirectory.url)
+        }
+    }
+
+    /// Moves all files from this directory to `destinationDirectory`.
+    func moveAllFiles(to destinationDirectory: Directory) throws {
+        try retry(times: 3, delay: 0.001) {
+            try files().forEach { file in
+                let destinationFileURL = destinationDirectory.url.appendingPathComponent(file.name)
+                try? retry(times: 3, delay: 0.0001) {
+                    try FileManager.default.moveItem(at: file.url, to: destinationFileURL)
+                }
+            }
+        }
+    }
+}
+
+extension Directory {
+    /// Returns `Directory` pointing to `/Library/Caches`.
+    /// - `/Library/Caches` is exclduded from iTunes and iCloud backups by default.
+    /// - System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working under heavy space pressure.
+    static func cache() throws -> Directory {
+        guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw InternalError(description: "Cannot obtain `/Library/Caches/` url.")
+        }
+        return Directory(url: cachesDirectoryURL)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Files/File.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Files/File.swift
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if SPM_BUILD
+import DatadogPrivateFork
+#endif
+
+/// Provides convenient interface for reading metadata and appending data to the file.
+internal protocol WritableFile {
+    /// Name of this file.
+    var name: String { get }
+
+    /// Current size of this file.
+    func size() throws -> UInt64
+
+    /// Synchronously appends given data at the end of this file.
+    func append(data: Data) throws
+}
+
+/// Provides convenient interface for reading contents and metadata of the file.
+internal protocol ReadableFile {
+    /// Name of this file.
+    var name: String { get }
+
+    /// Creates InputStream for reading the available data from this file.
+    func stream() throws -> InputStream
+
+    /// Deletes this file.
+    func delete() throws
+}
+
+private enum FileError: Error {
+    case unableToCreateInputStream
+}
+
+/// An immutable `struct` designed to provide optimized and thread safe interface for file manipulation.
+/// It doesn't own the file, which means the file presence is not guaranteed - the file can be deleted by OS at any time (e.g. due to memory pressure).
+internal struct File: WritableFile, ReadableFile {
+    let url: URL
+    let name: String
+
+    init(url: URL) {
+        self.url = url
+        self.name = url.lastPathComponent
+    }
+
+    /// Appends given data at the end of this file.
+    func append(data: Data) throws {
+        let fileHandle = try FileHandle(forWritingTo: url)
+
+        // NOTE: RUMM-669
+        // https://github.com/DataDog/dd-sdk-ios/issues/214
+        // https://en.wikipedia.org/wiki/Xcode#11.x_series
+        // compiler version needs to have iOS 13.4+ as base SDK
+        #if compiler(>=5.2)
+        /**
+         Even though the `fileHandle.seekToEnd()` should be available since iOS 13.0:
+         ```
+         @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+         public func seekToEnd() throws -> UInt64
+         ```
+         it crashes on iOS Simulators prior to iOS 13.4:
+         ```
+         Symbol not found: _$sSo12NSFileHandleC10FoundationE9seekToEnds6UInt64VyKF
+         ```
+         This is fixed in iOS 14/Xcode 12
+        */
+        if #available(iOS 13.4, tvOS 13.4, *) {
+            defer { try? fileHandle.close() }
+            try fileHandle.seekToEnd()
+            try fileHandle.write(contentsOf: data)
+        } else {
+            try legacyAppend(data, to: fileHandle)
+        }
+        #else
+        try legacyAppend(data, to: fileHandle)
+        #endif
+    }
+
+    private func legacyAppend(_ data: Data, to fileHandle: FileHandle) throws {
+        defer {
+            try? objcExceptionHandler.rethrowToSwift {
+                fileHandle.closeFile()
+            }
+        }
+        try objcExceptionHandler.rethrowToSwift {
+            fileHandle.seekToEndOfFile()
+            fileHandle.write(data)
+        }
+    }
+
+    func stream() throws -> InputStream {
+        guard let stream = InputStream(url: url) else {
+            throw FileError.unableToCreateInputStream
+        }
+        return stream
+    }
+
+    func size() throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return attributes[.size] as? UInt64 ?? 0
+    }
+
+    func delete() throws {
+        try FileManager.default.removeItem(at: url)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/FilesOrchestrator.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/FilesOrchestrator.swift
@@ -1,0 +1,299 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal protocol FilesOrchestratorType: AnyObject {
+    var performance: StoragePerformancePreset { get }
+
+    func getNewWritableFile(writeSize: UInt64) throws -> WritableFile
+    func getWritableFile(writeSize: UInt64) throws -> WritableFile
+    func getReadableFile(excludingFilesNamed excludedFileNames: Set<String>) -> ReadableFile?
+    func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason)
+
+    var ignoreFilesAgeWhenReading: Bool { get set }
+}
+
+/// Orchestrates files in a single directory.
+internal class FilesOrchestrator: FilesOrchestratorType {
+    /// Directory where files are stored.
+    let directory: Directory
+    /// Date provider.
+    let dateProvider: DateProvider
+    /// Performance rules for writing and reading files.
+    let performance: StoragePerformancePreset
+
+    /// Name of the last file returned by `getWritableFile()`.
+    private var lastWritableFileName: String? = nil
+    /// Tracks number of times the last file was returned from `getWritableFile(writeSize:)`.
+    /// This should correspond with number of objects stored in file, assuming that majority of writes succeed (the difference is negligible).
+    private var lastWritableFileObjectsCount: UInt64 = 0
+    /// Tracks the size of last writable file by accumulating the total `writeSize:` requested in `getWritableFile(writeSize:)`
+    /// This is approximated value as it assumes that all requested writes succed. The actual difference should be negligible.
+    private var lastWritableFileApproximatedSize: UInt64 = 0
+
+    /// Extra information for metrics set from this orchestrator.
+    struct MetricsData {
+        /// The name of the track reported for this orchestrator.
+        let trackName: String
+        /// The preset for uploader performance in this feature to include in metric.
+        let uploaderPerformance: UploadPerformancePreset
+    }
+
+    /// An extra information to include in metrics or `nil` if metrics should not be reported for this orchestrator.
+    let metricsData: MetricsData?
+
+    init(
+        directory: Directory,
+        performance: StoragePerformancePreset,
+        dateProvider: DateProvider,
+        metricsData: MetricsData? = nil
+    ) {
+        self.directory = directory
+        self.performance = performance
+        self.dateProvider = dateProvider
+        self.metricsData = metricsData
+    }
+
+    // MARK: - `WritableFile` orchestration
+
+    /// Creates and returns new writable file by ignoring the heuristic of reusing files.
+    ///
+    /// Note: the `getWritableFile(writeSize:)` should be preferred, unless the caller has specific reason for
+    /// enforcing new files to be created (e.g. batching is managed in upstream state).
+    ///
+    /// - Parameter writeSize: the size of data to be written
+    /// - Returns: `WritableFile` capable of writing data of given size
+    func getNewWritableFile(writeSize: UInt64) throws -> WritableFile {
+        try validate(writeSize: writeSize)
+        if let closedBatchName = lastWritableFileName {
+            sendBatchClosedMetric(fileName: closedBatchName, forcedNew: true)
+        }
+        return try createNewWritableFile(writeSize: writeSize)
+    }
+
+    /// Returns writable file accordingly to default heuristic of creating and reusing files.
+    ///
+    /// - Parameter writeSize: the size of data to be written
+    /// - Returns: `WritableFile` capable of writing data of given size
+    func getWritableFile(writeSize: UInt64) throws -> WritableFile {
+        try validate(writeSize: writeSize)
+
+        if let lastWritableFile = reuseLastWritableFileIfPossible(writeSize: writeSize) { // if last writable file can be reused
+            lastWritableFileObjectsCount += 1
+            lastWritableFileApproximatedSize += writeSize
+            return lastWritableFile
+        } else {
+            if let closedBatchName = lastWritableFileName {
+                sendBatchClosedMetric(fileName: closedBatchName, forcedNew: false)
+            }
+            return try createNewWritableFile(writeSize: writeSize)
+        }
+    }
+
+    private func validate(writeSize: UInt64) throws {
+        guard writeSize <= performance.maxObjectSize else {
+            throw InternalError(description: "data exceeds the maximum size of \(performance.maxObjectSize) bytes.")
+        }
+    }
+
+    private func createNewWritableFile(writeSize: UInt64) throws -> WritableFile {
+        // NOTE: RUMM-610 Because purging files directory is a memory-expensive operation, do it only when a new file
+        // is created (we assume here that this won't happen too often). In details, this is to avoid over-allocating
+        // internal `_FileCache` and `_NSFastEnumerationEnumerator` objects in downstream `FileManager` routines.
+        // This optimisation results with flat allocation graph in a long term (vs endlessly growing if purging
+        // happens too often).
+        try purgeFilesDirectoryIfNeeded()
+
+        let newFileName = fileNameFrom(fileCreationDate: dateProvider.now)
+        let newFile = try directory.createFile(named: newFileName)
+        lastWritableFileName = newFile.name
+        lastWritableFileObjectsCount = 1
+        lastWritableFileApproximatedSize = writeSize
+        return newFile
+    }
+
+    private func reuseLastWritableFileIfPossible(writeSize: UInt64) -> WritableFile? {
+        if let lastFileName = lastWritableFileName {
+            if !directory.hasFile(named: lastFileName) {
+                return nil // this is expected if the last writable file was deleted
+            }
+
+            do {
+                let lastFile = try directory.file(named: lastFileName)
+                let lastFileCreationDate = fileCreationDateFrom(fileName: lastFile.name)
+                let lastFileAge = dateProvider.now.timeIntervalSince(lastFileCreationDate)
+
+                let fileIsRecentEnough = lastFileAge <= performance.maxFileAgeForWrite
+                let fileHasRoomForMore = (try lastFile.size() + writeSize) <= performance.maxFileSize
+                let fileCanBeUsedMoreTimes = (lastWritableFileObjectsCount + 1) <= performance.maxObjectsInFile
+
+                if fileIsRecentEnough && fileHasRoomForMore && fileCanBeUsedMoreTimes {
+                    return lastFile
+                }
+            } catch {
+                DD.telemetry.error("Failed to reuse last writable file", error: error)
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - `ReadableFile` orchestration
+
+    func getReadableFile(excludingFilesNamed excludedFileNames: Set<String> = []) -> ReadableFile? {
+        do {
+            let filesWithCreationDate = try directory.files()
+                .map { (file: $0, creationDate: fileCreationDateFrom(fileName: $0.name)) }
+                .compactMap { try deleteFileIfItsObsolete(file: $0.file, fileCreationDate: $0.creationDate) }
+
+            guard let (oldestFile, creationDate) = filesWithCreationDate
+                .filter({ excludedFileNames.contains($0.file.name) == false })
+                .sorted(by: { $0.creationDate < $1.creationDate })
+                .first
+            else {
+                return nil
+            }
+
+            #if DD_SDK_COMPILED_FOR_TESTING
+            if ignoreFilesAgeWhenReading {
+                return oldestFile
+            }
+            #endif
+
+            let oldestFileAge = dateProvider.now.timeIntervalSince(creationDate)
+            let fileIsOldEnough = oldestFileAge >= performance.minFileAgeForRead
+
+            return fileIsOldEnough ? oldestFile : nil
+        } catch {
+            DD.telemetry.error("Failed to obtain readable file", error: error)
+            return nil
+        }
+    }
+
+    func delete(readableFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) {
+        do {
+            try readableFile.delete()
+            sendBatchDeletedMetric(batchFile: readableFile, deletionReason: deletionReason)
+        } catch {
+            DD.telemetry.error("Failed to delete file", error: error)
+        }
+    }
+
+    /// If files age should be ignored for obtaining `ReadableFile`.
+    internal var ignoreFilesAgeWhenReading = false
+
+    // MARK: - Directory size management
+
+    /// Removes oldest files from the directory if it becomes too big.
+    private func purgeFilesDirectoryIfNeeded() throws {
+        let filesSortedByCreationDate = try directory.files()
+            .map { (file: $0, creationDate: fileCreationDateFrom(fileName: $0.name)) }
+            .sorted { $0.creationDate < $1.creationDate }
+
+        var filesWithSizeSortedByCreationDate = try filesSortedByCreationDate
+            .map { (file: $0.file, size: try $0.file.size()) }
+
+        let accumulatedFilesSize = filesWithSizeSortedByCreationDate.map { $0.size }.reduce(0, +)
+
+        if accumulatedFilesSize > performance.maxDirectorySize {
+            let sizeToFree = accumulatedFilesSize - performance.maxDirectorySize
+            var sizeFreed: UInt64 = 0
+
+            while sizeFreed < sizeToFree && !filesWithSizeSortedByCreationDate.isEmpty {
+                let fileWithSize = filesWithSizeSortedByCreationDate.removeFirst()
+                try fileWithSize.file.delete()
+                sendBatchDeletedMetric(batchFile: fileWithSize.file, deletionReason: .purged)
+                sizeFreed += fileWithSize.size
+            }
+        }
+    }
+
+    private func deleteFileIfItsObsolete(file: File, fileCreationDate: Date) throws -> (file: File, creationDate: Date)? {
+        let fileAge = dateProvider.now.timeIntervalSince(fileCreationDate)
+
+        if fileAge > performance.maxFileAgeForRead {
+            try file.delete()
+            sendBatchDeletedMetric(batchFile: file, deletionReason: .obsolete)
+            return nil
+        } else {
+            return (file: file, creationDate: fileCreationDate)
+        }
+    }
+
+    // MARK: - Metrics
+
+    /// Sends "Batch Deleted" telemetry log.
+    /// - Parameters:
+    ///   - batchFile: The batch file that was deleted.
+    ///   - deletionReason: The reason of deleting this file.
+    ///
+    /// Note: The `batchFile` doesn't exist at this point.
+    private func sendBatchDeletedMetric(batchFile: ReadableFile, deletionReason: BatchDeletedMetric.RemovalReason) {
+        guard let metricsData = metricsData, deletionReason.includeInMetric else {
+            return // do not track metrics for this orchestrator or deletion reason
+        }
+
+        let batchAge = dateProvider.now.timeIntervalSince(fileCreationDateFrom(fileName: batchFile.name))
+
+        DD.telemetry.metric(
+            name: BatchDeletedMetric.name,
+            attributes: [
+                BatchMetric.typeKey: BatchDeletedMetric.typeValue,
+                BatchMetric.trackKey: metricsData.trackName,
+                BatchDeletedMetric.uploaderDelayKey: [
+                    BatchDeletedMetric.uploaderDelayMinKey: metricsData.uploaderPerformance.minUploadDelay.toMilliseconds,
+                    BatchDeletedMetric.uploaderDelayMaxKey: metricsData.uploaderPerformance.maxUploadDelay.toMilliseconds,
+                ],
+                BatchDeletedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
+                BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
+                BatchDeletedMetric.batchRemovalReasonKey: deletionReason.toString(),
+                BatchDeletedMetric.inBackgroundKey: false,
+            ]
+        )
+    }
+
+    /// Sends "Batch Closed" telemetry log.
+    /// - Parameters:
+    ///   - fileName: The name of the batch that was closed.
+    ///   - forcedNew: If the batch was closed due to default heuristic or because a new batch was forced by feature.
+    private func sendBatchClosedMetric(fileName: String, forcedNew: Bool) {
+        guard let metricsData = metricsData else {
+            return // do not track metrics for this orchestrator
+        }
+
+        let batchDuration = dateProvider.now.timeIntervalSince(fileCreationDateFrom(fileName: fileName))
+
+        DD.telemetry.metric(
+            name: BatchClosedMetric.name,
+            attributes: [
+                BatchMetric.typeKey: BatchClosedMetric.typeValue,
+                BatchMetric.trackKey: metricsData.trackName,
+                BatchClosedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
+                BatchClosedMetric.batchSizeKey: lastWritableFileApproximatedSize,
+                BatchClosedMetric.batchEventsCountKey: lastWritableFileObjectsCount,
+                BatchClosedMetric.batchDurationKey: batchDuration.toMilliseconds,
+                BatchClosedMetric.forcedNewKey: forcedNew
+            ]
+        )
+    }
+}
+
+/// File creation date is used as file name - timestamp in milliseconds is used for date representation.
+/// This function converts file creation date into file name.
+internal func fileNameFrom(fileCreationDate: Date) -> String {
+    let milliseconds = fileCreationDate.timeIntervalSinceReferenceDate * 1_000
+    let converted = (try? UInt64(withReportingOverflow: milliseconds)) ?? 0
+    return String(converted)
+}
+
+/// File creation date is used as file name - timestamp in milliseconds is used for date representation.
+/// This function converts file name into file creation date.
+internal func fileCreationDateFrom(fileName: String) -> Date {
+    let millisecondsSinceReferenceDate = TimeInterval(UInt64(fileName) ?? 0) / 1_000
+    return Date(timeIntervalSinceReferenceDate: TimeInterval(millisecondsSinceReferenceDate))
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/DataReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/DataReader.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Synchronizes the work of `FileReader` on given read/write queue.
+internal final class DataReader: Reader {
+    /// Queue used to synchronize reads and writes for the feature.
+    internal let queue: DispatchQueue
+    private let fileReader: Reader
+
+    init(readWriteQueue: DispatchQueue, fileReader: Reader) {
+        self.queue = readWriteQueue
+        self.fileReader = fileReader
+    }
+
+    func readNextBatch() -> Batch? {
+        queue.sync {
+            self.fileReader.readNextBatch()
+        }
+    }
+
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {
+        queue.sync {
+            self.fileReader.markBatchAsRead(batch, reason: reason)
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/FileReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/FileReader.swift
@@ -1,0 +1,97 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Reads data from files.
+internal final class FileReader: Reader {
+    /// Orchestrator producing reference to readable file.
+    private let orchestrator: FilesOrchestratorType
+    private let encryption: DataEncryption?
+
+    /// Files marked as read.
+    private var filesRead: Set<String> = []
+
+    init(
+        orchestrator: FilesOrchestratorType,
+        encryption: DataEncryption? = nil
+    ) {
+        self.orchestrator = orchestrator
+        self.encryption = encryption
+    }
+
+    // MARK: - Reading batches
+
+    func readNextBatch() -> Batch? {
+        guard let file = orchestrator.getReadableFile(excludingFilesNamed: filesRead) else {
+            return nil
+        }
+
+        do {
+            let dataBlocks = try decode(stream: file.stream())
+            return Batch(dataBlocks: dataBlocks, file: file)
+        } catch {
+            DD.telemetry.error("Failed to read data from file", error: error)
+            return nil
+        }
+    }
+
+    /// Decodes input data
+    ///
+    /// The input data is expected to be a stream of `DataBlock`. Only block of type `event` are
+    /// consumed and decrypted if encryption is available. Decrypted events are finally joined with
+    /// data-format separator.
+    ///
+    /// - Parameter stream: The InputStream that provides data to decode.
+    /// - Returns: The decoded and formatted data.
+    private func decode(stream: InputStream) throws -> [DataBlock] {
+        let reader = DataBlockReader(
+            input: stream,
+            maxBlockLength: orchestrator.performance.maxObjectSize
+        )
+
+        var failure: String? = nil
+        defer {
+            failure.map { DD.logger.error($0) }
+        }
+
+        return try reader.all()
+            .compactMap { dataBlock in
+                do {
+                    return try decrypt(dataBlock: dataBlock)
+                } catch {
+                    failure = "🔥 Failed to decrypt data with error: \(error)"
+                    return nil
+                }
+            }
+    }
+
+    private func decrypt(dataBlock: DataBlock) throws -> DataBlock {
+        let decrypted = try decrypt(data: dataBlock.data)
+        return DataBlock(type: dataBlock.type, data: decrypted)
+    }
+
+    /// Decrypts data if encryption is available.
+    ///
+    /// If no encryption, the data is returned.
+    ///
+    /// - Parameter data: The data to decrypt.
+    /// - Returns: Decrypted data.
+    private func decrypt(data: Data) throws -> Data {
+        guard let encryption = encryption else {
+            return data
+        }
+
+        return try encryption.decrypt(data: data)
+    }
+
+    // MARK: - Accepting batches
+
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason) {
+        orchestrator.delete(readableFile: batch.file, deletionReason: reason)
+        filesRead.insert(batch.file.name)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/Reader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Reading/Reader.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal struct Batch {
+    /// Data blocks in the batch.
+    let dataBlocks: [DataBlock]
+    /// File from which `data` was read.
+    let file: ReadableFile
+}
+
+extension Batch {
+    /// Events contained in the batch.
+    var events: [Event] {
+        let generator = EventGenerator(dataBlocks: dataBlocks)
+        return generator.map { $0 }
+    }
+}
+
+/// A type, reading batched data.
+internal protocol Reader {
+    func readNextBatch() -> Batch?
+    func markBatchAsRead(_ batch: Batch, reason: BatchDeletedMetric.RemovalReason)
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Writing/AsyncWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Writing/AsyncWriter.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Writer performing writes asynchronously on a given queue.
+internal struct AsyncWriter: Writer {
+    private let writer: Writer
+    private let queue: DispatchQueue
+
+    init(execute otherWriter: Writer, on queue: DispatchQueue) {
+        self.writer = otherWriter
+        self.queue = queue
+    }
+
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+        queue.async { writer.write(value: value, metadata: metadata) }
+    }
+}
+
+internal struct NOPWriter: Writer {
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Writing/FileWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Storage/Writing/FileWriter.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// JSON encoder used to encode data.
+private let jsonEncoder: JSONEncoder = .dd.default()
+
+/// Writes data to files.
+internal struct FileWriter: Writer {
+    /// Orchestrator producing reference to writable file.
+    let orchestrator: FilesOrchestratorType
+    /// Algorithm to encrypt written data.
+    let encryption: DataEncryption?
+    /// If this writer should force creation of a new file for writing events.
+    let forceNewFile: Bool
+
+    // MARK: - Writing data
+
+    /// Encodes given encodable value and metadata, and writes it to the file.
+    /// If encryption is available, the data is encrypted before writing.
+    /// - Parameters:
+    ///  - value: Encodable value to write.
+    ///  - metadata: Encodable metadata to write.
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?) {
+        do {
+            var encoded: Data = .init()
+            if let metadata = metadata {
+                let encodedMetadata = try encode(value: metadata, blockType: .eventMetadata)
+                encoded.append(encodedMetadata)
+            }
+
+            let encodedValue = try encode(value: value, blockType: .event)
+            encoded.append(encodedValue)
+
+            // Make sure both event and event metadata are written to the same file.
+            // This is to avoid a situation where event is written to one file and event metadata to another.
+            // If this happens, the reader will not be able to match event with its metadata.
+            let writeSize = UInt64(encoded.count)
+            let file = try forceNewFile ? orchestrator.getNewWritableFile(writeSize: writeSize) : orchestrator.getWritableFile(writeSize: writeSize)
+            try file.append(data: encoded)
+        } catch {
+            DD.logger.error("Failed to write data", error: error)
+            DD.telemetry.error("Failed to write data to file", error: error)
+        }
+    }
+
+    /// Encodes the given encodable value and encrypt it if encryption is available.
+    ///
+    /// The returned data format:
+    ///
+    ///     +- 2 bytes -+-  4 bytes -+- n bytes  -|
+    ///     |    0x00   | block size | block data |
+    ///     +-----------+------------+------------+
+    ///
+    /// Where the 2 first bytes represents the `block type` of
+    /// an event.
+    ///
+    /// - Parameter event: The value to encode.
+    /// - Returns: Data representation of the value.
+    private func encode<T: Encodable>(value: T, blockType: BlockType) throws -> Data {
+        let data = try jsonEncoder.encode(value)
+        return try DataBlock(
+            type: blockType,
+            data: encrypt(data: data)
+        ).serialize(
+            maxLength: orchestrator.performance.maxObjectSize
+        )
+    }
+
+    /// Encrypts data if encryption is available.
+    ///
+    /// If no encryption, the data is returned.
+    ///
+    /// - Parameter data: The data to encrypt.
+    /// - Returns: Encrypted data.
+    private func encrypt(data: Data) throws -> Data {
+        guard let encryption = encryption else {
+            return data
+        }
+
+        return try encryption.encrypt(data: data)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadConditions.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadConditions.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Tells if data upload can be performed based on given system conditions.
+internal struct DataUploadConditions {
+    enum Blocker {
+        case battery(level: Int, state: BatteryStatus.State)
+        case lowPowerModeOn
+        case networkReachability(description: String)
+    }
+
+    struct Constants {
+        /// Battery level above which data upload can be performed.
+        static let minBatteryLevel: Float = 0.1
+    }
+
+    /// Battery level above which data upload can be performed.
+    let minBatteryLevel: Float
+
+    init(minBatteryLevel: Float = Constants.minBatteryLevel) {
+        self.minBatteryLevel = minBatteryLevel
+    }
+
+    func blockersForUpload(with context: DatadogContext) -> [Blocker] {
+        guard let reachability = context.networkConnectionInfo?.reachability else {
+            // when `NetworkConnectionInfo` is not yet available
+            return [.networkReachability(description: "unknown")]
+        }
+        let networkIsReachable = reachability == .yes || reachability == .maybe
+        var blockers: [Blocker] = networkIsReachable ? [] : [.networkReachability(description: reachability.rawValue)]
+
+        guard let battery = context.batteryStatus, battery.state != .unknown else {
+            // Note: in RUMS-132 we got the report on `.unknown` battery state reporing `-1` battery level on iPad device
+            // plugged to Mac through lightning cable. As `.unkown` may lead to other unreliable values,
+            // it seems safer to arbitrary allow uploads in such case.
+            return blockers
+        }
+
+        let batteryFullOrCharging = battery.state == .full || battery.state == .charging
+        let batteryLevelIsEnough = battery.level > minBatteryLevel
+
+        if !(batteryFullOrCharging || batteryLevelIsEnough) {
+            blockers.append(
+                .battery(
+                    level: Int(battery.level * 100),
+                    state: battery.state
+                )
+            )
+        }
+
+        if context.isLowPowerModeEnabled {
+            blockers.append(.lowPowerModeOn)
+        }
+
+        return blockers
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadDelay.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadDelay.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal protocol Delay {
+    var current: TimeInterval { get }
+    mutating func decrease()
+    mutating func increase()
+}
+
+/// Mutable interval used for periodic data uploads.
+internal struct DataUploadDelay: Delay {
+    private let minDelay: TimeInterval
+    private let maxDelay: TimeInterval
+    private let changeRate: Double
+    private var delay: TimeInterval
+
+    init(performance: UploadPerformancePreset) {
+        self.minDelay = performance.minUploadDelay
+        self.maxDelay = performance.maxUploadDelay
+        self.changeRate = performance.uploadDelayChangeRate
+        self.delay = performance.initialUploadDelay
+    }
+
+    var current: TimeInterval { delay }
+
+    mutating func decrease() {
+        delay = max(minDelay, delay * (1.0 - changeRate))
+    }
+
+    mutating func increase() {
+        delay = min(delay * (1.0 + changeRate), maxDelay)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadStatus.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadStatus.swift
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+private enum HTTPResponseStatusCode: Int {
+    /// The request has been accepted for processing.
+    case accepted = 202
+    /// The server cannot or will not process the request (client error).
+    case badRequest = 400
+    /// The request lacks valid authentication credentials.
+    case unauthorized = 401
+    /// The server understood the request but refuses to authorize it.
+    case forbidden = 403
+    /// The server would like to shut down the connection.
+    case requestTimeout = 408
+    /// The request entity is larger than limits defined by server.
+    case payloadTooLarge = 413
+    /// The client has sent too many requests in a given amount of time.
+    case tooManyRequests = 429
+    /// The server encountered an unexpected condition.
+    case internalServerError = 500
+    /// The server is not ready to handle the request probably because it is overloaded.
+    case serviceUnavailable = 503
+    /// An unexpected status code.
+    case unexpected = -999
+
+    /// If it makes sense to retry the upload finished with this status code, e.g. if data upload failed due to `503` HTTP error, we should retry it later.
+    var needsRetry: Bool {
+        switch self {
+        case .accepted, .badRequest, .unauthorized, .forbidden, .payloadTooLarge:
+            // No retry - it's either success or a client error which won't be fixed in next upload.
+            return false
+        case .requestTimeout, .tooManyRequests, .internalServerError, .serviceUnavailable:
+            // Retry - it's a temporary server or connection issue that might disappear on next attempt.
+            return true
+        case .unexpected:
+            // This shouldn't happen, but if receiving an unexpected status code we do not retry.
+            // This is safer than retrying as we don't know if the issue is coming from the client or server.
+            return false
+        }
+    }
+}
+
+/// The status of a single upload attempt.
+internal struct DataUploadStatus {
+    /// If upload needs to be retried (`true`) because its associated data was not delivered but it may succeed
+    /// in the next attempt (i.e. it failed due to device leaving signal range or a temporary server unavailability occured).
+    /// If set to `false` then data associated with the upload should be deleted as it does not need any more upload
+    /// attempts (i.e. the upload succeeded or failed due to unrecoverable client error).
+    let needsRetry: Bool
+
+    // MARK: - Debug Info
+
+    /// The actual HTTP status code received in response (`nil` if transport error).
+    let responseCode: Int?
+
+    /// Upload status description printed to the console if SDK `.debug` verbosity is enabled.
+    let userDebugDescription: String
+
+    let error: DataUploadError?
+}
+
+extension DataUploadStatus {
+    // MARK: - Initialization
+
+    init(httpResponse: HTTPURLResponse, ddRequestID: String?) {
+        let statusCode = HTTPResponseStatusCode(rawValue: httpResponse.statusCode) ?? .unexpected
+
+        self.init(
+            needsRetry: statusCode.needsRetry,
+            responseCode: httpResponse.statusCode,
+            userDebugDescription: "[response code: \(httpResponse.statusCode) (\(statusCode)), request ID: \(ddRequestID ?? "(???)")]",
+            error: DataUploadError(status: httpResponse.statusCode)
+        )
+    }
+
+    init(networkError: Error) {
+        self.init(
+            needsRetry: true, // retry this upload as it failed due to network transport isse
+            responseCode: nil,
+            userDebugDescription: "[error: \(DDError(error: networkError).message)]", // e.g. "[error: A data connection is not currently allowed]"
+            error: DataUploadError(networkError: networkError)
+        )
+    }
+}
+
+// MARK: - Data Upload Errors
+
+internal enum DataUploadError: Error, Equatable {
+    case unauthorized
+    case httpError(statusCode: Int)
+    case networkError(error: NSError)
+}
+
+/// A list of known NSURLError codes which should not produce error in Telemetry.
+/// Receiving these codes doesn't mean SDK issue, but the network transportation scenario where the connection interrupted due to external factors.
+/// These list should evolve and we may want to add more codes in there.
+///
+/// Ref.: https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes
+private let ignoredNSURLErrorCodes = Set([
+    NSURLErrorNetworkConnectionLost, // -1005
+    NSURLErrorTimedOut, // -1001
+    NSURLErrorCannotParseResponse, // - 1017
+    NSURLErrorNotConnectedToInternet, // -1009
+    NSURLErrorCannotFindHost, // -1003
+    NSURLErrorSecureConnectionFailed, // -1200
+    NSURLErrorDataNotAllowed, // -1020
+    NSURLErrorCannotConnectToHost, // -1004
+])
+
+extension DataUploadError {
+    init?(status code: Int) {
+        guard let responseStatusCode = HTTPResponseStatusCode(rawValue: code) else {
+            // If status code is unexpected, do not produce an error for internal Telemetry - otherwise monitoring may
+            // become too verbose for old installations if we introduce a new status code in the API.
+            return nil
+        }
+
+        switch responseStatusCode {
+        case .accepted:
+            return nil
+        case .unauthorized, .forbidden:
+            self = .unauthorized
+        case .internalServerError, .serviceUnavailable:
+            // These codes mean Datadog service issue - do not produce SDK error as this is already monitored by other means.
+            return nil
+        case .badRequest, .payloadTooLarge, .tooManyRequests, .requestTimeout:
+            // These codes mean that something wrong is happening either in the SDK or on the server - produce an error.
+            self = .httpError(statusCode: code)
+        case .unexpected:
+            return nil
+        }
+    }
+
+    init?(networkError: Error) {
+        let nsError = networkError as NSError
+        guard nsError.domain == NSURLErrorDomain, !ignoredNSURLErrorCodes.contains(nsError.code) else {
+            return nil
+        }
+
+        self = .networkError(error: nsError)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadWorker.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploadWorker.swift
@@ -1,0 +1,178 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Abstracts the `DataUploadWorker`, so we can have no-op uploader in tests.
+internal protocol DataUploadWorkerType {
+    func flushSynchronously()
+    func cancelSynchronously()
+}
+
+internal class DataUploadWorker: DataUploadWorkerType {
+    /// Queue to execute uploads.
+    private let queue: DispatchQueue
+    /// File reader providing data to upload.
+    private let fileReader: Reader
+    /// Data uploader sending data to server.
+    private let dataUploader: DataUploaderType
+    /// Variable system conditions determining if upload should be performed.
+    private let uploadConditions: DataUploadConditions
+    /// Name of the feature this worker is performing uploads for.
+    private let featureName: String
+
+    /// The core context provider
+    private let contextProvider: DatadogContextProvider
+
+    /// Delay used to schedule consecutive uploads.
+    private var delay: Delay
+
+    /// Upload work scheduled by this worker.
+    private var uploadWork: DispatchWorkItem?
+
+    init(
+        queue: DispatchQueue,
+        fileReader: Reader,
+        dataUploader: DataUploaderType,
+        contextProvider: DatadogContextProvider,
+        uploadConditions: DataUploadConditions,
+        delay: Delay,
+        featureName: String
+    ) {
+        self.queue = queue
+        self.fileReader = fileReader
+        self.uploadConditions = uploadConditions
+        self.dataUploader = dataUploader
+        self.contextProvider = contextProvider
+        self.delay = delay
+        self.featureName = featureName
+
+        let uploadWork = DispatchWorkItem { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let context = contextProvider.read()
+            let blockersForUpload = self.uploadConditions.blockersForUpload(with: context)
+            let isSystemReady = blockersForUpload.isEmpty
+            let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil
+            if let batch = nextBatch {
+                DD.logger.debug("⏳ (\(self.featureName)) Uploading batch...")
+
+                do {
+                    // Upload batch
+                    let uploadStatus = try self.dataUploader.upload(
+                        events: batch.events,
+                        context: context
+                    )
+
+                    // Delete or keep batch depending on the upload status
+                    if uploadStatus.needsRetry {
+                        self.delay.increase()
+
+                        DD.logger.debug("   → (\(self.featureName)) not delivered, will be retransmitted: \(uploadStatus.userDebugDescription)")
+                    } else {
+                        self.fileReader.markBatchAsRead(batch, reason: .intakeCode(responseCode: uploadStatus.responseCode ?? -1)) // -1 is unexpected here
+                        self.delay.decrease()
+
+                        DD.logger.debug("   → (\(self.featureName)) accepted, won't be retransmitted: \(uploadStatus.userDebugDescription)")
+                    }
+
+                    switch uploadStatus.error {
+                    case .unauthorized:
+                        DD.logger.error("⚠️ Make sure that the provided token still exists and you're targeting the relevant Datadog site.")
+                    case let .httpError(statusCode: statusCode):
+                        DD.telemetry.error("Data upload finished with status code: \(statusCode)")
+                    case let .networkError(error: error):
+                        DD.telemetry.error("Data upload finished with error", error: error)
+                    case .none: break
+                    }
+                } catch let error {
+                    // If upload can't be initiated do not retry, so drop the batch:
+                    self.fileReader.markBatchAsRead(batch, reason: .invalid)
+                    DD.telemetry.error("Failed to initiate '\(self.featureName)' data upload", error: error)
+                }
+            } else {
+                let batchLabel = nextBatch != nil ? "YES" : (isSystemReady ? "NO" : "NOT CHECKED")
+                DD.logger.debug("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(blockersForUpload.description)")
+
+                self.delay.increase()
+            }
+
+            self.scheduleNextUpload(after: self.delay.current)
+        }
+
+        self.uploadWork = uploadWork
+
+        scheduleNextUpload(after: self.delay.current)
+    }
+
+    private func scheduleNextUpload(after delay: TimeInterval) {
+        guard let work = uploadWork else {
+            return
+        }
+
+        queue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    /// Sends all unsent data synchronously.
+    /// - It performs arbitrary upload (without checking upload condition and without re-transmitting failed uploads).
+    internal func flushSynchronously() {
+        queue.sync {
+            while let nextBatch = self.fileReader.readNextBatch() {
+                defer {
+                    // RUMM-3459 Delete the underlying batch with `.flushed` reason that will be ignored in reported
+                    // metrics or telemetry. This is legitimate as long as `flush()` routine is only available for testing
+                    // purposes and never run in production apps.
+                    self.fileReader.markBatchAsRead(nextBatch, reason: .flushed)
+                }
+                do {
+                    // Try uploading the batch and do one more retry on failure.
+                    _ = try self.dataUploader.upload(events: nextBatch.events, context: contextProvider.read())
+                } catch {
+                    _ = try? self.dataUploader.upload(events: nextBatch.events, context: contextProvider.read())
+                }
+            }
+        }
+    }
+
+    /// Cancels scheduled uploads and stops scheduling next ones.
+    /// - It does not affect the upload that has already begun.
+    /// - It blocks the caller thread if called in the middle of upload execution.
+    internal func cancelSynchronously() {
+        queue.sync {
+            // This cancellation must be performed on the `queue` to ensure that it is not called
+            // in the middle of a `DispatchWorkItem` execution - otherwise, as the pending block would be
+            // fully executed, it will schedule another upload by calling `nextScheduledWork(after:)` at the end.
+            self.uploadWork?.cancel()
+            self.uploadWork = nil
+        }
+    }
+}
+
+extension DataUploadConditions.Blocker: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case let .battery(level: level, state: state):
+            return "🔋 Battery state is: \(state) (\(level)%)"
+        case .lowPowerModeOn:
+            return "🔌 Low Power Mode is: enabled"
+        case let .networkReachability(description: description):
+            return "📡 Network reachability is: " + description
+        }
+    }
+}
+
+fileprivate extension Array where Element == DataUploadConditions.Blocker {
+    var description: String {
+        if self.isEmpty {
+            return "✅"
+        } else {
+            return "❌ [upload was skipped because: " + self.map { $0.description }.joined(separator: " AND ") + "]"
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/DataUploader.swift
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// A type that performs data uploads.
+internal protocol DataUploaderType {
+    func upload(events: [Event], context: DatadogContext) throws -> DataUploadStatus
+}
+
+/// Synchronously uploads data to server using `HTTPClient`.
+internal final class DataUploader: DataUploaderType {
+    /// An unreachable upload status - only meant to satisfy the compiler.
+    private static let unreachableUploadStatus = DataUploadStatus(
+        needsRetry: false,
+        responseCode: nil,
+        userDebugDescription: "",
+        error: nil
+    )
+
+    private let httpClient: HTTPClient
+    private let requestBuilder: FeatureRequestBuilder
+
+    init(httpClient: HTTPClient, requestBuilder: FeatureRequestBuilder) {
+        self.httpClient = httpClient
+        self.requestBuilder = requestBuilder
+    }
+
+    /// Uploads data synchronously (will block current thread) and returns the upload status.
+    /// Uses timeout configured for `HTTPClient`.
+    func upload(events: [Event], context: DatadogContext) throws -> DataUploadStatus {
+        let request = try requestBuilder.request(for: events, with: context)
+        let requestID = request.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddRequestIDHeaderField)
+
+        var uploadStatus: DataUploadStatus?
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        httpClient.send(request: request) { result in
+            switch result {
+            case .success(let httpResponse):
+                uploadStatus = DataUploadStatus(httpResponse: httpResponse, ddRequestID: requestID)
+            case .failure(let error):
+                uploadStatus = DataUploadStatus(networkError: error)
+            }
+
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .distantFuture)
+
+        return uploadStatus ?? DataUploader.unreachableUploadStatus
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/FeatureUpload.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/FeatureUpload.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal struct FeatureUpload {
+    /// Uploads data to server.
+    let uploader: DataUploadWorkerType
+
+    init(
+        featureName: String,
+        contextProvider: DatadogContextProvider,
+        fileReader: Reader,
+        requestBuilder: FeatureRequestBuilder,
+        httpClient: HTTPClient,
+        performance: PerformancePreset
+    ) {
+        let uploadQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-\(featureName)-upload",
+            autoreleaseFrequency: .workItem,
+            target: .global(qos: .utility)
+        )
+
+        let dataUploader = DataUploader(
+            httpClient: httpClient,
+            requestBuilder: requestBuilder
+        )
+
+        self.init(
+            uploader: DataUploadWorker(
+                queue: uploadQueue,
+                fileReader: fileReader,
+                dataUploader: dataUploader,
+                contextProvider: contextProvider,
+                uploadConditions: DataUploadConditions(),
+                delay: DataUploadDelay(performance: performance),
+                featureName: featureName
+            )
+        )
+    }
+
+    init(uploader: DataUploadWorkerType) {
+        self.uploader = uploader
+    }
+
+    /// Flushes all authorised data and tears down the upload stack.
+    /// - It completes all pending asynchronous work in upload worker and cancels its next schedules.
+    /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
+    ///
+    /// This method is executed synchronously. After return, the upload feature has no more
+    /// pending asynchronous operations and all its authorized data should be considered uploaded.
+    internal func flushAndTearDown() {
+        uploader.cancelSynchronously()
+        uploader.flushSynchronously()
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/HTTPClient.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/HTTPClient.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Defines a type responsible for sending HTTP requests.
+internal protocol HTTPClient {
+    /// Sends the provided request using HTTP.
+    /// - Parameters:
+    ///   - request: The request to be sent.
+    ///   - completion: A closure that receives a Result containing either an HTTPURLResponse or an Error.
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void)
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/URLSessionClient.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Core/Upload/URLSessionClient.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Client for sending requests over HTTP.
+internal class URLSessionClient: HTTPClient {
+    internal let session: URLSession
+
+    convenience init(proxyConfiguration: [AnyHashable: Any]? = nil) {
+        let configuration: URLSessionConfiguration = .ephemeral
+        // NOTE: RUMM-610 Default behaviour of `.ephemeral` session is to cache requests.
+        // To not leak requests memory (including their `.httpBody` which may be significant)
+        // we explicitly opt-out from using cache. This cannot be achieved using `.requestCachePolicy`.
+        configuration.urlCache = nil
+        configuration.connectionProxyDictionary = proxyConfiguration
+
+        // URLSession does not set the `Proxy-Authorization` header automatically when using a proxy
+        // configuration. We manually set the HTTP basic authentication header.
+        if
+            let user = proxyConfiguration?[kCFProxyUsernameKey] as? String,
+            let password = proxyConfiguration?[kCFProxyPasswordKey] as? String
+        {
+            let authorization = basicHTTPAuthentication(username: user, password: password)
+            configuration.httpAdditionalHeaders = ["Proxy-Authorization": authorization]
+        }
+
+        self.init(session: URLSession(configuration: configuration))
+    }
+
+    init(session: URLSession) {
+        self.session = session
+    }
+
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+        let task = session.dataTask(with: request) { data, response, error in
+            completion(httpClientResult(for: (data, response, error)))
+        }
+        task.resume()
+    }
+}
+
+/// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
+/// The code execution in `URLSessionTransport` should never reach its initialization.
+internal struct URLSessionTransportInconsistencyException: Error {}
+
+/// Returns a `Basic` `Authorization` header using the `username` and `password` provided.
+///
+/// - Parameters:
+///   - username: The username of the header.
+///   - password: The password of the header.
+/// - Returns: The HTTP Basic authentication header value
+private func basicHTTPAuthentication(username: String, password: String) -> String {
+    let credential = Data("\(username):\(password)".utf8).base64EncodedString()
+    return "Basic \(credential)"
+}
+
+/// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
+/// it into only two possible states of `HTTPTransportResult`.
+private func httpClientResult(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, Error> {
+    let (_, response, error) = urlSessionTaskCompletion
+
+    if let error = error {
+        return .failure(error)
+    }
+
+    if let httpResponse = response as? HTTPURLResponse {
+        return .success(httpResponse)
+    }
+
+    return .failure(URLSessionTransportInconsistencyException())
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Datadog+Internal.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Datadog+Internal.swift
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+extension Datadog: InternalExtended {}
+
+/// This extension exposes internal methods that are used by other Datadog modules and cross platform
+/// frameworks. It is not meant for public use.
+///
+/// DO NOT USE this extension or its methods if you are not working on the internals of the Datadog SDK
+/// or one of the cross platform frameworks.
+///
+/// Methods, members, and functionality of this class  are subject to change without notice, as they
+/// are not considered part of the public interface of the Datadog SDK.
+extension InternalExtension where ExtendedType == Datadog {
+    /// Internal telemetry proxy.
+    public static var telemetry: _TelemetryProxy { .init() }
+
+    /// Changes the `version` used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    public static func set(customVersion: String) {
+        guard let core = CoreRegistry.default as? DatadogCore else {
+            return
+        }
+
+        core.applicationVersionPublisher.version = customVersion
+    }
+}
+
+public struct _TelemetryProxy {
+    /// See Telementry.debug
+    public func debug(id: String, message: String) {
+        DD.telemetry.debug(id: id, message: message)
+    }
+
+    /// See Telementry.error
+    public func error(id: String, message: String, kind: String?, stack: String?) {
+        DD.telemetry.error(id: id, message: message, kind: kind, stack: stack)
+    }
+}
+
+extension Datadog.Configuration: InternalExtended { }
+extension InternalExtension where ExtendedType == Datadog.Configuration {
+    /// Sets additional configuration attributes.
+    /// This can be used to tweak internal features of the SDK.
+    public var additionalConfiguration: [String: Any] {
+        get { type.additionalConfiguration }
+        set { type.additionalConfiguration = newValue}
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Datadog.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Datadog.swift
@@ -1,0 +1,466 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An entry point to Datadog SDK.
+///
+/// Initialize the core instance of the Datadog SDK prior to enabling any Product.
+///
+/// ```swift
+/// Datadog.initialize(
+///     with: Datadog.Configuration(clientToken: "<client token>", env: "<environment>"),
+///     trackingConsent: .pending
+/// )
+/// ```
+///
+/// Once Datadog SDK is initialized, you can enable products, such as RUM:
+///
+/// ```swift
+/// RUM.enable(
+///     with: RUM.Configuration(applicationID: "<application>")
+/// )
+/// ```
+///     
+public struct Datadog {
+    /// Configuration of Datadog SDK.
+    public struct Configuration {
+        /// Defines the Datadog SDK policy when batching data together before uploading it to Datadog servers.
+        /// Smaller batches mean smaller but more network requests, whereas larger batches mean fewer but larger network requests.
+        public enum BatchSize {
+            /// Prefer small sized data batches.
+            case small
+            /// Prefer medium sized data batches.
+            case medium
+            /// Prefer large sized data batches.
+            case large
+        }
+
+        /// Defines the frequency at which Datadog SDK will try to upload data batches.
+        public enum UploadFrequency {
+            /// Try to upload batched data frequently.
+            case frequent
+            /// Try to upload batched data with a medium frequency.
+            case average
+            /// Try to upload batched data rarely.
+            case rare
+        }
+
+        /// Either the RUM client token (which supports RUM, Logging and APM) or regular client token, only for Logging and APM.
+        public var clientToken: String
+
+        /// The environment name which will be sent to Datadog. This can be used
+        /// To filter events on different environments (e.g. "staging" or "production").
+        public var env: String
+
+        /// The Datadog server site where data is sent.
+        ///
+        /// Default value is `.us1`.
+        public var site: DatadogSite
+
+        /// The service name associated with data send to Datadog.
+        ///
+        /// Default value is set to application bundle identifier.
+        public var service: String?
+
+        /// The preferred size of batched data uploaded to Datadog servers.
+        /// This value impacts the size and number of requests performed by the SDK.
+        ///
+        /// `.medium` by default.
+        public var batchSize: BatchSize
+
+        /// The preferred frequency of uploading data to Datadog servers.
+        /// This value impacts the frequency of performing network requests by the SDK.
+        ///
+        /// `.average` by default.
+        public var uploadFrequency: UploadFrequency
+
+        /// Proxy configuration attributes.
+        /// This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
+        ///
+        /// Ref.: https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411499-connectionproxydictionary
+        public var proxyConfiguration: [AnyHashable: Any]?
+
+        /// SeData encryption to use for on-disk data persistency by providing an object
+        /// complying with `DataEncryption` protocol.
+        public var encryption: DataEncryption?
+
+        /// A custom NTP synchronization interface.
+        ///
+        /// By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
+        /// https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
+        /// implementation will result in desynchronization of the SDK instance and the Datadog servers.
+        /// This can lead to significant time shift in RUM sessions or distributed traces.
+        public var serverDateProvider: ServerDateProvider
+
+        /// The bundle object that contains the current executable.
+        public var bundle: Bundle
+
+        /// Creates a Datadog SDK Configuration object.
+        ///
+        /// - Parameters:
+        ///   - clientToken:                Either the RUM client token (which supports RUM, Logging and APM) or regular client token,
+        ///                                 only for Logging and APM.
+        ///
+        ///   - env:                        The environment name which will be sent to Datadog. This can be used
+        ///                                 To filter events on different environments (e.g. "staging" or "production").
+        ///
+        ///   - site:                       Datadog site endpoint, default value is `.us1`.
+        ///
+        ///   - service:                    The service name associated with data send to Datadog.
+        ///                                 Default value is set to application bundle identifier.
+        ///
+        ///   - bundle:                     The bundle object that contains the current executable.
+        ///
+        ///   - batchSize:                  The preferred size of batched data uploaded to Datadog servers.
+        ///                                 This value impacts the size and number of requests performed by the SDK.
+        ///                                 `.medium` by default.
+        ///
+        ///   - uploadFrequency:            The preferred frequency of uploading data to Datadog servers.
+        ///                                 This value impacts the frequency of performing network requests by the SDK.
+        ///                                 `.average` by default.
+        ///
+        ///   - proxyConfiguration:         A proxy configuration attributes.
+        ///                                 This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
+        ///
+        ///   - encryption:                 Data encryption to use for on-disk data persistency by providing an object
+        ///                                 complying with `DataEncryption` protocol.
+        ///
+        ///   - serverDateProvider:         A custom NTP synchronization interface.
+        ///                                 By default, the Datadog SDK synchronizes with dedicated NTP pools provided by the
+        ///                                 https://www.ntppool.org/ . Using different pools or setting a no-op `ServerDateProvider`
+        ///                                 implementation will result in desynchronization of the SDK instance and the Datadog servers.
+        ///                                 This can lead to significant time shift in RUM sessions or distributed traces.
+        public init(
+            clientToken: String,
+            env: String,
+            site: DatadogSite = .us1,
+            service: String? = nil,
+            bundle: Bundle = .main,
+            batchSize: BatchSize = .medium,
+            uploadFrequency: UploadFrequency = .average,
+            proxyConfiguration: [AnyHashable: Any]? = nil,
+            encryption: DataEncryption? = nil,
+            serverDateProvider: ServerDateProvider? = nil
+        ) {
+            self.clientToken = clientToken
+            self.env = env
+            self.site = site
+            self.service = service
+            self.bundle = bundle
+            self.batchSize = batchSize
+            self.uploadFrequency = uploadFrequency
+            self.proxyConfiguration = proxyConfiguration
+            self.encryption = encryption
+            self.serverDateProvider = serverDateProvider ?? DatadogNTPDateProvider()
+        }
+
+        // MARK: - Internal
+
+        /// Obtains OS directory where SDK creates its root folder.
+        /// All instances of the SDK use the same root folder, but each creates its own subdirectory.
+        internal var systemDirectory: () throws -> Directory = { try Directory.cache() }
+
+        /// Default process information.
+        internal var processInfo: ProcessInfo = .processInfo
+
+        /// Sets additional configuration attributes.
+        /// This can be used to tweak internal features of the SDK.
+        internal var additionalConfiguration: [String: Any] = [:]
+
+        /// Default date provider used by the SDK and all products.
+        internal var dateProvider: DateProvider = SystemDateProvider()
+
+        /// Creates `HTTPClient` with given proxy configuration attributes.
+        internal var httpClientFactory: ([AnyHashable: Any]?) -> HTTPClient = { proxyConfiguration in
+            URLSessionClient(proxyConfiguration: proxyConfiguration)
+        }
+    }
+
+    /// Verbosity level of Datadog SDK. Can be used for debugging purposes.
+    /// If set, internal events occuring inside SDK will be printed to debugger console if their level is equal or greater than `verbosityLevel`.
+    /// Default is `nil`.
+    public static var verbosityLevel: CoreLoggerLevel? = nil
+
+    /// Returns `true` if the Datadog SDK is already initialized, `false` otherwise.
+    ///
+    /// - Parameter name: The name of the SDK instance to verify.
+    public static func isInitialized(instanceName name: String = CoreRegistry.defaultInstanceName) -> Bool {
+        CoreRegistry.instance(named: name) is DatadogCore
+    }
+
+    /// Returns the Datadog SDK instance for the given name.
+    ///
+    /// - Parameter name: The name of the instance to get.
+    /// - Returns: The core instance if it exists, `NOPDatadogCore` instance otherwise.
+    public static func sdkInstance(named name: String) -> DatadogCoreProtocol {
+        CoreRegistry.instance(named: name)
+    }
+
+    /// Sets current user information.
+    ///
+    /// Those will be added to logs, traces and RUM events automatically.
+    ///
+    /// - Parameters:
+    ///   - id: User ID, if any
+    ///   - name: Name representing the user, if any
+    ///   - email: User's email, if any
+    ///   - extraInfo: User's custom attributes, if any
+    public static func setUserInfo(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:],
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
+        let core = core as? DatadogCore
+        core?.setUserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
+    }
+
+    /// Add custom attributes  to the current user information
+    ///
+    /// This extra info will be added to already existing extra info that is added
+    /// to  logs traces and RUM events automatically.
+    ///
+    /// - Parameters:
+    ///   - extraInfo: User's additionall custom attributes
+    public static func addUserExtraInfo(
+        _ extraInfo: [AttributeKey: AttributeValue?],
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
+        let core = core as? DatadogCore
+        core?.addUserExtraInfo(extraInfo)
+    }
+
+    /// Sets the tracking consent regarding the data collection for the Datadog SDK.
+    /// - Parameter trackingConsent: new consent value, which will be applied for all data collected from now on
+    public static func set(trackingConsent: TrackingConsent, in core: DatadogCoreProtocol = CoreRegistry.default) {
+        let core = core as? DatadogCore
+        core?.set(trackingConsent: trackingConsent)
+    }
+
+    /// Clears all data that has not already been sent to Datadog servers.
+    public static func clearAllData(in core: DatadogCoreProtocol = CoreRegistry.default) {
+        let core = core as? DatadogCore
+        core?.clearAllData()
+    }
+
+    /// Initializes the Datadog SDK.
+    ///
+    /// You **must** initialize the core instance of the Datadog SDK prior to enabling any Product.
+    ///
+    ///    ```swift
+    ///     Datadog.initialize(
+    ///         with: Datadog.Configuration(clientToken: "<client token>", env: "<environment>"),
+    ///         trackingConsent: .pending
+    ///     )
+    ///    ```
+    ///
+    /// Once Datadog SDK is initialized, you can enable products, such as RUM:
+    ///
+    ///    ```swift
+    ///     RUM.enable(
+    ///         with: RUM.Configuration(applicationID: "<application>")
+    ///     )
+    ///    ```
+    /// It is possible to initialize multiple instances of the SDK, associating them with a name.
+    /// Many methods of the SDK can optionally take a SDK instance as an argument. If not provided,
+    /// the call will be associated with the default (nameless) SDK instance.
+    ///
+    /// To use a secondary instance of the SDK, provide a name to the ``initialize`` method
+    /// and use the returned instance to enable products:
+    ///
+    ///    ```swift
+    ///     let core = Datadog.initialize(
+    ///         with: Datadog.Configuration(clientToken: "<client token>", env: "<environment>"),
+    ///         trackingConsent: .pending,
+    ///         instanceName: "my-instance"
+    ///     )
+    ///
+    ///     RUM.enable(
+    ///         with: RUM.Configuration(applicationID: "<application>"),
+    ///         in: core
+    ///     )
+    ///    ```
+    ///
+    /// - Parameters:
+    ///   - configuration: the SDK configuration.
+    ///   - trackingConsent: the initial state of the Data Tracking Consent given by the user of the app.
+    ///   - instanceName:   The core instance name. This value will be used for data persistency and should be
+    ///                     stable between application runs.
+    @discardableResult
+    public static func initialize(
+        with configuration: Configuration,
+        trackingConsent: TrackingConsent,
+        instanceName: String = CoreRegistry.defaultInstanceName
+    ) -> DatadogCoreProtocol {
+        // TODO: RUMM-511 remove this warning
+        #if targetEnvironment(macCatalyst)
+        consolePrint("⚠️ Catalyst is not officially supported by Datadog SDK: some features may NOT be functional!")
+        #endif
+
+        do {
+            return try initializeOrThrow(
+                with: configuration,
+                trackingConsent: trackingConsent,
+                instanceName: instanceName
+            )
+        } catch {
+            consolePrint("\(error)")
+            return NOPDatadogCore()
+        }
+    }
+
+    private static func initializeOrThrow(
+        with configuration: Configuration,
+        trackingConsent: TrackingConsent,
+        instanceName: String
+    ) throws -> DatadogCoreProtocol {
+        guard !CoreRegistry.isRegistered(instanceName: instanceName) else {
+            throw ProgrammerError(description: "The '\(instanceName)' instance of SDK is already initialized.")
+        }
+
+        let debug = configuration.processInfo.arguments.contains(LaunchArguments.Debug)
+        if debug {
+            consolePrint("⚠️ Overriding verbosity, and upload frequency due to \(LaunchArguments.Debug) launch argument")
+            Datadog.verbosityLevel = .debug
+        }
+
+        let applicationVersion = configuration.bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? configuration.bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            ?? "0.0.0"
+
+        let bundleName = configuration.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
+        let bundleType: BundleType = configuration.bundle.bundlePath.hasSuffix(".appex") ? .iOSAppExtension : .iOSApp
+        let bundleIdentifier = configuration.bundle.bundleIdentifier ?? "unknown"
+        let service = configuration.service ?? configuration.bundle.bundleIdentifier ?? "ios"
+        let source = configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String ?? "ios"
+        let variant = configuration.additionalConfiguration[CrossPlatformAttributes.variant] as? String
+        let sdkVersion = configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String ?? __sdkVersion
+
+        let performance = PerformancePreset(
+            batchSize: debug ? .small : configuration.batchSize,
+            uploadFrequency: debug ? .frequent : configuration.uploadFrequency,
+            bundleType: bundleType
+        )
+
+        // Set default `DatadogCore`:
+        let core = DatadogCore(
+            directory: try CoreDirectory(
+                in: configuration.systemDirectory(),
+                instancenName: instanceName,
+                site: configuration.site
+            ),
+            dateProvider: configuration.dateProvider,
+            initialConsent: trackingConsent,
+            performance: performance,
+            httpClient: configuration.httpClientFactory(configuration.proxyConfiguration),
+            encryption: configuration.encryption,
+            contextProvider: DatadogContextProvider(
+                site: configuration.site,
+                clientToken: try ifValid(clientToken: configuration.clientToken),
+                service: service,
+                env: try ifValid(env: configuration.env),
+                version: applicationVersion,
+                variant: variant,
+                source: source,
+                sdkVersion: sdkVersion,
+                ciAppOrigin: CITestIntegration.active?.origin,
+                applicationName: bundleName ?? bundleType.rawValue,
+                applicationBundleIdentifier: bundleIdentifier,
+                applicationVersion: applicationVersion,
+                sdkInitDate: configuration.dateProvider.now,
+                device: DeviceInfo(),
+                dateProvider: configuration.dateProvider,
+                serverDateProvider: configuration.serverDateProvider
+            ),
+            applicationVersion: applicationVersion
+        )
+
+        let telemetry = TelemetryCore(core: core)
+
+        telemetry.configuration(
+            batchSize: Int64(exactly: performance.maxFileSize),
+            batchUploadFrequency: performance.minUploadDelay.toInt64Milliseconds,
+            useLocalEncryption: configuration.encryption != nil,
+            useProxy: configuration.proxyConfiguration != nil
+        )
+
+        CITestIntegration.active?.startIntegration()
+
+        CoreRegistry.register(core, named: instanceName)
+        deleteV1Folders(in: core)
+
+        DD.logger = InternalLogger(
+            dateProvider: configuration.dateProvider,
+            timeZone: .current,
+            printFunction: consolePrint,
+            verbosityLevel: { Datadog.verbosityLevel }
+        )
+
+        DD.telemetry = telemetry
+
+        return core
+    }
+
+    private static func deleteV1Folders(in core: DatadogCore) {
+        let deprecated = ["com.datadoghq.logs", "com.datadoghq.traces", "com.datadoghq.rum"].compactMap {
+            try? Directory.cache().subdirectory(path: $0) // ignore errors - deprecated paths likely do not exist
+        }
+
+        core.readWriteQueue.async {
+            // ignore errors
+            deprecated.forEach { try? FileManager.default.removeItem(at: $0.url) }
+        }
+    }
+
+    /// Flushes all authorised data for each feature, tears down and deinitializes the SDK.
+    /// - It flushes all data authorised for each feature by performing its arbitrary upload (without retrying).
+    /// - It completes all pending asynchronous work in each feature.
+    ///
+    /// This is highly experimental API and only supported in tests.
+#if DD_SDK_COMPILED_FOR_TESTING
+    public static func flushAndDeinitialize(instanceName: String = CoreRegistry.defaultInstanceName) {
+        internalFlushAndDeinitialize(instanceName: instanceName)
+    }
+#endif
+
+    internal static func internalFlushAndDeinitialize(instanceName: String = CoreRegistry.defaultInstanceName) {
+        assert(CoreRegistry.instance(named: instanceName) is DatadogCore, "SDK must be first initialized.")
+
+        // Flush and tear down SDK core:
+        (CoreRegistry.instance(named: instanceName) as? DatadogCore)?.flushAndTearDown()
+
+        // Reset Globals:
+        DD.telemetry = NOPTelemetry()
+
+        // Deinitialize `Datadog`:
+        CoreRegistry.unregisterInstance(named: instanceName)
+    }
+}
+
+private func ifValid(env: String) throws -> String {
+    /// 1. cannot be more than 200 chars (including `env:` prefix)
+    /// 2. cannot end with `:`
+    /// 3. can contain letters, numbers and _:./-_ (other chars are converted to _ at backend)
+    let regex = #"^[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]$"#
+    if env.range(of: regex, options: .regularExpression, range: nil, locale: nil) == nil {
+        throw ProgrammerError(description: "`env`: \(env) contains illegal characters (only alphanumerics and `_` are allowed)")
+    }
+    return env
+}
+
+private func ifValid(clientToken: String) throws -> String {
+    if clientToken.isEmpty {
+        throw ProgrammerError(description: "`clientToken` cannot be empty.")
+    }
+    return clientToken
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/FeaturesIntegration/CITestIntegration.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/FeaturesIntegration/CITestIntegration.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+private enum DDCFMessageID {
+    static let setCustomTags: Int32 = 0x1111
+    static let enableRUM: Int32 = 0x2222
+    static let forceFlush: Int32 = 0x3333
+}
+
+internal class CITestIntegration {
+    /// Current and active integration with CIApp.
+    /// `nil` if the integration is not enabled.
+    static let active: CITestIntegration? = CITestIntegration()
+    /// RUMCITest model to be attached to events, it contains the CI context
+    let testExecutionId: String
+    /// Tag that must be added to spans and headers when running inside a CIApp test
+    let origin = "ciapp-test"
+
+    private init?(processInfo: ProcessInfo = .processInfo) {
+        guard let testID = processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"] else {
+            return nil
+        }
+        self.testExecutionId = testID
+    }
+
+    /// Entry point for running all the tasks needed for CIApp integration
+    func startIntegration() {
+        startMessageListener()
+        notifyRUMSession()
+    }
+
+    /// Notifies the CIApp framework that a RUM session is being started. It sends a message to a CFMessagePort that is
+    /// created in the CIApp framework
+    private func notifyRUMSession() {
+        let timeout: CFTimeInterval = 1.0
+        guard let remotePort = CFMessagePortCreateRemote(nil, "DatadogTestingPort" as CFString) else {
+            return
+        }
+        CFMessagePortSendRequest(
+            remotePort,
+            DDCFMessageID.enableRUM, // Message ID for notifying the test that rum is enabled
+            nil,
+            timeout,
+            timeout,
+            nil,
+            nil
+        )
+    }
+
+    /// Creates a CFMessagePort that is used by the CIApp framework to notify that a test is going to finish, so all
+    /// information must be flushed to the backend. It uses a non public API `internalFlushAndDeinitialize()`
+    private func startMessageListener() {
+        func attributeCallback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
+            switch msgid {
+            case DDCFMessageID.forceFlush:
+                Datadog.internalFlushAndDeinitialize()
+            default:
+                break
+            }
+            return nil
+        }
+
+        guard let port = CFMessagePortCreateLocal(nil, "DatadogRUMTestingPort" as CFString, attributeCallback, nil, nil) else {
+            return
+        }
+        let runLoopSource = CFMessagePortCreateRunLoopSource(nil, port, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosClock.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosClock.swift
@@ -1,0 +1,160 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+/// Struct that has time + related metadata
+internal typealias KronosAnnotatedTime = (
+    /// Time that is being annotated
+    date: Date,
+
+    /// Amount of time that has passed since the last NTP sync; in other words, the NTP response age.
+    timeSinceLastNtpSync: TimeInterval
+)
+
+internal protocol KronosClockProtocol {
+    /// The most accurate date that we have so far (nil if no synchronization was done yet)
+    var now: Date? { get }
+
+    /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given
+    /// closure will be called with the first valid NTP response which accuracy should be good enough for the
+    /// initial clock adjustment but it might not be the most accurate representation. After calling the
+    /// closure this method will continue syncing with multiple servers and multiple passes.
+    ///
+    /// - parameter pool:       NTP pool that will be resolved into multiple NTP servers that will be used for
+    ///                         the synchronization.
+    /// - parameter samples:    The number of samples to be acquired from each server.
+    /// - parameter first:      A closure that will be called after the first valid date is calculated.
+    /// - parameter completion: A closure that will be called after _all_ the NTP calls are finished.
+    func sync(
+        from pool: String,
+        samples: Int,
+        first: ((Date, TimeInterval) -> Void)?,
+        completion: ((Date?, TimeInterval?) -> Void)?
+    )
+}
+
+extension KronosClockProtocol {
+    /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given
+    /// closure will be called with the first valid NTP response which accuracy should be good enough for the
+    /// initial clock adjustment but it might not be the most accurate representation. After calling the
+    /// closure this method will continue syncing with multiple servers and multiple passes. 4 samples per
+    /// server will be acquired.
+    ///
+    /// - parameter pool:       NTP pool that will be resolved into multiple NTP servers that will be used for
+    ///                         the synchronization.
+    /// - parameter first:      A closure that will be called after the first valid date is calculated.
+    /// - parameter completion: A closure that will be called after _all_ the NTP calls are finished.
+    func sync(
+        from pool: String,
+        first: ((Date, TimeInterval) -> Void)?,
+        completion: ((Date?, TimeInterval?) -> Void)?
+    ) {
+        sync(from: pool, samples: 4, first: first, completion: completion)
+    }
+}
+
+/// High level implementation for clock synchronization using NTP. All returned dates use the most accurate
+/// synchronization and it's not affected by clock changes. The NTP synchronization implementation has sub-
+/// second accuracy but given that Darwin doesn't support microseconds on bootTime, dates don't have sub-
+/// second accuracy.
+///
+/// Example usage:
+///
+/// ```swift
+/// KronosClock.sync { date, offset in
+///     print(date)
+/// }
+/// // (... later on ...)
+/// print(KronosClock.now)
+/// ```
+internal final class KronosClock: KronosClockProtocol {
+    private var stableTime: KronosTimeFreeze? {
+        didSet {
+            self.storage.stableTime = self.stableTime
+        }
+    }
+
+    /// Determines where the most current stable time is stored. Use TimeStoragePolicy.appGroup to share
+    /// between your app and an extension.
+    private var storage = KronosTimeStorage(storagePolicy: .standard)
+
+    /// The most accurate timestamp that we have so far (nil if no synchronization was done yet)
+    var timestamp: TimeInterval? {
+        return self.stableTime?.adjustedTimestamp
+    }
+
+    /// The most accurate date that we have so far (nil if no synchronization was done yet)
+    var now: Date? {
+        return self.annotatedNow?.date
+    }
+
+    /// Same as `now` except with analytic metadata about the time
+    var annotatedNow: KronosAnnotatedTime? {
+        guard let stableTime = self.stableTime else {
+            return nil
+        }
+
+        return KronosAnnotatedTime(
+            date: Date(timeIntervalSince1970: stableTime.adjustedTimestamp),
+            timeSinceLastNtpSync: stableTime.timeSinceLastNtpSync
+        )
+    }
+
+    /// Syncs the clock using NTP. Note that the full synchronization could take a few seconds. The given
+    /// closure will be called with the first valid NTP response which accuracy should be good enough for the
+    /// initial clock adjustment but it might not be the most accurate representation. After calling the
+    /// closure this method will continue syncing with multiple servers and multiple passes.
+    ///
+    /// - parameter pool:       NTP pool that will be resolved into multiple NTP servers that will be used for
+    ///                         the synchronization.
+    /// - parameter samples:    The number of samples to be acquired from each server (default 4).
+    /// - parameter first:      A closure that will be called after the first valid date is calculated.
+    /// - parameter completion: A closure that will be called after _all_ the NTP calls are finished.
+    func sync(
+        from pool: String = "time.apple.com",
+        samples: Int = 4,
+        first: ((Date, TimeInterval) -> Void)? = nil,
+        completion: ((Date?, TimeInterval?) -> Void)? = nil
+    ) {
+        self.loadFromDefaults()
+
+        KronosNTPClient().query(pool: pool, numberOfSamples: samples) { [weak self] offset, done, total in
+            guard let self = self else {
+                return
+            }
+
+            if let offset = offset {
+                self.stableTime = KronosTimeFreeze(offset: offset)
+
+                if done == 1, let now = self.now {
+                    first?(now, offset)
+                }
+            }
+
+            if done == total {
+                completion?(self.now, offset)
+            }
+        }
+    }
+
+    /// Resets all state of the monotonic clock. Note that you won't be able to access `now` until you `sync`
+    /// again.
+    func reset() {
+        self.stableTime = nil
+    }
+
+    private func loadFromDefaults() {
+        guard let previousStableTime = self.storage.stableTime else {
+            self.stableTime = nil
+            return
+        }
+        self.stableTime = previousStableTime
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosDNSResolver.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosDNSResolver.swift
@@ -1,0 +1,102 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+private let kCopyNoOperation = unsafeBitCast(0, to: CFAllocatorCopyDescriptionCallBack.self)
+private let kDefaultTimeout = 8.0
+
+internal final class KronosDNSResolver {
+    private var completion: (([KronosInternetAddress]) -> Void)?
+    private var timer: Timer?
+
+    private init() {}
+
+    /// Performs DNS lookups and calls the given completion with the answers that are returned from the name
+    /// server(s) that were queried.
+    ///
+    /// - parameter host:       The host to be looked up.
+    /// - parameter timeout:    The connection timeout.
+    /// - parameter completion: A completion block that will be called both on failure and success with a list
+    ///                         of IPs.
+    static func resolve(
+        host: String,
+        timeout: TimeInterval = kDefaultTimeout,
+        completion: @escaping ([KronosInternetAddress]) -> Void
+    ) {
+        let callback: CFHostClientCallBack = { host, _, _, info in
+            guard let info = info else {
+                return
+            }
+            let retainedSelf = Unmanaged<KronosDNSResolver>.fromOpaque(info)
+            let resolver = retainedSelf.takeUnretainedValue()
+            resolver.timer?.invalidate()
+            resolver.timer = nil
+
+            var resolved: DarwinBoolean = false
+            guard let addresses = CFHostGetAddressing(host, &resolved), resolved.boolValue else {
+                resolver.completion?([])
+                retainedSelf.release()
+                return
+            }
+
+            let IPs = (addresses.takeUnretainedValue() as NSArray)
+                .compactMap { $0 as? NSData }
+                .compactMap(KronosInternetAddress.init)
+                .filter { ip in !ip.isPrivate } // to avoid querying private IPs, see: https://github.com/DataDog/dd-sdk-ios/issues/647
+
+            resolver.completion?(IPs)
+            retainedSelf.release()
+        }
+
+        let resolver = KronosDNSResolver()
+        resolver.completion = completion
+
+        let retainedClosure = Unmanaged.passRetained(resolver).toOpaque()
+        var clientContext = CFHostClientContext(
+            version: 0,
+            info: UnsafeMutableRawPointer(retainedClosure),
+            retain: nil,
+            release: nil,
+            copyDescription: kCopyNoOperation
+        )
+
+        let hostReference = CFHostCreateWithName(kCFAllocatorDefault, host as CFString).takeUnretainedValue()
+        resolver.timer = Timer.scheduledTimer(
+            timeInterval: timeout,
+            target: resolver,
+            selector: #selector(KronosDNSResolver.onTimeout),
+            userInfo: hostReference,
+            repeats: false
+        )
+
+        CFHostSetClient(hostReference, callback, &clientContext)
+        CFHostScheduleWithRunLoop(hostReference, CFRunLoopGetMain(), CFRunLoopMode.commonModes.rawValue)
+        CFHostStartInfoResolution(hostReference, .addresses, nil)
+    }
+
+    @objc
+    private func onTimeout() {
+        defer {
+            self.completion?([])
+
+            // Manually release the previously retained self.
+            Unmanaged.passUnretained(self).release()
+        }
+
+        guard let userInfo = self.timer?.userInfo else {
+            return
+        }
+
+        let hostReference = unsafeBitCast(userInfo as AnyObject, to: CFHost.self)
+        CFHostCancelInfoResolution(hostReference, .addresses)
+        CFHostUnscheduleFromRunLoop(hostReference, CFRunLoopGetMain(), CFRunLoopMode.commonModes.rawValue)
+        CFHostSetClient(hostReference, nil, nil)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosData+Bytes.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosData+Bytes.swift
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+extension Data {
+    /// Creates an Data instance based on a hex string (example: "ffff" would be <FF FF>).
+    ///
+    /// - parameter hex: The hex string without any spaces; should only have [0-9A-Fa-f].
+    init?(hex: String) {
+        if hex.count % 2 != 0 {
+            return nil
+        }
+
+        let hexArray = Array(hex)
+        var bytes: [UInt8] = []
+
+        for index in stride(from: 0, to: hexArray.count, by: 2) {
+            guard let byte = UInt8("\(hexArray[index])\(hexArray[index + 1])", radix: 16) else {
+                return nil
+            }
+
+            bytes.append(byte)
+        }
+
+        self.init(bytes: bytes, count: bytes.count)
+    }
+
+    /// Gets one byte from the given index.
+    ///
+    /// - parameter index: The index of the byte to be retrieved. Note that this should never be >= length.
+    ///
+    /// - returns: The byte located at position `index`.
+    func getByte(at index: Int) -> Int8 {
+        let data: Int8 = self.subdata(in: index ..< (index + 1)).withUnsafeBytes { rawPointer in
+            rawPointer.bindMemory(to: Int8.self).baseAddress!.pointee // swiftlint:disable:this force_unwrapping
+        }
+
+        return data
+    }
+
+    /// Gets an unsigned int (32 bits => 4 bytes) from the given index.
+    ///
+    /// - parameter index: The index of the uint to be retrieved. Note that this should never be >= length -
+    ///                    3.
+    ///
+    /// - returns: The unsigned int located at position `index`.
+    func getUnsignedInteger(at index: Int, bigEndian: Bool = true) -> UInt32 {
+        let data: UInt32 = self.subdata(in: index ..< (index + 4)).withUnsafeBytes { rawPointer in
+            rawPointer.bindMemory(to: UInt32.self).baseAddress!.pointee // swiftlint:disable:this force_unwrapping
+        }
+
+        return bigEndian ? data.bigEndian : data.littleEndian
+    }
+
+    /// Gets an unsigned long integer (64 bits => 8 bytes) from the given index.
+    ///
+    /// - parameter index: The index of the ulong to be retrieved. Note that this should never be >= length -
+    ///                    7.
+    ///
+    /// - returns: The unsigned long integer located at position `index`.
+    func getUnsignedLong(at index: Int, bigEndian: Bool = true) -> UInt64 {
+        let data: UInt64 = self.subdata(in: index ..< (index + 8)).withUnsafeBytes { rawPointer in
+            rawPointer.bindMemory(to: UInt64.self).baseAddress!.pointee // swiftlint:disable:this force_unwrapping
+        }
+
+        return bigEndian ? data.bigEndian : data.littleEndian
+    }
+
+    /// Appends the given byte (8 bits) into the receiver Data.
+    ///
+    /// - parameter data: The byte to be appended.
+    mutating func append(byte data: Int8) {
+        var data = data
+        self.append(Data(bytes: &data, count: MemoryLayout<Int8>.size))
+    }
+
+    /// Appends the given unsigned integer (32 bits; 4 bytes) into the receiver Data.
+    ///
+    /// - parameter data: The unsigned integer to be appended.
+    mutating func append(unsignedInteger data: UInt32, bigEndian: Bool = true) {
+        var data = bigEndian ? data.bigEndian : data.littleEndian
+        self.append(Data(bytes: &data, count: MemoryLayout<UInt32>.size))
+    }
+
+    /// Appends the given unsigned long (64 bits; 8 bytes) into the receiver Data.
+    ///
+    /// - parameter data: The unsigned long to be appended.
+    mutating func append(unsignedLong data: UInt64, bigEndian: Bool = true) {
+        var data = bigEndian ? data.bigEndian : data.littleEndian
+        self.append(Data(bytes: &data, count: MemoryLayout<UInt64>.size))
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosInternetAddress.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosInternetAddress.swift
@@ -1,0 +1,163 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+/// This enum represents an internet address that can either be IPv4 or IPv6.
+///
+/// - IPv6: An Internet Address of type IPv6 (e.g.: '::1').
+/// - IPv4: An Internet Address of type IPv4 (e.g.: '127.0.0.1').
+internal enum KronosInternetAddress: Hashable {
+    case ipv6(sockaddr_in6)
+    case ipv4(sockaddr_in)
+
+    /// Human readable host represetnation (e.g. '192.168.1.1' or 'ab:ab:ab:ab:ab:ab:ab:ab').
+    var host: String? {
+        switch self {
+        case .ipv6(var address):
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            inet_ntop(AF_INET6, &address.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
+            return String(cString: buffer)
+
+        case .ipv4(var address):
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            inet_ntop(AF_INET, &address.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
+            return String(cString: buffer)
+        }
+    }
+
+    /// The protocol family that should be used on the socket creation for this address.
+    var family: Int32 {
+        switch self {
+        case .ipv4:
+            return PF_INET
+
+        case .ipv6:
+            return PF_INET6
+        }
+    }
+
+    /// If the address is reserved for private internets (local / private IP).
+    var isPrivate: Bool {
+        guard let host = host else {
+            return false
+        }
+
+        switch self {
+        case .ipv6:
+            // Ref.:  https://datatracker.ietf.org/doc/html/rfc4193#section-3
+            // +--------+-+------------+-----------+----------------------------+
+            // | 7 bits |1|  40 bits   |  16 bits  |          64 bits           |
+            // +--------+-+------------+-----------+----------------------------+
+            // | Prefix |L| Global ID  | Subnet ID |        Interface ID        |
+            // +--------+-+------------+-----------+----------------------------+
+            //
+            // Local IP is expected to have FC00::/7 prefix (7 bits) and L byte set to 1,
+            // which effectively means `fd` prefix for local IPs.
+            let localPrefix = "fd"
+
+            // Ref.: https://datatracker.ietf.org/doc/html/rfc4291#section-2.4
+            let multicastPrefix = "ff"
+
+            let hostLowercased = host.lowercased()
+            return hostLowercased.starts(with: localPrefix)
+                || hostLowercased.starts(with: multicastPrefix)
+        case .ipv4:
+            // Ref.: https://datatracker.ietf.org/doc/html/rfc1918#section-3
+            // Local IPs have predefined ranges:
+            // - class A: 10.0.0.0 — 10.255.255.255
+            // - class B: 172.16.0.0 — 172.31.255.255
+            // - class C: 192.168.0.0 — 192.168.255.255
+            let classABCregex = #"^((10\.)|(172\.1[6-9]\.)|(172\.2[0-9]\.)|(172\.3[0-1]\.)|(192\.168\.))"#
+
+            // Ref.: https://datatracker.ietf.org/doc/html/rfc5771#section-3
+            // Multicast address (range 224.0.0.0 - 239.255.255.255) are considered to be local network
+            // addresses too (https://developer.apple.com/forums/thread/663848)
+            //
+            let multicastRegex = #"^((22[4-9]\.)|(23[0-9]\.))"#
+            let broadcastIP = "255.255.255.255"
+
+            return host.range(of: classABCregex, options: .regularExpression) != nil
+                || host.range(of: multicastRegex, options: .regularExpression) != nil
+                || host == broadcastIP
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.host)
+    }
+
+    init?(dataWithSockAddress data: NSData) {
+        let storage = sockaddr_storage.from(unsafeDataWithSockAddress: data)
+        switch Int32(storage.ss_family) {
+        case AF_INET:
+            self = storage.withUnsafeAddress { KronosInternetAddress.ipv4($0.pointee) }
+
+        case AF_INET6:
+            self = storage.withUnsafeAddress { KronosInternetAddress.ipv6($0.pointee) }
+
+        default:
+            return nil
+        }
+    }
+
+    /// Returns the address struct (either sockaddr_in or sockaddr_in6) represented as an CFData.
+    ///
+    /// - parameter port: The port number to associate on the address struct.
+    ///
+    /// - returns: An address struct wrapped into a CFData type.
+    func addressData(withPort port: Int) -> CFData {
+        switch self {
+        case .ipv6(var address):
+            address.sin6_port = in_port_t(port).bigEndian
+            return Data(bytes: &address, count: MemoryLayout<sockaddr_in6>.size) as CFData
+
+        case .ipv4(var address):
+            address.sin_port = in_port_t(port).bigEndian
+            return Data(bytes: &address, count: MemoryLayout<sockaddr_in>.size) as CFData
+        }
+    }
+}
+
+/// Compare InternetAddress(es) by making sure the host representation are equal.
+internal func == (lhs: KronosInternetAddress, rhs: KronosInternetAddress) -> Bool {
+    return lhs.host == rhs.host
+}
+
+// MARK: - sockaddr_storage helpers
+
+extension sockaddr_storage {
+    /// Creates a new storage value from a data type that contains the memory layout of a sockaddr_t. This
+    /// is used to create sockaddr_storage(s) from some of the CF C functions such as `CFHostGetAddressing`.
+    ///
+    /// !!! WARNING: This method is unsafe and assumes the memory layout is of `sockaddr_t`. !!!
+    ///
+    /// - parameter data: The data to be interpreted as sockaddr
+    /// - returns: The newly created sockaddr_storage value
+    fileprivate static func from(unsafeDataWithSockAddress data: NSData) -> sockaddr_storage {
+        var storage = sockaddr_storage()
+        data.getBytes(&storage, length: data.length)
+        return storage
+    }
+
+    /// Calls a closure with traditional BSD Sockets address parameters.
+    ///
+    /// - parameter body: A closure to call with `self` referenced appropriately for calling
+    ///   BSD Sockets APIs that take an address.
+    ///
+    /// - throws: Any error thrown by `body`.
+    ///
+    /// - returns: Any result returned by `body`.
+    fileprivate func withUnsafeAddress<T, U>(_ body: (_ address: UnsafePointer<U>) -> T) -> T {
+        var storage = self
+        return withUnsafePointer(to: &storage) {
+            $0.withMemoryRebound(to: U.self, capacity: 1) { address in body(address) }
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNSTimer+ClosureKit.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNSTimer+ClosureKit.swift
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+internal typealias CKTimerHandler = (Timer) -> Void
+
+/// Simple closure implementation on NSTimer scheduling.
+///
+/// Example:
+///
+/// ```swift
+/// KronosBlockTimer.scheduledTimer(withTimeInterval: 1.0) { timer in
+///     print("Did something after 1s!")
+/// }
+/// ```
+internal final class KronosBlockTimer: NSObject {
+    /// Creates and returns a block-based NSTimer object and schedules it on the current run loop.
+    ///
+    /// - parameter interval: The number of seconds between firings of the timer.
+    /// - parameter repeated: If true, the timer will repeatedly reschedule itself until invalidated. If
+    ///                       false, the timer will be invalidated after it fires.
+    /// - parameter handler:  The closure that the NSTimer fires.
+    ///
+    /// - returns: A new NSTimer object, configured according to the specified parameters.
+    class func scheduledTimer(
+        withTimeInterval interval: TimeInterval,
+        repeated: Bool = false,
+        handler: @escaping CKTimerHandler
+    ) -> Timer {
+        return Timer.scheduledTimer(
+            timeInterval: interval,
+            target: self,
+            selector: #selector(KronosBlockTimer.invokeFrom(timer:)),
+            userInfo: TimerClosureWrapper(handler: handler, repeats: repeated),
+            repeats: repeated
+        )
+    }
+
+    // MARK: Private methods
+
+    @objc
+    private class func invokeFrom(timer: Timer) {
+        if let closureWrapper = timer.userInfo as? TimerClosureWrapper {
+            closureWrapper.handler(timer)
+        }
+    }
+}
+
+// MARK: - Private classes
+
+private final class TimerClosureWrapper {
+    fileprivate var handler: CKTimerHandler
+    private var repeats: Bool
+
+    init(handler: @escaping CKTimerHandler, repeats: Bool) {
+        self.handler = handler
+        self.repeats = repeats
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPClient.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPClient.swift
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+internal let kronosDefaultTimeout = 6.0
+private let kDefaultSamples = 4
+private let kMaximumNTPServers = 5
+private let kMaximumResultDispersion = 10.0
+
+private typealias ObjCCompletionType = @convention(block) (Data?, TimeInterval) -> Void
+
+/// Exception raised while sending / receiving NTP packets.
+internal enum KronosNTPNetworkError: Error {
+    case noValidNTPPacketFound
+}
+
+/// NTP client session.
+internal final class KronosNTPClient {
+    /// Query the all ips that resolve from the given pool.
+    ///
+    /// - parameter pool:            NTP pool that will be resolved into multiple NTP servers.
+    /// - parameter port:            Server NTP port (default 123).
+    /// - parameter version:         NTP version to use (default 3).
+    /// - parameter numberOfSamples: The number of samples to be acquired from each server (default 4).
+    /// - parameter maximumServers:  The maximum number of servers to be queried (default 5).
+    /// - parameter timeout:         The individual timeout for each of the NTP operations.
+    /// - parameter completion:      A closure that will be response PDU on success or nil on error.
+    func query(
+        pool: String = "time.apple.com",
+        version: Int8 = 3,
+        port: Int = 123,
+        numberOfSamples: Int = kDefaultSamples,
+        maximumServers: Int = kMaximumNTPServers,
+        timeout: CFTimeInterval = kronosDefaultTimeout,
+        progress: @escaping (TimeInterval?, Int, Int) -> Void
+    ) {
+        var servers: [KronosInternetAddress: [KronosNTPPacket]] = [:]
+        var completed: Int = 0
+
+        let queryIPAndStoreResult = { (address: KronosInternetAddress, totalQueries: Int) -> Void in
+            self.query(ip: address, port: port, version: version, timeout: timeout, numberOfSamples: numberOfSamples) { packet in
+                defer {
+                    completed += 1
+
+                    let responses = Array(servers.values)
+                    progress(try? self.offset(from: responses), completed, totalQueries)
+                }
+
+                guard let PDU = packet else {
+                    return
+                }
+
+                if servers[address] == nil {
+                    servers[address] = []
+                }
+
+                servers[address]?.append(PDU)
+            }
+        }
+
+        KronosDNSResolver.resolve(host: pool) { addresses in
+            if addresses.count == 0 {
+                return progress(nil, 0, 0)
+            }
+
+            let totalServers = min(addresses.count, maximumServers)
+            let addressesToQuery = Array(addresses[0 ..< totalServers])
+
+            for address in addressesToQuery {
+                queryIPAndStoreResult(address, totalServers * numberOfSamples)
+            }
+        }
+    }
+
+    /// Query the given NTP server for the time exchange.
+    ///
+    /// - parameter ip:              Server socket address.
+    /// - parameter port:            Server NTP port (default 123).
+    /// - parameter version:         NTP version to use (default 3).
+    /// - parameter timeout:         Timeout on socket operations.
+    /// - parameter numberOfSamples: The number of samples to be acquired from the server (default 4).
+    /// - parameter completion:      A closure that will be response PDU on success or nil on error.
+    func query(
+        ip: KronosInternetAddress,
+        port: Int = 123,
+        version: Int8 = 3,
+        timeout: CFTimeInterval = kronosDefaultTimeout,
+        numberOfSamples: Int = kDefaultSamples,
+        completion: @escaping (KronosNTPPacket?) -> Void
+    ) {
+        var timer: Timer?
+        let bridgeCallback: ObjCCompletionType = { data, destinationTime in
+            defer {
+                // If we still have samples left; we'll keep querying the same server
+                if numberOfSamples > 1 {
+                    self.query(ip: ip, port: port, version: version, timeout: timeout, numberOfSamples: numberOfSamples - 1, completion: completion)
+                }
+            }
+            timer?.invalidate()
+            guard
+                let data = data, let PDU = try? KronosNTPPacket(data: data, destinationTime: destinationTime),
+                PDU.isValidResponse() else
+            {
+                completion(nil)
+                return
+            }
+
+            completion(PDU)
+        }
+
+        let callback = unsafeBitCast(bridgeCallback, to: AnyObject.self)
+        let retainedCallback = Unmanaged.passRetained(callback)
+        let sourceAndSocket = self.sendAsyncUDPQuery(
+            to: ip, port: port, timeout: timeout, completion: UnsafeMutableRawPointer(retainedCallback.toOpaque())
+        )
+
+        timer = KronosBlockTimer.scheduledTimer(withTimeInterval: timeout, repeated: true) { _ in
+            bridgeCallback(nil, TimeInterval.infinity)
+            retainedCallback.release()
+
+            if let (source, socket) = sourceAndSocket {
+                CFSocketInvalidate(socket)
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, CFRunLoopMode.commonModes)
+            }
+        }
+    }
+
+    // MARK: - Private helpers (NTP Calculation)
+
+    private func offset(from responses: [[KronosNTPPacket]]) throws -> TimeInterval {
+        let now = kronosCurrentTime()
+        var bestResponses: [KronosNTPPacket] = []
+        for serverResponses in responses {
+            let filtered = serverResponses
+                .filter { abs($0.originTime - now) < kMaximumResultDispersion }
+                .min { $0.delay < $1.delay }
+
+            if let filtered = filtered {
+                bestResponses.append(filtered)
+            }
+        }
+
+        if bestResponses.count == 0 {
+            throw KronosNTPNetworkError.noValidNTPPacketFound
+        }
+
+        bestResponses.sort { $0.offset < $1.offset }
+        return bestResponses[bestResponses.count / 2].offset
+    }
+
+    // MARK: - Private helpers (CFSocket)
+
+    private func sendAsyncUDPQuery(
+        to ip: KronosInternetAddress,
+        port: Int,
+        timeout: TimeInterval,
+        completion: UnsafeMutableRawPointer
+    ) -> (CFRunLoopSource, CFSocket)? {
+        signal(SIGPIPE, SIG_IGN)
+
+        let callback: CFSocketCallBack = { socket, callbackType, _, data, info in
+            if callbackType == .writeCallBack {
+                var packet = KronosNTPPacket()
+                let PDU = packet.prepareToSend() as CFData
+                CFSocketSendData(socket, nil, PDU, kronosDefaultTimeout)
+                return
+            }
+
+            guard let info = info else {
+                return
+            }
+
+            CFSocketInvalidate(socket)
+
+            let destinationTime = kronosCurrentTime()
+            let retainedClosure = Unmanaged<AnyObject>.fromOpaque(info)
+            let completion = unsafeBitCast(retainedClosure.takeUnretainedValue(), to: ObjCCompletionType.self)
+
+            let data = unsafeBitCast(data, to: CFData.self) as Data?
+            completion(data, destinationTime)
+            retainedClosure.release()
+        }
+
+        let types = CFSocketCallBackType.dataCallBack.rawValue | CFSocketCallBackType.writeCallBack.rawValue
+        var context = CFSocketContext(version: 0, info: completion, retain: nil, release: nil, copyDescription: nil)
+        guard let socket = CFSocketCreate(nil, ip.family, SOCK_DGRAM, IPPROTO_UDP, types, callback, &context),
+                CFSocketIsValid(socket) else {
+            return nil
+        }
+
+        let runLoopSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, socket, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, CFRunLoopMode.commonModes)
+        CFSocketConnectToAddress(socket, ip.addressData(withPort: port), timeout)
+        return (runLoopSource!, socket) // swiftlint:disable:this force_unwrapping
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPPacket.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPPacket.swift
@@ -1,0 +1,207 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+/// Delta between system and NTP time
+private let kEpochDelta = 2_208_988_800.0
+
+/// This is the maximum that we'll tolerate for the client's time vs self.delay
+private let kMaximumDelayDifference = 0.1
+private let kMaximumDispersion = 100.0
+
+/// Returns the current time in decimal EPOCH timestamp format.
+///
+/// - returns: The current time in EPOCH timestamp format.
+internal func kronosCurrentTime() -> TimeInterval {
+    var current = timeval()
+    let systemTimeError = gettimeofday(&current, nil) != 0
+    assert(!systemTimeError, "system clock error: system time unavailable")
+
+    return Double(current.tv_sec) + Double(current.tv_usec) / 1_000_000
+}
+
+internal struct KronosNTPPacket {
+    /// The leap indicator warning of an impending leap second to be inserted or deleted in the last
+    /// minute of the current month.
+    let leap: KronosLeapIndicator
+
+    /// Version Number (VN): This is a three-bit integer indicating the NTP version number, currently 3.
+    let version: Int8
+
+    /// The current connection mode.
+    let mode: KronosMode
+
+    /// Mode representing the stratum level of the local clock.
+    let stratum: KronosStratum
+
+    /// Indicates the maximum interval between successive messages, in seconds to the nearest power of two.
+    /// The values that normally appear in this field range from 6 to 10, inclusive.
+    let poll: Int8
+
+    /// The precision of the local clock, in seconds to the nearest power of two. The values that normally
+    /// appear in this field range from -6 for mains-frequency clocks to -18 for microsecond clocks found
+    /// in some workstations.
+    let precision: Int8
+
+    /// The total roundtrip delay to the primary reference source, in seconds with fraction point between
+    /// bits 15 and 16. Note that this variable can take on both positive and negative values, depending on
+    /// the relative time and frequency errors. The values that normally appear in this field range from
+    /// negative values of a few milliseconds to positive values of several hundred milliseconds.
+    let rootDelay: TimeInterval
+
+    /// Total dispersion to the reference clock, in EPOCH.
+    let rootDispersion: TimeInterval
+
+    /// Server or reference clock. This value is generated based on a reference identifier maintained by IANA.
+    let clockSource: KronosClockSource
+
+    /// Time when the system clock was last set or corrected, in EPOCH timestamp format.
+    let referenceTime: TimeInterval
+
+    /// Time at the client when the request departed for the server, in EPOCH timestamp format.
+    let originTime: TimeInterval
+
+    /// Time at the server when the request arrived from the client, in EPOCH timestamp format.
+    let receiveTime: TimeInterval
+
+    /// Time at the server when the response left for the client, in EPOCH timestamp format.
+    var transmitTime: TimeInterval = 0.0
+
+    /// Time at the client when the response arrived, in EPOCH timestamp format.
+    let destinationTime: TimeInterval
+
+    /// NTP protocol package representation.
+    ///
+    /// - parameter transmitTime: Packet transmission timestamp.
+    /// - parameter version:      NTP protocol version.
+    /// - parameter mode:         Packet mode (client, server).
+    init(version: Int8 = 3, mode: KronosMode = .client) {
+        self.version = version
+        self.leap = .noWarning
+        self.mode = mode
+        self.stratum = .unspecified
+        self.poll = 4
+        self.precision = -6
+        self.rootDelay = 1
+        self.rootDispersion = 1
+        self.clockSource = .referenceIdentifier(id: 0)
+        self.referenceTime = -kEpochDelta
+        self.originTime = -kEpochDelta
+        self.receiveTime = -kEpochDelta
+        self.destinationTime = -1
+    }
+
+    /// Creates a NTP package based on a network PDU.
+    ///
+    /// - parameter data:            The PDU received from the NTP call.
+    /// - parameter destinationTime: The time where the package arrived (client time) in EPOCH format.
+    /// - throws:                    KronosNTPParsingError in case of an invalid response.
+    init(data: Data, destinationTime: TimeInterval) throws {
+        if data.count < 48 {
+            throw KronosNTPParsingError.invalidNTPPDU("Invalid PDU length: \(data.count)")
+        }
+
+        self.leap = KronosLeapIndicator(rawValue: (data.getByte(at: 0) >> 6) & 0b11) ?? .noWarning
+        self.version = data.getByte(at: 0) >> 3 & 0b111
+        self.mode = KronosMode(rawValue: data.getByte(at: 0) & 0b111) ?? .unknown
+        self.stratum = KronosStratum(value: data.getByte(at: 1))
+        self.poll = data.getByte(at: 2)
+        self.precision = data.getByte(at: 3)
+        self.rootDelay = KronosNTPPacket.intervalFromNTPFormat(data.getUnsignedInteger(at: 4))
+        self.rootDispersion = KronosNTPPacket.intervalFromNTPFormat(data.getUnsignedInteger(at: 8))
+        self.clockSource = KronosClockSource(stratum: self.stratum, sourceID: data.getUnsignedInteger(at: 12))
+        self.referenceTime = KronosNTPPacket.dateFromNTPFormat(data.getUnsignedLong(at: 16))
+        self.originTime = KronosNTPPacket.dateFromNTPFormat(data.getUnsignedLong(at: 24))
+        self.receiveTime = KronosNTPPacket.dateFromNTPFormat(data.getUnsignedLong(at: 32))
+        self.transmitTime = KronosNTPPacket.dateFromNTPFormat(data.getUnsignedLong(at: 40))
+        self.destinationTime = destinationTime
+    }
+
+    /// Convert this NTPPacket to a buffer that can be sent over a socket.
+    ///
+    /// - returns: A bytes buffer representing this packet.
+    mutating func prepareToSend(transmitTime: TimeInterval? = nil) -> Data {
+        var data = Data()
+        data.append(byte: self.leap.rawValue << 6 | self.version << 3 | self.mode.rawValue)
+        data.append(byte: self.stratum.rawValue)
+        data.append(byte: self.poll)
+        data.append(byte: self.precision)
+        data.append(unsignedInteger: self.intervalToNTPFormat(self.rootDelay))
+        data.append(unsignedInteger: self.intervalToNTPFormat(self.rootDispersion))
+        data.append(unsignedInteger: self.clockSource.ID)
+        data.append(unsignedLong: self.dateToNTPFormat(self.referenceTime))
+        data.append(unsignedLong: self.dateToNTPFormat(self.originTime))
+        data.append(unsignedLong: self.dateToNTPFormat(self.receiveTime))
+
+        self.transmitTime = transmitTime ?? kronosCurrentTime()
+        data.append(unsignedLong: self.dateToNTPFormat(self.transmitTime))
+        return data
+    }
+
+    /// Checks properties to make sure that the received PDU is a valid response that we can use.
+    ///
+    /// - returns: A boolean indicating if the response is valid for the given version.
+    func isValidResponse() -> Bool {
+        return (self.mode == .server || self.mode == .symmetricPassive) && self.leap != .alarm
+            && self.stratum != .invalid && self.stratum != .unspecified
+            && self.rootDispersion < kMaximumDispersion
+            && abs(kronosCurrentTime() - self.originTime - self.delay) < kMaximumDelayDifference
+    }
+
+    // MARK: - Private helpers
+
+    private func dateToNTPFormat(_ time: TimeInterval) -> UInt64 {
+        let integer = UInt32(time + kEpochDelta)
+        let decimal = modf(time).1 * 4_294_967_296.0 // 2 ^ 32
+        return UInt64(integer) << 32 | UInt64(decimal)
+    }
+
+    private func intervalToNTPFormat(_ time: TimeInterval) -> UInt32 {
+        let integer = UInt16(time)
+        let decimal = modf(time).1 * 65_536 // 2 ^ 16
+        return UInt32(integer) << 16 | UInt32(decimal)
+    }
+
+    private static func dateFromNTPFormat(_ time: UInt64) -> TimeInterval {
+        let integer = Double(time >> 32)
+        let decimal = Double(time & 0xffffffff) / 4_294_967_296.0
+        return integer - kEpochDelta + decimal
+    }
+
+    private static func intervalFromNTPFormat(_ time: UInt32) -> TimeInterval {
+        let integer = Double(time >> 16)
+        let decimal = Double(time & 0xffff) / 65_536
+        return integer + decimal
+    }
+}
+
+/// From RFC 2030 (with a correction to the delay math):
+///
+/// Timestamp Name          ID   When Generated
+/// ------------------------------------------------------------
+/// Originate Timestamp     T1   time request sent by client
+/// Receive Timestamp       T2   time request received by server
+/// Transmit Timestamp      T3   time reply sent by server
+/// Destination Timestamp   T4   time reply received by client
+///
+/// The roundtrip delay d and local clock offset t are defined as
+///
+/// d = (T4 - T1) - (T3 - T2)     t = ((T2 - T1) + (T3 - T4)) / 2.
+extension KronosNTPPacket {
+    /// Clocks offset in seconds.
+    var offset: TimeInterval {
+        return ((self.receiveTime - self.originTime) + (self.transmitTime - self.destinationTime)) / 2.0
+    }
+
+    /// Round-trip delay in seconds
+    var delay: TimeInterval {
+        return (self.destinationTime - self.originTime) - (self.transmitTime - self.receiveTime)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPProtocol.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosNTPProtocol.swift
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+/// Exception raised when the received PDU is invalid.
+internal enum KronosNTPParsingError: Error {
+    case invalidNTPPDU(String)
+}
+
+/// The leap indicator warning of an impending leap second to be inserted or deleted in the last minute of the
+/// current month.
+internal enum KronosLeapIndicator: Int8 {
+    case noWarning, sixtyOneSeconds, fiftyNineSeconds, alarm
+
+    /// Human readable value of the leap warning.
+    var description: String {
+        switch self {
+        case .noWarning:
+            return "No warning"
+        case .sixtyOneSeconds:
+            return "Last minute of the day has 61 seconds"
+        case .fiftyNineSeconds:
+            return "Last minute of the day has 59 seconds"
+        case .alarm:
+            return "Unknown (clock unsynchronized)"
+        }
+    }
+}
+
+/// The connection mode.
+internal enum KronosMode: Int8 {
+    case reserved, symmetricActive, symmetricPassive, client, server, broadcast, reservedNTP, unknown
+}
+
+/// Mode representing the stratum level of the clock.
+internal enum KronosStratum: Int8 {
+    case unspecified, primary, secondary, invalid
+
+    init(value: Int8) {
+        switch value {
+        case 0:
+            self = .unspecified
+
+        case 1:
+            self = .primary
+
+        case 0 ..< 15:
+            self = .secondary
+
+        default:
+            self = .invalid
+        }
+    }
+}
+
+/// Server or reference clock. This value is generated based on the server stratum.
+///
+/// - ReferenceClock:          Contains the sourceID and the description for the reference clock (stratum 1).
+/// - Debug(id):               Contains the kiss code for debug purposes (stratum 0).
+/// - ReferenceIdentifier(id): The reference identifier of the server (stratum > 1).
+internal enum KronosClockSource {
+    case referenceClock(id: UInt32, description: String)
+    case debug(id: UInt32)
+    case referenceIdentifier(id: UInt32)
+
+    init(stratum: KronosStratum, sourceID: UInt32) {
+        switch stratum {
+        case .unspecified:
+            self = .debug(id: sourceID)
+
+        case .primary:
+            let (id, description) = KronosClockSource.description(fromID: sourceID)
+            self = .referenceClock(id: id, description: description)
+
+        case .secondary, .invalid:
+            self = .referenceIdentifier(id: sourceID)
+        }
+    }
+
+    /// The id for the reference clock (IANA, stratum 1), debug (stratum 0) or referenceIdentifier
+    var ID: UInt32 {
+        switch self {
+        case .referenceClock(let id, _):
+            return id
+
+        case .debug(let id):
+            return id
+
+        case .referenceIdentifier(let id):
+            return id
+        }
+    }
+
+    private static func description(fromID sourceID: UInt32) -> (UInt32, String) {
+        let sourceMap: [UInt32: String] = [
+            0x47505300: "Global Position System",
+            0x47414c00: "Galileo Positioning System",
+            0x50505300: "Generic pulse-per-second",
+            0x49524947: "Inter-Range Instrumentation Group",
+            0x57575642: "LF Radio WWVB Ft. Collins, CO 60 kHz",
+            0x44434600: "LF Radio DCF77 Mainflingen, DE 77.5 kHz",
+            0x48424700: "LF Radio HBG Prangins, HB 75 kHz",
+            0x4d534600: "LF Radio MSF Anthorn, UK 60 kHz",
+            0x4a4a5900: "LF Radio JJY Fukushima, JP 40 kHz, Saga, JP 60 kHz",
+            0x4c4f5243: "MF Radio LORAN C station, 100 kHz",
+            0x54444600: "MF Radio Allouis, FR 162 kHz",
+            0x43485500: "HF Radio CHU Ottawa, Ontario",
+            0x57575600: "HF Radio WWV Ft. Collins, CO",
+            0x57575648: "HF Radio WWVH Kauai, HI",
+            0x4e495354: "NIST telephone modem",
+            0x41435453: "ACTS telephone modem",
+            0x55534e4f: "USNO telephone modem",
+            0x50544200: "European telephone modem",
+            0x4c4f434c: "Uncalibrated local clock",
+            0x4345534d: "Calibrated Cesium clock",
+            0x5242444d: "Calibrated Rubidium clock",
+            0x4f4d4547: "OMEGA radio navigation system",
+            0x44434e00: "DCN routing protocol",
+            0x54535000: "TSP time protocol",
+            0x44545300: "Digital Time Service",
+            0x41544f4d: "Atomic clock (calibrated)",
+            0x564c4600: "VLF radio (OMEGA,, etc.)",
+            0x31505053: "External 1 PPS input",
+            0x46524545: "(Internal clock)",
+            0x494e4954: "(Initialization)",
+        ]
+
+        return (sourceID, sourceMap[sourceID] ?? "NULL")
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosTimeFreeze.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosTimeFreeze.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+private let kUptimeKey = "Uptime"
+private let kTimestampKey = "Timestamp"
+private let kOffsetKey = "Offset"
+
+internal struct KronosTimeFreeze {
+    private let uptime: TimeInterval
+    private let timestamp: TimeInterval
+    private let offset: TimeInterval
+
+    /// The stable timestamp adjusted by the most accurate offset known so far.
+    var adjustedTimestamp: TimeInterval {
+        return self.offset + self.stableTimestamp
+    }
+
+    /// The stable timestamp (calculated based on the uptime); note that this doesn't have sub-seconds
+    /// precision. See `systemUptime()` for more information.
+    var stableTimestamp: TimeInterval {
+        return (KronosTimeFreeze.systemUptime() - self.uptime) + self.timestamp
+    }
+
+    /// Time interval between now and the time the NTP response represented by this TimeFreeze was received.
+    var timeSinceLastNtpSync: TimeInterval {
+        return KronosTimeFreeze.systemUptime() - uptime
+    }
+
+    init(offset: TimeInterval) {
+        self.offset = offset
+        self.timestamp = kronosCurrentTime()
+        self.uptime = KronosTimeFreeze.systemUptime()
+    }
+
+    init?(from dictionary: [String: TimeInterval]) {
+        guard let uptime = dictionary[kUptimeKey],
+              let timestamp = dictionary[kTimestampKey],
+              let offset = dictionary[kOffsetKey] else {
+            return nil
+        }
+
+        let currentUptime = KronosTimeFreeze.systemUptime()
+        let currentTimestamp = kronosCurrentTime()
+        let currentBoot = currentUptime - currentTimestamp
+        let previousBoot = uptime - timestamp
+        if rint(currentBoot) - rint(previousBoot) != 0 {
+            return nil
+        }
+
+        self.uptime = uptime
+        self.timestamp = timestamp
+        self.offset = offset
+    }
+
+    /// Convert this TimeFreeze to a dictionary representation.
+    ///
+    /// - returns: A dictionary representation.
+    func toDictionary() -> [String: TimeInterval] {
+        return [
+            kUptimeKey: self.uptime,
+            kTimestampKey: self.timestamp,
+            kOffsetKey: self.offset,
+        ]
+    }
+
+    /// Returns a high-resolution measurement of system uptime, that continues ticking through device sleep
+    /// *and* user- or system-generated clock adjustments. This allows for stable differences to be calculated
+    /// between timestamps.
+    ///
+    /// Note: Due to an issue in BSD/darwin, sub-second precision will be lost;
+    /// see: https://github.com/darwin-on-arm/xnu/blob/master/osfmk/kern/clock.c#L522.
+    ///
+    /// - returns: An Int measurement of system uptime in microseconds.
+    static func systemUptime() -> TimeInterval {
+        var mib = [CTL_KERN, KERN_BOOTTIME]
+        var size = MemoryLayout<timeval>.stride
+        var bootTime = timeval()
+
+        let bootTimeError = sysctl(&mib, u_int(mib.count), &bootTime, &size, nil, 0) != 0
+        assert(!bootTimeError, "system clock error: kernel boot time unavailable")
+
+        let now = kronosCurrentTime()
+        let uptime = Double(bootTime.tv_sec) + Double(bootTime.tv_usec) / 1_000_000
+        assert(now >= uptime, "inconsistent clock state: system time precedes boot time")
+
+        return now - uptime
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosTimeStorage.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Kronos/KronosTimeStorage.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by MobileNativeFoundation, https://mobilenativefoundation.org and altered by Datadog.
+ * Use of this source code is governed by Apache License 2.0 license: https://github.com/MobileNativeFoundation/Kronos/blob/main/LICENSE
+ */
+
+import Foundation
+
+/// Defines where the user defaults are stored
+internal enum KronosTimeStoragePolicy {
+    /// Uses `UserDefaults.Standard`
+    case standard
+    /// Attempts to use the specified App Group ID (which is the String) to access shared storage.
+    case appGroup(String)
+
+    /// Creates an instance
+    ///
+    /// - parameter appGroupID: The App Group ID that maps to a shared container for `UserDefaults`. If this
+    ///                         is nil, the resulting instance will be `.standard`
+    init(appGroupID: String?) {
+        if let appGroupID = appGroupID {
+            self = .appGroup(appGroupID)
+        } else {
+            self = .standard
+        }
+    }
+}
+
+/// Handles saving and retrieving instances of `KronosTimeFreeze` for quick retrieval
+internal struct KronosTimeStorage {
+    private var userDefaults: UserDefaults
+    private let kDefaultsKey = "KronosStableTime"
+
+    /// The most recent stored `TimeFreeze`. Getting retrieves from the UserDefaults defined by the storage
+    /// policy. Setting sets the value in UserDefaults
+    var stableTime: KronosTimeFreeze? {
+        get {
+            guard let stored = self.userDefaults.value(forKey: kDefaultsKey) as? [String: TimeInterval],
+                let previousStableTime = KronosTimeFreeze(from: stored) else {
+                return nil
+            }
+
+            return previousStableTime
+        }
+
+        set {
+            guard let newFreeze = newValue else {
+                return
+            }
+
+            self.userDefaults.set(newFreeze.toDictionary(), forKey: kDefaultsKey)
+        }
+    }
+
+    /// Creates an instance
+    ///
+    /// - parameter storagePolicy: Defines the storage location of `UserDefaults`
+    init(storagePolicy: KronosTimeStoragePolicy) {
+        switch storagePolicy {
+        case .standard:
+            self.userDefaults = .standard
+        case .appGroup(let groupName):
+            let sharedDefaults = UserDefaults(suiteName: groupName)
+            assert(sharedDefaults != nil, "Could not create UserDefaults for group: '\(groupName)'")
+            self.userDefaults = sharedDefaults ?? .standard
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/PerformancePreset.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/PerformancePreset.swift
@@ -1,0 +1,157 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal protocol StoragePerformancePreset {
+    /// Maximum size of a single file (in bytes).
+    /// Each feature (logging, tracing, ...) serializes its objects data to that file for later upload.
+    /// If last written file is too big to append next data, new file is created.
+    var maxFileSize: UInt64 { get }
+    /// Maximum size of data directory (in bytes).
+    /// Each feature uses separate directory.
+    /// If this size is exceeded, the oldest files are deleted until this limit is met again.
+    var maxDirectorySize: UInt64 { get }
+    /// Maximum age qualifying given file for reuse (in seconds).
+    /// If recently used file is younger than this, it is reused - otherwise: new file is created.
+    var maxFileAgeForWrite: TimeInterval { get }
+    /// Minimum age qualifying given file for upload (in seconds).
+    /// If the file is older than this, it is uploaded (and then deleted if upload succeeded).
+    /// It has an arbitrary offset  (~0.5s) over `maxFileAgeForWrite` to ensure that no upload can start for the file being currently written.
+    var minFileAgeForRead: TimeInterval { get }
+    /// Maximum age qualifying given file for upload (in seconds).
+    /// Files older than this are considered obsolete and get deleted without uploading.
+    var maxFileAgeForRead: TimeInterval { get }
+    /// Maximum number of serialized objects written to a single file.
+    /// If number of objects in recently used file reaches this limit, new file is created for new data.
+    var maxObjectsInFile: Int { get }
+    /// Maximum size of serialized object data (in bytes).
+    /// If serialized object data exceeds this limit, it is skipped (not written to file and not uploaded).
+    var maxObjectSize: UInt64 { get }
+}
+
+internal extension StoragePerformancePreset {
+    /// The uploader window duration determines when a file is considered "ready for upload" by the uploader after the last write.
+    ///
+    /// This value is crucial for computing batching and upload metrics within the SDK (see RUMM-3459). The uploader window is derived from the
+    /// original `batchSize` value, which is either configured by the user or set as an internal override. The `batchSize` represents the age of
+    /// "batch maturity" for uploads and is specified in seconds.
+    ///
+    /// The uploader window is calculated as the average of two key parameters: `minFileAgeForRead` and `maxFileAgeForWrite`. Batches younger
+    /// than `maxFileAgeForWrite` are considered "writable" (available for the writer), while batches older than `minFileAgeForRead` are
+    /// meant to be "readable" (available for the uploader). To ensure that the writer and uploader don't access the same batch simultaneously,
+    /// a safe-guard window (10% of `batchSize`) is implemented within which the batch is neither writable nor readable.
+    var uploaderWindow: TimeInterval { (minFileAgeForRead + maxFileAgeForWrite) * 0.5 }
+}
+
+internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPerformancePreset {
+    // MARK: - StoragePerformancePreset
+
+    let maxFileSize: UInt64
+    let maxDirectorySize: UInt64
+    let maxFileAgeForWrite: TimeInterval
+    let minFileAgeForRead: TimeInterval
+    let maxFileAgeForRead: TimeInterval
+    let maxObjectsInFile: Int
+    let maxObjectSize: UInt64
+
+    // MARK: - UploadPerformancePreset
+
+    let initialUploadDelay: TimeInterval
+    let minUploadDelay: TimeInterval
+    let maxUploadDelay: TimeInterval
+    let uploadDelayChangeRate: Double
+}
+
+internal extension PerformancePreset {
+    init(
+        batchSize: Datadog.Configuration.BatchSize,
+        uploadFrequency: Datadog.Configuration.UploadFrequency,
+        bundleType: BundleType
+    ) {
+        let meanFileAgeInSeconds: TimeInterval = {
+            switch (bundleType, batchSize) {
+            case (.iOSApp, .small): return 5
+            case (.iOSApp, .medium): return 15
+            case (.iOSApp, .large): return 60
+            case (.iOSAppExtension, .small): return 1
+            case (.iOSAppExtension, .medium): return 3
+            case (.iOSAppExtension, .large): return 12
+            }
+        }()
+
+        let minUploadDelayInSeconds: TimeInterval = {
+            switch (bundleType, uploadFrequency) {
+            case (.iOSApp, .frequent): return 1
+            case (.iOSApp, .average): return 5
+            case (.iOSApp, .rare): return 10
+            case (.iOSAppExtension, .frequent): return 0.5
+            case (.iOSAppExtension, .average): return 1
+            case (.iOSAppExtension, .rare): return 5
+            }
+        }()
+
+        let uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double) = {
+            switch bundleType {
+            case .iOSApp:
+                return (
+                    initial: 5,
+                    min: 1,
+                    max: 10,
+                    changeRate: 0.1
+                )
+            case .iOSAppExtension:
+                return (
+                    initial: 0.5, // ensures the the first upload is checked quickly after starting the short-lived app extension
+                    min: 1,
+                    max: 5,
+                    changeRate: 0.5 // if batches are found, reduces interval significantly for more uploads in short-lived app extension
+                )
+            }
+        }()
+
+        self.init(
+            meanFileAge: meanFileAgeInSeconds,
+            minUploadDelay: minUploadDelayInSeconds,
+            uploadDelayFactors: uploadDelayFactors
+        )
+    }
+
+    init(
+        meanFileAge: TimeInterval,
+        minUploadDelay: TimeInterval,
+        uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double)
+    ) {
+        self.maxFileSize = UInt64(4).MB
+        self.maxDirectorySize = UInt64(512).MB
+        self.maxFileAgeForWrite = meanFileAge * 0.95 // 5% below the mean age
+        self.minFileAgeForRead = meanFileAge * 1.05 //  5% above the mean age
+        self.maxFileAgeForRead = 18.hours
+        self.maxObjectsInFile = 500
+        self.maxObjectSize = UInt64(512).KB
+        self.initialUploadDelay = minUploadDelay * uploadDelayFactors.initial
+        self.minUploadDelay = minUploadDelay * uploadDelayFactors.min
+        self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
+        self.uploadDelayChangeRate = uploadDelayFactors.changeRate
+    }
+
+    func updated(with override: PerformancePresetOverride) -> PerformancePreset {
+        return PerformancePreset(
+            maxFileSize: override.maxFileSize ?? maxFileSize,
+            maxDirectorySize: maxDirectorySize,
+            maxFileAgeForWrite: override.maxFileAgeForWrite ?? maxFileAgeForWrite,
+            minFileAgeForRead: override.minFileAgeForRead ?? minFileAgeForRead,
+            maxFileAgeForRead: maxFileAgeForRead,
+            maxObjectsInFile: maxObjectsInFile,
+            maxObjectSize: override.maxObjectSize ?? maxObjectSize,
+            initialUploadDelay: override.initialUploadDelay ?? initialUploadDelay,
+            minUploadDelay: override.minUploadDelay ?? minUploadDelay,
+            maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
+            uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Utils/CoreMetrics.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Utils/CoreMetrics.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Common definitions for batch telemetries.
+internal enum BatchMetric {
+    /// Metric type key.
+    static let typeKey = "metric_type"
+    /// Track name key
+    static let trackKey = "track"
+    /// Track name value.
+    /// Returns the corresponding track value based on the given feature name.
+    static func trackValue(for featureName: String) -> String? {
+        switch featureName {
+        case "rum":             return "rum"
+        case "logging":         return "logs"
+        case "tracing":         return "trace"
+        case "session-replay":  return "sr"
+        default:                return nil
+        }
+    }
+}
+
+/// Definition of "Batch Deleted" telemetry.
+internal enum BatchDeletedMetric {
+    /// The name of this metric, included in telemetry log.
+    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+    static let name = "Batch Deleted"
+    /// Metric type value.
+    static let typeValue = "batch deleted"
+    /// The key for uploader's delay options.
+    static let uploaderDelayKey = "uploader_delay"
+    /// The min delay of uploads for this track (in ms).
+    static let uploaderDelayMinKey = "min"
+    /// The min delay of uploads for this track (in ms).
+    static let uploaderDelayMaxKey = "max"
+    /// The default duration since last write (in ms) after which the uploader considers the file to be "ready for upload".
+    static let uploaderWindowKey = "uploader_window"
+
+    /// The duration from batch creation to batch deletion (in ms).
+    static let batchAgeKey = "batch_age"
+    /// The reason of batch deletion.
+    static let batchRemovalReasonKey = "batch_removal_reason"
+    /// If the batch was deleted in the background.
+    static let inBackgroundKey = "in_background"
+
+    /// Allowed values for `batchRemovalReasonKey`.
+    enum RemovalReason {
+        /// The batch was delivered to Intake and deleted upon receiving given `responseCode`.
+        ///
+        /// The intake-code-202 represents a successful delivery. While some status codes, such as 401, indicate unrecoverable
+        /// user errors, others, like 400, will indicate faults within the SDK. It is important to note that not all status codes will appear
+        /// in this field, as the SDKs implement retry mechanisms for certain codes, e.g. 503 (see: ``DataUploadStatus``).
+        case intakeCode(responseCode: Int)
+        /// The batch become obsolete (older than allowed limit for this track's intake).
+        case obsolete
+        /// The batch was deleted due to exceeding allowed max size for batches directory.
+        case purged
+        /// The feature failed to create request for that batch (e.g. data was malformed).
+        case invalid
+        /// The batch was deleted arbitrarily without considering its delivery status. This option is only used in test logic
+        /// and we don't send "Batch Deleted" metric for this case.
+        case flushed
+
+        /// Converts the removal reason to the string value expected for `batchRemovalReasonKey`.
+        func toString() -> String {
+            switch self {
+            case .intakeCode(let responseCode):
+                return "intake-code-\(responseCode)"
+            case .obsolete:
+                return "obsolete"
+            case .purged:
+                return "purged"
+            case .invalid:
+                return "invalid"
+            case .flushed:
+                return "flushed"
+            }
+        }
+
+        /// Indicates whether the metric should be sent for this removal reason.
+        var includeInMetric: Bool {
+            switch self {
+            case .intakeCode, .obsolete, .purged, .invalid:
+                return true
+            case .flushed:
+                return false
+            }
+        }
+    }
+}
+
+/// Definition of "Batch Closed" telemetry.
+internal enum BatchClosedMetric {
+    /// The name of this metric, included in telemetry log.
+    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+    static let name = "Batch Closed"
+    /// Metric type value.
+    static let typeValue = "batch closed"
+    /// The default duration since last write (in ms) after which the uploader considers the file to be "ready for upload".
+    static let uploaderWindowKey = "uploader_window"
+
+    /// The size of batch at closing (in bytes).
+    static let batchSizeKey = "batch_size"
+    /// The number of events written to this batch before closing.
+    static let batchEventsCountKey = "batch_events_count"
+    /// The duration from batch creation to batch closing (in ms).
+    static let batchDurationKey = "batch_duration"
+    /// If the batch was closed by core or after new batch was forced by the feature.
+    static let forcedNewKey = "forced_new"
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Utils/Cryptography.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Utils/Cryptography.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import CommonCrypto
+
+/// Computes SHA256 for given `string`.
+internal func sha256(_ string: String) -> String {
+    guard let data = string.data(using: .utf8) else {
+        return string
+    }
+
+    var digest: [UInt8] = Array(repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    _ = data.withUnsafeBytes { CC_SHA256($0.baseAddress, UInt32(data.count), &digest) }
+    return digest
+        .map({ byte in String(format: "%02x", byte) })
+        .joined(separator: "")
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Utils/Globals.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Utils/Globals.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if SPM_BUILD
+import DatadogPrivateFork
+#endif
+
+/// Exception handler rethrowing `NSExceptions` to Swift `NSError`.
+internal var objcExceptionHandler = __fork_dd_private_ObjcExceptionHandler()

--- a/Sources/ForageSDK/Vendor/DatadogCore/Utils/Retrying.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Utils/Retrying.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Retries given `block` several `times` in predefined `delay` until it does not throw an error.
+/// If all tries resulted with error, the last `Error` is thrown from this function.
+internal func retry<R>(times: UInt, delay: TimeInterval, block: () throws -> R) throws -> R {
+    for _ in (1..<times) {
+        do {
+            return try block()
+        } catch {
+            Thread.sleep(forTimeInterval: delay)
+        }
+    }
+
+    return try block()
+}

--- a/Sources/ForageSDK/Vendor/DatadogCore/Versioning.swift
+++ b/Sources/ForageSDK/Vendor/DatadogCore/Versioning.swift
@@ -1,0 +1,3 @@
+// GENERATED FILE: Do not edit directly
+
+internal let __sdkVersion = "2.1.0"

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Attributes/Attributes.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Attributes/Attributes.swift
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A `String` value naming the attribute.
+///
+/// Dot syntax can be used to nest objects:
+///
+///     logger.addAttribute(forKey: "person.name", value: "Adam")
+///     logger.addAttribute(forKey: "person.age", value: 32)
+///
+///     // When seen in Datadog console:
+///     {
+///         person: {
+///             name: "Adam"
+///             age: 32
+///         }
+///     }
+///
+/// - Important
+/// Values can be nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by the SDK.
+///
+public typealias AttributeKey = String
+
+/// Any `Encodable` value of the attribute (`String`, `Int`, `Bool`, `Date` etc.).
+///
+/// Custom `Encodable` types are supported as well with nested encoding containers:
+///
+///     struct Person: Codable {
+///         let name: String
+///         let age: Int
+///         let address: Address
+///     }
+///
+///     struct Address: Codable {
+///         let city: String
+///         let street: String
+///     }
+///
+///     let address = Address(city: "Paris", street: "Champs Elysees")
+///     let person = Person(name: "Adam", age: 32, address: address)
+///
+///     // When seen in Datadog console:
+///     {
+///         person: {
+///             name: "Adam"
+///             age: 32
+///             address: {
+///                 city: "Paris",
+///                 street: "Champs Elysees"
+///             }
+///         }
+///     }
+///
+/// - Important
+/// Attributes in Datadog console can be nested up to 10 levels deep. If number of nested attribute levels
+/// defined as sum of key levels and value levels exceeds 10, the data may not be delivered.
+///
+public typealias AttributeValue = Encodable
+
+// MARK: - Internal attributes
+
+/// Internal attributes, passed from cross-platform bridge.
+/// Used to configure or override SDK internal features and attributes for the need of cross-platform SDKs (e.g. React Native SDK).
+public struct CrossPlatformAttributes {
+    /// Custom app version passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `version` read from `Info.plist`.
+    /// Expects `String` value (semantic version).
+    public static let version: String = "_dd.version"
+
+    /// Custom SDK version passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `sdkVersion`.
+    /// Expects `String` value (semantic version).
+    public static let sdkVersion: String = "_dd.sdk_version"
+
+    /// Custom SDK `source` passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `ddsource` value (`"ios"`).
+    /// Expects `String` value.
+    public static let ddsource: String = "_dd.source"
+
+    /// Custom Variant passed from a CP SDK. This is the 'flavor' parameter used in Android and Flutter, Used for all events issued by the SDK (both coming from cross-platform
+    /// SDK and produced internally, like RUM long tasks).
+    /// It does not replace any default native properties as iOS does not have the concept of 'flavors' or variants.
+    public static let variant: String = "_dd.variant"
+
+    /// Event timestamp passed from CP SDK. Used for all RUM events issued by cross platform SDK.
+    /// It should replace event time obtained from `DateProvider` to ensure that events are not skewed due to time difference in native and cross-platform SDKs.
+    /// Expects `Int64` value (milliseconds).
+    public static let timestampInMilliseconds = "_dd.timestamp"
+
+    /// Custom "source type" of the error passed from CP SDK. Used in RUM errors reported by cross platform SDK.
+    /// It names the language or platform of the RUM error stack trace, so the SCI backend knows how to symbolicate it.
+    /// Expects `String` value.
+    public static let errorSourceType = "_dd.error.source_type"
+
+    /// Custom attribute of the error passed from CP SDK. Used in RUM errors reported by cross platform SDK.
+    /// It flags the error has being fatal for the host application.
+    /// Expects `Bool` value.
+    public static let errorIsCrash = "_dd.error.is_crash"
+
+    /// Trace ID passed from CP SDK. Used in RUM resources created by cross platform SDK.
+    /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
+    /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
+    /// Expects `String` value.
+    public static let traceID = "_dd.trace_id"
+
+    /// Span ID passed from CP SDK. Used in RUM resources created by cross platform SDK.
+    /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
+    /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
+    /// Expects `String` value.
+    public static let spanID = "_dd.span_id"
+
+    /// Trace sample rate applied to RUM resources created by cross platform SDK.
+    /// We send cross-platform SDK's sample rate within RUM resource in order to provide accurate visibility into what settings are
+    /// configured at the SDK level. This gets displayed on APM's traffic ingestion control page.
+    /// Expects `Double` value between `0.0` and `1.0`.
+    public static let rulePSR = "_dd.rule_psr"
+
+    /// Custom attribute of the log passed from CP SDK. Used in error logs reported by cross platform SDK.
+    /// It flags the error has being fatal for the host application, so we can prevent creating a duplicate RUM error.
+    /// The goal of RUMM-3289 is to create an RFC to get rid of this mechanism.
+    /// Expects `Bool` value.
+    public static let errorLogIsCrash = "_dd.error_log.is_crash"
+}
+
+public struct LaunchArguments {
+    /// Each product should consider this argument to offer simple debugging experience. 
+    /// For example, if this flag is present it can use no sampling.
+    public static let Debug = "DD_DEBUG"
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Attributes/AttributesSanitizer.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Attributes/AttributesSanitizer.swift
@@ -1,0 +1,85 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Common attributes sanitizer for all features.
+public struct AttributesSanitizer {
+    public struct Constraints {
+        /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
+        /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).
+        public static let maxNestedLevelsInAttributeName: Int = 10
+        /// Maximum number of attributes in log.
+        /// If this number is exceeded, extra attributes will be ignored.
+        public static let maxNumberOfAttributes: Int = 128
+    }
+
+    let featureName: String
+
+    public init(featureName: String) {
+        self.featureName = featureName
+    }
+
+    // MARK: - Attribute keys sanitization
+
+    /// Attribute keys can only have `Constants.maxNestedLevelsInAttributeName` levels.
+    /// Extra levels are escaped with "_", e.g.:
+    ///
+    ///     one.two.three.four.five.six.seven.eight.nine.ten.eleven
+    ///
+    /// becomes:
+    ///
+    ///     one.two.three.four.five.six.seven.eight_nine_ten_eleven
+    ///
+    public func sanitizeKeys<Value>(for attributes: [String: Value], prefixLevels: Int = 0) -> [String: Value] {
+        let sanitizedAttributes: [(String, Value)] = attributes.map { key, value in
+            let sanitizedName = sanitize(attributeKey: key, prefixLevels: prefixLevels)
+            if sanitizedName != key {
+                DD.logger.warn(
+                    """
+                    \(featureName) attribute '\(key)' was modified to '\(sanitizedName)' to match Datadog constraints.
+                    """
+                )
+                return (sanitizedName, value)
+            } else {
+                return (key, value)
+            }
+        }
+        return Dictionary(uniqueKeysWithValues: sanitizedAttributes)
+    }
+
+    private func sanitize(attributeKey: String, prefixLevels: Int = 0) -> String {
+        var dotsCount = prefixLevels
+        var sanitized = ""
+        for char in attributeKey {
+            if char == "." {
+                dotsCount += 1
+                sanitized.append(dotsCount >= Constraints.maxNestedLevelsInAttributeName ? "_" : char)
+            } else {
+                sanitized.append(char)
+            }
+        }
+        return sanitized
+    }
+
+    // MARK: - Attributes count limitting
+
+    /// Removes attributes exceeding the `count` limit.
+    public func limitNumberOf<Value>(attributes: [String: Value], to count: Int) -> [String: Value] {
+        if attributes.count > count {
+            let extraAttributesCount = attributes.count - count
+            DD.logger.warn(
+                """
+                Number of \(featureName) attributes exceeds the limit of \(Constraints.maxNumberOfAttributes).
+                \(extraAttributesCount) attribute(s) will be ignored.
+                """
+            )
+            return Dictionary(uniqueKeysWithValues: attributes.dropLast(extraAttributesCount))
+        } else {
+            return attributes
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyCodable.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyCodable.swift
@@ -1,0 +1,98 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by Flight School, https://flight.school/ and altered by Datadog.
+ * Use of this source code is governed by MIT license:
+ *
+ * Copyright 2018 Read Evaluate Press, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/**
+ A type-erased `Codable` value.
+ The `AnyCodable` type forwards encoding and decoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+ You can encode or decode mixed-type values in dictionaries
+ and other collections that require `Encodable` or `Decodable` conformance
+ by declaring their contained type to be `AnyCodable`.
+ - SeeAlso: `AnyEncodable`
+ - SeeAlso: `AnyDecodable`
+ */
+@frozen
+public struct AnyCodable: Codable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+extension AnyCodable: _AnyEncodable, _AnyDecodable {}
+
+extension AnyCodable: Equatable {
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyCodable], rhs as [String: AnyCodable]):
+            return lhs == rhs
+        case let (lhs as [AnyCodable], rhs as [AnyCodable]):
+            return lhs == rhs
+        case let (lhs as [String: Any], rhs as [String: Any]):
+            return NSDictionary(dictionary: lhs) == NSDictionary(dictionary: rhs)
+        case let (lhs as [Any], rhs as [Any]):
+            return NSArray(array: lhs) == NSArray(array: rhs)
+        case is (NSNull, NSNull):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyDecodable.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyDecodable.swift
@@ -1,0 +1,149 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by Flight School, https://flight.school/ and altered by Datadog.
+ * Use of this source code is governed by MIT license:
+ *
+ * Copyright 2018 Read Evaluate Press, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/**
+ A type-erased `Decodable` value.
+ The `AnyDecodable` type forwards decoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+ You can decode mixed-type values in dictionaries
+ and other collections that require `Decodable` conformance
+ by declaring their contained type to be `AnyDecodable`:
+     let json = """
+     {
+         "boolean": true,
+         "integer": 42,
+         "double": 3.141592653589793,
+         "string": "string",
+         "array": [1, 2, 3],
+         "nested": {
+             "a": "alpha",
+             "b": "bravo",
+             "c": "charlie"
+         },
+         "null": null
+     }
+     """.data(using: .utf8)!
+     let decoder = JSONDecoder()
+     let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
+ */
+@frozen
+public struct AnyDecodable: Decodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+@usableFromInline
+internal protocol _AnyDecodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+
+extension AnyDecodable: _AnyDecodable {}
+
+extension _AnyDecodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            #if canImport(Foundation)
+                self.init(NSNull())
+            #else
+                self.init(Optional<Self>.none)
+            #endif
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let int = try? container.decode(Int64.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let uint = try? container.decode(UInt64.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([AnyDecodable].self) {
+            self.init(array.map { $0.value })
+        } else if let dictionary = try? container.decode([String: AnyDecodable].self) {
+            self.init(dictionary.mapValues { $0.value })
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyDecodable value cannot be decoded")
+        }
+    }
+}
+
+extension AnyDecodable: Equatable {
+    public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+#if canImport(Foundation)
+        case is (NSNull, NSNull), is (Void, Void):
+            return true
+#endif
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyDecodable], rhs as [String: AnyDecodable]):
+            return lhs == rhs
+        case let (lhs as [AnyDecodable], rhs as [AnyDecodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyDecoder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyDecoder.swift
@@ -1,0 +1,858 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An object that decodes instances of a `Any` type.
+///
+/// The example below shows how to decode an instance of a simple `GroceryProduct`
+/// type from a `Any` object. The type adopts `Codable` so that it's decodable using a
+/// `AnyDecoder` instance.
+///
+///     struct GroceryProduct: Codable {
+///         var name: String
+///         var points: Int
+///         var description: String?
+///     }
+///
+///     let dictionary: [String: Any] = [
+///         "name": "Durian",
+///         "points": 600,
+///         "description": "A fruit with a distinctive scent."
+///     ]
+///
+///     let decoder = AnyDecoder()
+///     let product = try decoder.decode(GroceryProduct.self, from: dictionary)
+///
+///     print(product.name) // Prints "Durian"
+///
+open class AnyDecoder {
+    /// Initializes `self`.
+    public init() { }
+
+    /// Decodes a top-level any value to the given type.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter object: The object to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T>(_ type: T.Type = T.self, from any: Any?) throws -> T where T: Decodable {
+        // swiftlint:disable:previous function_default_parameter_at_end
+        let container = _AnyDecoder.SingleValueContainer(any)
+        return try container.decode(T.self)
+    }
+}
+
+// swiftlint:enable closing_brace_whitespace
+// MARK: - Internal Decoder
+private class _AnyDecoder: Decoder {
+    /// The path of coding keys taken to get to this point in decoding.
+    let codingPath: [CodingKey]
+
+    /// The source value.
+    let value: Any?
+
+    /// Any contextual information set by the user for decoding.
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    init(_ value: Any?, path: [CodingKey] = []) {
+        self.value = value
+        codingPath = path
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// keyed by the given key type.
+    ///
+    /// - parameter type: The key type to use for the container.
+    /// - returns: A keyed decoding container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not a keyed container.
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+        let container = try KeyedContainer<Key>(value, path: codingPath)
+        return KeyedDecodingContainer(container)
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// appropriate for holding values with no keys.
+    ///
+    /// - returns: An unkeyed container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not an unkeyed container.
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try UnkeyedContainer(value, path: codingPath)
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// appropriate for holding a single primitive value.
+    ///
+    /// - returns: A single value container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not a single value container.
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        SingleValueContainer(value, path: codingPath)
+    }
+
+    /// A type that provides a view into an encoder's storage and is used to hold
+    /// the encoded properties of an encodable type in a keyed manner.
+    struct KeyedContainer<Key>: KeyedDecodingContainerProtocol where Key: CodingKey {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The source dictionary.
+        let dict: [String: Any?]
+
+        init(_ any: Any?, path: [CodingKey] = []) throws {
+            guard let dict = any as? [String: Any?] else {
+                let context = DecodingError.Context(
+                    codingPath: path,
+                    debugDescription: "Invalid conversion of '\(String(describing: any))' to Dictionary."
+                )
+
+                throw DecodingError.typeMismatch([String: Any?].self, context)
+            }
+
+            self.dict = dict
+            self.codingPath = path
+        }
+
+        /// All the keys the `Decoder` has for this container.
+        ///
+        /// Different keyed containers from the same `Decoder` may return different
+        /// keys here; it is possible to encode with multiple key types which are
+        /// not convertible to one another. This should report all keys present
+        /// which are convertible to the requested type.
+        var allKeys: [Key] {
+            dict.keys.compactMap { Key(stringValue: $0) }
+        }
+
+        /// Returns a Boolean value indicating whether the decoder contains a value
+        /// associated with the given key.
+        ///
+        /// The value associated with `key` may be a null value as appropriate for
+        /// the data format.
+        ///
+        /// - parameter key: The key to search for.
+        /// - returns: Whether the `Decoder` has an entry for the given key.
+        func contains(_ key: Key) -> Bool {
+            dict[key.stringValue] != nil
+        }
+
+        func value(forKey key: Key) throws -> Any? {
+            if let value = dict[key.stringValue] {
+                return value
+            }
+
+            let context = DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "No value associated with key \(key.stringValue)."
+            )
+
+            throw DecodingError.keyNotFound(key, context)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decodeNil(forKey key: Key) throws -> Bool {
+            try nestedSingleValueContainer(forKey: key).decodeNil()
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: String.Type, forKey key: Key) throws -> String {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Returns the data stored for the given key as represented in a container
+        /// keyed by the given key type.
+        ///
+        /// - parameter type: The key type to use for the container.
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: A keyed decoding container view into `self`.
+        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = try KeyedContainer<NestedKey>(value(forKey: key), path: codingPath + [key])
+            return KeyedDecodingContainer(container)
+        }
+
+        /// Returns the data stored for the given key as represented in an unkeyed
+        /// container.
+        ///
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: An unkeyed decoding container view into `self`.
+        func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+            try UnkeyedContainer(value(forKey: key), path: codingPath + [key])
+        }
+
+        /// Returns the data stored for the given key as represented in an single value
+        /// container.
+        ///
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: An single value decoding container view into `self`.
+        func nestedSingleValueContainer(forKey key: Key) throws -> SingleValueDecodingContainer {
+            try SingleValueContainer(value(forKey: key), path: codingPath + [key])
+        }
+
+        /// Returns a `Decoder` instance for decoding `super` from the container
+        /// associated with the default `super` key.
+        ///
+        /// Equivalent to calling `superDecoder(forKey:)` with
+        /// `Key(stringValue: "super", intValue: 0)`.
+        ///
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        func superDecoder() throws -> Decoder {
+            _AnyDecoder(dict, path: codingPath)
+        }
+
+        /// Returns a `Decoder` instance for decoding `super` from the container
+        /// associated with the given key.
+        ///
+        /// - parameter key: The key to decode `super` for.
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        func superDecoder(forKey key: Key) throws -> Decoder {
+            try _AnyDecoder(value(forKey: key), path: codingPath + [key])
+        }
+    }
+
+    /// A type that provides a view into a decoder's storage and is used to hold
+    /// the encoded properties of a decodable type sequentially, without keys.
+    struct UnkeyedContainer: UnkeyedDecodingContainer {
+        /// The path of coding keys taken to get to this point in decoding.
+        let codingPath: [CodingKey]
+
+        /// The number of elements contained within this container.
+        ///
+        /// If the number of elements is unknown, the value is `nil`.
+        var count: Int? { array.count }
+
+        /// A Boolean value indicating whether there are no more elements left to be
+        /// decoded in the container.
+        var isAtEnd: Bool { currentIndex >= array.count }
+
+        /// The current decoding index of the container (i.e. the index of the next
+        /// element to be decoded.) Incremented after every successful decode call.
+        private(set) var currentIndex: Int = 0
+
+        /// The source array.
+        private let array: [Any?]
+
+        init(_ any: Any?, path: [CodingKey] = []) throws {
+            guard let array = any as? [Any?] else {
+                let context = DecodingError.Context(
+                    codingPath: path,
+                    debugDescription: "Invalid conversion of '\(String(describing: any))' to Array."
+                )
+
+                throw DecodingError.typeMismatch([Any?].self, context)
+            }
+
+            self.array = array
+            self.codingPath = path
+        }
+
+        /// Decodes a null value.
+        ///
+        /// If the value is not null, does not increment currentIndex.
+        ///
+        /// - returns: Whether the encountered value was null.
+        mutating func decodeNil() throws -> Bool {
+            if try nestedSingleValueContainer().decodeNil() {
+                return true
+            }
+
+            currentIndex -= 1
+            return false
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Bool.Type) throws -> Bool {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: String.Type) throws -> String {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Double.Type) throws -> Double {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Float.Type) throws -> Float {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int.Type) throws -> Int {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int8.Type) throws -> Int8 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int16.Type) throws -> Int16 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int32.Type) throws -> Int32 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int64.Type) throws -> Int64 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt.Type) throws -> UInt {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        private mutating func next() throws -> Any? {
+            defer { currentIndex += 1 }
+
+            if isAtEnd {
+                let context = DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Unkeyed container is at end."
+                )
+
+                throw DecodingError.valueNotFound(Any.self, context)
+            }
+
+            return array[currentIndex]
+        }
+
+        /// Decodes a nested container keyed by the given type.
+        ///
+        /// - parameter type: The key type to use for the container.
+        /// - returns: A keyed decoding container view into `self`.
+        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = try KeyedContainer<NestedKey>(next(), path: codingPath)
+            return KeyedDecodingContainer(container)
+        }
+
+        /// Decodes an unkeyed nested container.
+        ///
+        /// - returns: An unkeyed decoding container view into `self`.
+        mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+            try UnkeyedContainer(next(), path: codingPath)
+        }
+
+        /// Decodes an single value nested container.
+        ///
+        /// - returns: An unkeyed decoding container view into `self`.
+        mutating func nestedSingleValueContainer() throws -> SingleValueDecodingContainer {
+            try SingleValueContainer(next(), path: codingPath)
+        }
+
+        /// Decodes a nested container and returns a `Decoder` instance for decoding
+        /// `super` from that container.
+        ///
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        mutating func superDecoder() throws -> Decoder {
+            _AnyDecoder(array, path: codingPath)
+        }
+    }
+
+    /// A container that can support the storage and direct decoding of a single
+    /// nonkeyed value.
+    struct SingleValueContainer: SingleValueDecodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        let value: Any?
+
+        init(_ value: Any?, path: [CodingKey] = []) {
+            self.value = value
+            self.codingPath = path
+        }
+
+        /// Decodes a null value.
+        ///
+        /// - returns: Whether the encountered value was null.
+        func decodeNil() -> Bool {
+            value == nil
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Bool.Type) throws -> Bool {
+            guard let value = value as? Bool else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+            return value
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: String.Type) throws -> String {
+            guard let value = value as? String else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+            return value
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Double.Type) throws -> Double {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Float.Type) throws -> Float {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int.Type) throws -> Int {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int8.Type) throws -> Int8 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int16.Type) throws -> Int16 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int32.Type) throws -> Int32 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int64.Type) throws -> Int64 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt.Type) throws -> UInt {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt8.Type) throws -> UInt8 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt16.Type) throws -> UInt16 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt32.Type) throws -> UInt32 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt64.Type) throws -> UInt64 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+            if let value = value as? T {
+                return value
+            }
+
+            let decoder = _AnyDecoder(value, path: codingPath)
+            return try T(from: decoder)
+        }
+
+        /// Converts value to any `BinaryInteger`.
+        ///
+        /// - Parameter type: The `BinaryInteger` to convert as.
+        /// - Returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        private func value<T>(as type: T.Type) throws -> T where T: BinaryInteger {
+            var value: T?
+            switch self.value {
+            case let source as T: return source
+            case let source as Int: value = T(exactly: source)
+            case let source as Int8: value = T(exactly: source)
+            case let source as Int16: value = T(exactly: source)
+            case let source as Int32: value = T(exactly: source)
+            case let source as Int64: value = T(exactly: source)
+            case let source as UInt: value = T(exactly: source)
+            case let source as UInt8: value = T(exactly: source)
+            case let source as UInt16: value = T(exactly: source)
+            case let source as UInt32: value = T(exactly: source)
+            case let source as UInt64: value = T(exactly: source)
+            default: break
+            }
+
+            guard let value = value else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+
+            return value
+        }
+
+        /// Converts value to any `BinaryFloatingPoint`.
+        ///
+        /// - Parameter type: The `BinaryFloatingPoint` to convert as.
+        /// - Returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        private func value<T>(as type: T.Type) throws -> T where T: BinaryFloatingPoint {
+            if let source = value as? T {
+                return source
+            }
+
+            if let source = value as? Double {
+                return T(source)
+            }
+
+            if let source = value as? Float {
+                return T(source)
+            }
+
+            if let source = try? value(as: Int.self) {
+                return T(source)
+            }
+
+            throw DecodingError.typeMismatch(type, in: self)
+        }
+    }
+}
+
+private extension DecodingError {
+    /// Returns a new `.typeMismatch` error using a constructed coding path and
+    /// the given container.
+    ///
+    /// The coding path for the returned error is the given container's coding
+    /// path.
+    ///
+    /// - param container: The container in which the corrupted data was
+    ///   accessed.
+    /// - param debugDescription: A description of the error to aid in debugging.
+    ///
+    /// - Returns: A new `.typeMismatch` error with the given information.
+    static func typeMismatch(_ type: Any.Type, in container: _AnyDecoder.SingleValueContainer) -> DecodingError {
+        let context = DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "Invalid conversion of '\(String(describing: container.value))' to \(type)."
+        )
+
+        return .typeMismatch(type, context)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyEncodable.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyEncodable.swift
@@ -1,0 +1,213 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by Flight School, https://flight.school/ and altered by Datadog.
+ * Use of this source code is governed by MIT license:
+ *
+ * Copyright 2018 Read Evaluate Press, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/**
+ A type-erased `Encodable` value.
+ The `AnyEncodable` type forwards encoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+ You can encode mixed-type values in dictionaries
+ and other collections that require `Encodable` conformance
+ by declaring their contained type to be `AnyEncodable`:
+     let dictionary: [String: AnyEncodable] = [
+         "boolean": true,
+         "integer": 42,
+         "double": 3.141592653589793,
+         "string": "string",
+         "array": [1, 2, 3],
+         "nested": [
+             "a": "alpha",
+             "b": "bravo",
+             "c": "charlie"
+         ],
+         "null": nil
+     ]
+     let encoder = JSONEncoder()
+     let json = try! encoder.encode(dictionary)
+ */
+@frozen
+public struct AnyEncodable: Encodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+@usableFromInline
+internal protocol _AnyEncodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+
+extension AnyEncodable: _AnyEncodable {}
+
+// MARK: - Encodable
+extension _AnyEncodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        case is Void:
+            try container.encodeNil()
+        #if canImport(Foundation)
+        case is NSNull:
+            try container.encodeNil()
+        case let number as NSNumber:
+            try encode(nsnumber: number, into: &container)
+        case let date as Date:
+            try container.encode(date)
+        case let url as URL:
+            try container.encode(url.absoluteString)
+        #else
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let int8 as Int8:
+            try container.encode(int8)
+        case let int16 as Int16:
+            try container.encode(int16)
+        case let int32 as Int32:
+            try container.encode(int32)
+        case let int64 as Int64:
+            try container.encode(int64)
+        case let uint as UInt:
+            try container.encode(uint)
+        case let uint8 as UInt8:
+            try container.encode(uint8)
+        case let uint16 as UInt16:
+            try container.encode(uint16)
+        case let uint32 as UInt32:
+            try container.encode(uint32)
+        case let uint64 as UInt64:
+            try container.encode(uint64)
+        case let float as Float:
+            try container.encode(float)
+        case let double as Double:
+            try container.encode(double)
+        #endif
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any?]:
+            try container.encode(array.map { AnyEncodable($0) })
+        case let dictionary as [String: Any?]:
+            try container.encode(dictionary.mapValues { AnyEncodable($0) })
+        case let encodable as Encodable:
+            try encodable.encode(to: encoder)
+        default:
+            let context = EncodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "AnyEncodable value cannot be encoded: \(type(of: value))"
+            )
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+
+    #if canImport(Foundation)
+    private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
+        // objCType: A C string containing the Objective-C type of the data contained
+        // in the value object. This property provides the same string produced by
+        // the @encode() compiler directive. This property is more reliable than
+        // CFNumberGetType(nsnumber) which can return a wrong type after casting a
+        // Swift fixed-width numeric.
+        //
+        // The list of NSNumber encoding value can be found in the following links:
+        // - https://developer.apple.com/documentation/foundation/nsnumber
+        // - https://github.com/gnustep/libs-base/blob/master/Source/NSNumber.m
+        switch Character(Unicode.Scalar(UInt8(nsnumber.objCType.pointee))) {
+        case "c":
+            try container.encode(nsnumber.boolValue)
+        case "s":
+            try container.encode(nsnumber.int16Value)
+        case "i", "l":
+            try container.encode(nsnumber.int32Value)
+        case "q":
+            try container.encode(nsnumber.int64Value)
+        case "C":
+            try container.encode(nsnumber.uint8Value)
+        case "S":
+            try container.encode(nsnumber.uint16Value)
+        case "I", "L":
+            try container.encode(nsnumber.uint32Value)
+        case "Q":
+            try container.encode(nsnumber.uint64Value)
+        case "f":
+            try container.encode(nsnumber.floatValue)
+        case "d":
+            try container.encode(nsnumber.doubleValue)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "NSNumber cannot be encoded because its type is not handled")
+            throw EncodingError.invalidValue(nsnumber, context)
+        }
+    }
+    #endif
+}
+
+extension AnyEncodable: Equatable {
+    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyEncodable], rhs as [String: AnyEncodable]):
+            return lhs == rhs
+        case let (lhs as [AnyEncodable], rhs as [AnyEncodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyEncoder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/AnyEncoder.swift
@@ -1,0 +1,673 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An object that encodes instances of an `Encodable` type as `Any?`.
+///
+/// The example below shows how to encode an instance of a simple `GroceryProduct`
+/// type to `Any` object. The type adopts `Codable` so that it's encodable as `Any`
+/// using a `AnyEncoder` instance.
+///
+///     struct GroceryProduct: Codable {
+///         var name: String
+///         var points: Int
+///         var description: String?
+///     }
+///
+///     let pear = GroceryProduct(name: "Pear", points: 250, description: "A ripe pear.")
+///
+///     let encoder = AnyEncoder()
+///
+///     let object = try encoder.encode(pear)
+///     print(object as! NSDictionary)
+///
+///     /* Prints:
+///     {
+///         description = "A ripe pear.";
+///         name = Pear;
+///         points = 250;
+///     }
+///     */
+open class AnyEncoder {
+    /// Initializes `self`.
+    public init() { }
+
+    /// Encodes the given top-level value and returns its Any representation.
+    ///
+    /// Depending on the value and its `Encodable` implementation the returned
+    /// encoded value can be `Any`, `[Any?]`, `[String: Any?]`, or `nil`.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: An `Any` object containing the value.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<T>(_ value: T) throws -> Any? where T: Encodable {
+        let encoder = _AnyEncoder()
+        try value.encode(to: encoder)
+        return encoder.any
+    }
+}
+
+/// A type that can encode values into a native format for external
+/// representation.
+private class _AnyEncoder: Encoder {
+    typealias AnyEncodingStorage = (Any?) -> Void
+
+    /// The path of coding keys taken to get to this point in encoding.
+    let codingPath: [CodingKey]
+
+    /// Any contextual information set by the user for encoding.
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    /// The encoded value.
+    var any: Any?
+
+    init(path: [CodingKey] = []) {
+        codingPath = path
+    }
+
+    /// Returns an encoding container appropriate for holding multiple values
+    /// keyed by the given key type.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `unkeyedContainer()` or after
+    /// encoding a value through a call to `singleValueContainer()`
+    ///
+    /// - parameter type: The key type to use for the container.
+    /// - returns: A new keyed encoding container.
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+        let container = KeyedContainer<Key>(
+            store: { self.any = $0 },
+            dictionary: any as? [String: Any?],
+            path: codingPath
+        )
+        self.any = container.dictionary
+        return KeyedEncodingContainer(container)
+    }
+
+    /// Returns an encoding container appropriate for holding multiple unkeyed
+    /// values.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `container(keyedBy:)` or after
+    /// encoding a value through a call to `singleValueContainer()`
+    ///
+    /// - returns: A new empty unkeyed container.
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = UnkeyedContainer(
+            store: { self.any = $0 },
+            array: any as? [Any?],
+            path: codingPath
+        )
+        self.any = container.array
+        return container
+    }
+
+    /// Returns an encoding container appropriate for holding a single primitive
+    /// value.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `unkeyedContainer()` or
+    /// `container(keyedBy:)`, or after encoding a value through a call to
+    /// `singleValueContainer()`
+    ///
+    /// - returns: A new empty single value container.
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        SingleValueContainer(
+            store: { self.any = $0 },
+            path: codingPath
+        )
+    }
+
+    /// A concrete container that provides a view into an encoder's storage, making
+    /// the encoded properties of an encodable type accessible by keys.
+    class KeyedContainer<Key>: KeyedEncodingContainerProtocol where Key: CodingKey {
+        /// The path of coding keys taken to get to this point in encoding.
+        var codingPath: [CodingKey]
+
+        /// The dictionary of encoded value.
+        var dictionary: [String: Any?]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a keyed container for encoding an `Encodable` object to
+        /// a dictionary of `[String: Any?]`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - dictionary: An existing dictionary of any.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            dictionary: [String: Any?]? = nil,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.dictionary = dictionary ?? [:]
+            self.codingPath = path
+        }
+
+        /// Encodes a null value for the given key.
+        ///
+        /// - parameter key: The key to associate the value with.
+        func encodeNil(forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encodeNil()
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Bool, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: String, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Double, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Float, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int8, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int16, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int32, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int64, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt8, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt16, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt32, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt64, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Stores a keyed encoding container for the given key and returns it.
+        ///
+        /// - parameter keyType: The key type to use for the container.
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new keyed encoding container.
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = KeyedContainer<NestedKey>(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+            return KeyedEncodingContainer(container)
+        }
+
+        /// Stores an unkeyed encoding container for the given key and returns it.
+        ///
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new unkeyed encoding container.
+        func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+            UnkeyedContainer(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+        }
+
+        /// Stores an single value encoding container for the given key and returns it.
+        ///
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new unkeyed encoding container.
+        func nestedSingleValueContainer(forKey key: Key) -> SingleValueContainer {
+            SingleValueContainer(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+        }
+
+        /// Set the encoded value at the given key.
+        ///
+        /// - Parameters:
+        ///   - any: The encoded value.
+        ///   - key: The key to encode the value for.
+        private func set(_ any: Any?, forKey key: Key) {
+            dictionary[key.stringValue] = any
+            store(dictionary)
+        }
+
+        /// Stores a new nested container for the default `super` key and returns a
+        /// new encoder instance for encoding `super` into that container.
+        ///
+        /// Equivalent to calling `superEncoder(forKey:)` with
+        /// `Key(stringValue: "super", intValue: 0)`.
+        ///
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder() -> Encoder {
+            _AnyEncoder(path: codingPath)
+        }
+
+        /// Stores a new nested container for the given key and returns a new encoder
+        /// instance for encoding `super` into that container.
+        ///
+        /// - parameter key: The key to encode `super` for.
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder(forKey key: Key) -> Encoder {
+            _AnyEncoder(path: codingPath + [key])
+        }
+    }
+
+    /// A type that provides a view into an encoder's storage and is used to hold
+    /// the encoded properties of an encodable type sequentially, without keys.
+    class UnkeyedContainer: UnkeyedEncodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The number of elements encoded into the container.
+        var count: Int { array.count }
+
+        /// The array of encoded value.
+        var array: [Any?]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a unkeyed container for encoding an `Encodable` object to
+        /// an array of `[Any?]`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - array: An existing array of any.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            array: [Any?]? = nil,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.array = array ?? []
+            self.codingPath = path
+        }
+
+        /// Encodes a null value.
+        func encodeNil() throws {
+            try nestedSingleValueContainer().encodeNil()
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Bool) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: String) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Double) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Float) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        func encode(_ value: Int) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int8) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int16) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int32) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int64) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt8) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt16) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt32) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt64) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode<T>(_ value: T) throws where T: Encodable {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes a nested container keyed by the given type and returns it.
+        ///
+        /// - parameter keyType: The key type to use for the container.
+        /// - returns: A new keyed encoding container.
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = KeyedContainer<NestedKey>(store: append, path: codingPath)
+            return KeyedEncodingContainer(container)
+        }
+
+        /// Encodes an unkeyed encoding container and returns it.
+        ///
+        /// - returns: A new unkeyed encoding container.
+        func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+            UnkeyedContainer(store: append, path: codingPath)
+        }
+
+        /// Encodes an single value encoding container and returns it.
+        ///
+        /// - returns: A new unkeyed encoding container.
+        func nestedSingleValueContainer() -> SingleValueContainer {
+            SingleValueContainer(store: append, path: codingPath)
+        }
+
+        /// Encodes a nested container and returns an `Encoder` instance for encoding
+        /// `super` into that container.
+        ///
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder() -> Encoder {
+            _AnyEncoder(path: codingPath)
+        }
+
+        private func append(_ any: Any?) {
+            array.append(any)
+            store(array)
+        }
+    }
+
+    /// A container that can support the storage and direct encoding of a single
+    /// non-keyed value.
+    struct SingleValueContainer: SingleValueEncodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a single value container for encoding an `Encodable` object to
+        /// `Any?`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.codingPath = path
+        }
+
+        /// Encodes a null value.
+        func encodeNil() throws {
+            store(nil)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Bool) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: String) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Double) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Float) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int8) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int16) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int32) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int64) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt8) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt16) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt32) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt64) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode<T>(_ value: T) throws where T: Encodable {
+            if value is DictionaryEncodable {
+                store(value)
+            } else {
+                let encoder = _AnyEncoder(path: codingPath)
+                try value.encode(to: encoder)
+                store(encoder.any)
+            }
+        }
+    }
+}
+
+/// A shared encodable object will skip encoding when using the `AnyEncoder`.
+///
+/// Making an `Encodable` as shared allow to bypass encoding when the type is
+/// known by multiple parties.
+public protocol DictionaryEncodable { }
+
+extension URL: DictionaryEncodable { }
+extension Date: DictionaryEncodable { }
+extension UUID: DictionaryEncodable { }
+extension Data: DictionaryEncodable { }

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Codable/DynamicCodingKey.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Codable/DynamicCodingKey.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct DynamicCodingKey: CodingKey, Hashable {
+    /// The string to use in a named collection (e.g. a string-keyed dictionary).
+    public var stringValue: String
+
+    /// Creates a new instance from the given string.
+    ///
+    /// If the string passed as `stringValue` does not correspond to any instance
+    /// of this type, the result is `nil`.
+    ///
+    /// - parameter stringValue: The string value of the desired key.
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    /// The value to use in an integer-indexed collection (e.g. an int-keyed
+    /// dictionary).
+    public var intValue: Int?
+
+    /// Creates a new instance from the specified integer.
+    ///
+    /// If the value passed as `intValue` does not correspond to any instance of
+    /// this type, the result is `nil`.
+    ///
+    /// - parameter intValue: The integer value of the desired key.
+    public init?(intValue: Int) {
+        return nil
+    }
+
+    /// Creates a new instance from the given string.
+    ///
+    /// - parameter stringValue: The string value of the desired key.
+    public init(_ stringValue: String) {
+        self.stringValue = stringValue
+    }
+}
+
+extension DynamicCodingKey: ExpressibleByStringLiteral {
+    /// Creates an instance initialized to the given string value.
+    ///
+    /// - Parameter value: The value of the new instance.
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Concurrency/Flushable.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Concurrency/Flushable.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush()
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Concurrency/ReadWriteLock.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Concurrency/ReadWriteLock.swift
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A property wrapper using a fair, POSIX conforming reader-writer lock for atomic
+/// access to the value.  It is optimised for concurrent reads and exclusive writes.
+///
+/// The wrapper is a class to prevent copying the lock, it creates and initilaizes a `pthread_rwlock_t`.
+/// An additional method `mutate` allow to safely mutate the value in-place (to read it
+/// and write it while obtaining the lock only once).
+@propertyWrapper
+public final class ReadWriteLock<Value> {
+    /// The wrapped value.
+    private var value: Value
+
+    /// The lock object.
+    private var rwlock = pthread_rwlock_t()
+
+    public init(wrappedValue value: Value) {
+        pthread_rwlock_init(&rwlock, nil)
+        self.value = value
+    }
+
+    deinit {
+        pthread_rwlock_destroy(&rwlock)
+    }
+
+    /// The wrapped value.
+    ///
+    /// The `get` will acquire the lock for reading while the `set` will acquire for
+    /// writing.
+    public var wrappedValue: Value {
+        get {
+            pthread_rwlock_rdlock(&rwlock)
+            defer { pthread_rwlock_unlock(&rwlock) }
+            return value
+        }
+        set {
+            pthread_rwlock_wrlock(&rwlock)
+            value = newValue
+            pthread_rwlock_unlock(&rwlock)
+        }
+    }
+
+    /// Provides a non-escaping closure for mutation.
+    /// The lock will be acquired once for writing before invoking the closure.
+    ///
+    /// - Parameter closure: The closure with the mutable value.
+    public func mutate(_ closure: (inout Value) -> Void) {
+        pthread_rwlock_wrlock(&rwlock)
+        closure(&value)
+        pthread_rwlock_unlock(&rwlock)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/AppState.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/AppState.swift
@@ -1,0 +1,162 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Application state.
+public enum AppState: Codable, DictionaryEncodable {
+    /// The app is running in the foreground and currently receiving events.
+    case active
+    /// The app is running in the foreground but is not receiving events.
+    /// This might happen as a result of an interruption or because the app is transitioning to or from the background.
+    case inactive
+    /// The app is running in the background.
+    case background
+
+    /// If the app is running in the foreground - no matter if receiving events or not (i.e. being interrupted because of transitioning from background).
+    public var isRunningInForeground: Bool {
+        switch self {
+        case .active, .inactive:
+            return true
+        case .background:
+            return false
+        }
+    }
+}
+
+/// A data structure to represent recorded app states in a given period of time
+public struct AppStateHistory: Codable, Equatable, DictionaryEncodable {
+    /// Snapshot of the app state at `date`
+    public struct Snapshot: Codable, Equatable {
+        /// The app state at this `date`.
+        public let state: AppState
+        /// Date of recording this snapshot.
+        public let date: Date
+
+        public init(state: AppState, date: Date) {
+            self.state = state
+            self.date = date
+        }
+    }
+
+    public private(set) var initialSnapshot: Snapshot
+    public private(set) var snapshots: [Snapshot]
+
+    /// Date of last the update to `AppStateHistory`.
+    public private(set) var recentDate: Date
+
+    /// The most recent app state `Snapshot`.
+    public var currentSnapshot: Snapshot {
+        return Snapshot(
+            state: (snapshots.last ?? initialSnapshot).state,
+            date: recentDate
+        )
+    }
+
+    public init(
+        initialSnapshot: Snapshot,
+        recentDate: Date,
+        snapshots: [Snapshot] = []
+    ) {
+        self.initialSnapshot = initialSnapshot
+        self.snapshots = snapshots
+        self.recentDate = recentDate
+    }
+
+    public init(
+        initialState: AppState,
+        date: Date,
+        snapshots: [Snapshot] = []
+    ) {
+        self.init(
+            initialSnapshot: .init(state: initialState, date: date),
+            recentDate: date,
+            snapshots: snapshots
+        )
+    }
+
+    /// Limits or extrapolates app state history to the given range
+    /// This is useful when you record between 0...3t but you are concerned of t...2t only
+    /// - Parameter range: if outside of initial and final states, it extrapolates; otherwise it limits
+    /// - Returns: a history instance spanning the given range
+    public func take(between range: ClosedRange<Date>) -> AppStateHistory {
+        .init(
+            // move initial state to lowerBound
+            initialSnapshot: Snapshot(
+                state: state(at: range.lowerBound),
+                date: range.lowerBound
+            ),
+            // move final state to upperBound
+            recentDate: range.upperBound,
+            // filter changes outside of the range
+            snapshots: snapshots.filter { range.contains($0.date) }
+        )
+    }
+
+    public mutating func append(_ snapshot: Snapshot) {
+        snapshots.append(snapshot)
+    }
+
+    public var foregroundDuration: TimeInterval {
+        var duration: TimeInterval = 0.0
+        var lastActiveStartDate: Date?
+        let allEvents = [initialSnapshot] + snapshots + [currentSnapshot]
+        for event in allEvents {
+            if let startDate = lastActiveStartDate {
+                duration += event.date.timeIntervalSince(startDate)
+            }
+            if event.state.isRunningInForeground {
+                lastActiveStartDate = event.date
+            } else {
+                lastActiveStartDate = nil
+            }
+        }
+        return duration
+    }
+
+    private func state(at date: Date) -> AppState {
+        for snapshot in snapshots.reversed() {
+            if snapshot.date > date {
+                continue
+            }
+
+            return snapshot.state
+        }
+
+        // we assume there was no change before initial state
+        return initialSnapshot.state
+    }
+}
+
+extension AppStateHistory {
+    /// Return a history with an active initial state.
+    ///
+    /// - Parameter date: The date since the application is considred active.
+    public static func active(since date: Date) -> AppStateHistory {
+        .init(initialState: .active, date: date)
+    }
+}
+
+#if canImport(UIKit)
+
+import UIKit
+
+extension AppState {
+    public init(_ state: UIApplication.State) {
+        switch state {
+        case .active:
+            self = .active
+        case .inactive:
+            self = .inactive
+        case .background:
+            self = .background
+        @unknown default:
+            self = .active // in case a new state is introduced, we rather want to fallback to most expected state
+        }
+    }
+}
+
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/BatteryStatus.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/BatteryStatus.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Describe the battery state for mobile devices.
+public struct BatteryStatus: Codable, Equatable, DictionaryEncodable {
+    public enum State: Codable {
+        case unknown
+        case unplugged
+        case charging
+        case full
+    }
+
+    /// The charging state of the battery.
+    public let state: State
+
+    /// The battery power level, range between 0 and 1.
+    public let level: Float
+
+    public init(state: State, level: Float) {
+        self.state = state
+        self.level = level
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/CarrierInfo.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/CarrierInfo.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Carrier details specific to cellular radio access.
+public struct CarrierInfo: Codable, Equatable, DictionaryEncodable {
+    // swiftlint:disable identifier_name
+    public enum RadioAccessTechnology: String, Codable, CaseIterable {
+        case GPRS
+        case Edge
+        case WCDMA
+        case HSDPA
+        case HSUPA
+        case CDMA1x
+        case CDMAEVDORev0
+        case CDMAEVDORevA
+        case CDMAEVDORevB
+        case eHRPD
+        case LTE
+        case unknown
+    }
+    // swiftlint:enable identifier_name
+
+    /// The name of the user’s home cellular service provider.
+    public let carrierName: String?
+    /// The ISO country code for the user’s cellular service provider.
+    public let carrierISOCountryCode: String?
+    /// Indicates if the carrier allows making VoIP calls on its network.
+    public let carrierAllowsVOIP: Bool
+    /// The radio access technology used for cellular connection.
+    public let radioAccessTechnology: RadioAccessTechnology
+
+    public init(
+        carrierName: String?,
+        carrierISOCountryCode: String?,
+        carrierAllowsVOIP: Bool,
+        radioAccessTechnology: RadioAccessTechnology
+    ) {
+        self.carrierName = carrierName
+        self.carrierISOCountryCode = carrierISOCountryCode
+        self.carrierAllowsVOIP = carrierAllowsVOIP
+        self.radioAccessTechnology = radioAccessTechnology
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/DatadogContext.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/DatadogContext.swift
@@ -1,0 +1,154 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct DatadogContext {
+    // MARK: - Datadog Specific
+
+    /// [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads. It can be `nil` in V1
+    /// if the SDK is configured using deprecated APIs:
+    /// `set(logsEndpoint:)`, `set(tracesEndpoint:)` and `set(rumEndpoint:)`.
+    public let site: DatadogSite
+
+    /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
+    public let clientToken: String
+
+    /// The name of the service that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    public let service: String
+
+    /// The name of the environment that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    public let env: String
+
+    /// The version of the application that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    public var version: String
+
+    /// The variant of the build, equivelent to Android's "Flavor".  Only used by cross platform SDKs
+    public let variant: String?
+
+    /// Denotes the mobile application's platform, such as `"ios"` or `"flutter"` that data is generated from.
+    ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
+    public let source: String
+
+    /// The version of Datadog iOS SDK.
+    public let sdkVersion: String
+
+    /// The name of [CI Visibility](https://docs.datadoghq.com/continuous_integration/) origin.
+    /// It is only set if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
+    public let ciAppOrigin: String?
+
+    /// Interval between device and server time.
+    ///
+    /// The value can change as the device continue to sync with the server.
+    public var serverTimeOffset: TimeInterval = .zero
+
+    // MARK: - Application Specific
+
+    /// The name of the application, read from `Info.plist` (`CFBundleExecutable`).
+    public let applicationName: String
+
+    /// The bundle identifier, read from `Info.plist` (`CFBundleIdentifier`).
+    public let applicationBundleIdentifier: String
+
+    /// Date of SDK initialization measured in device time (without NTP correction).
+    public let sdkInitDate: Date
+
+    /// Current device information.
+    public let device: DeviceInfo
+
+    /// Current user information.
+    public var userInfo: UserInfo?
+
+    /// The user's consent to data collection
+    public var trackingConsent: TrackingConsent = .pending
+
+    /// Application launch time.
+    ///
+    /// Can be `nil` if the launch could not yet been evaluated.
+    public var launchTime: LaunchTime?
+
+    /// Provides the history of app foreground / background states.
+    public var applicationStateHistory: AppStateHistory
+
+    // MARK: - Device Specific
+
+    /// Network information.
+    ///
+    /// Represents the current state of the device network connectivity and interface.
+    /// The value can be `unknown` if the network interface is not available or if it has not
+    /// yet been evaluated.
+    public var networkConnectionInfo: NetworkConnectionInfo?
+
+    /// Carrier information.
+    ///
+    /// Represents the current telephony service info of the device.
+    /// This value can be `nil` of no service is currently registered, or if the device does
+    /// not support telephony services.
+    public var carrierInfo: CarrierInfo?
+
+    /// The current mobile device battery status.
+    ///
+    /// This value can be `nil` of the current device battery interface is not available.
+    public var batteryStatus: BatteryStatus?
+
+    /// `true` if the Low Power Mode is enabled.
+    public var isLowPowerModeEnabled = false
+
+    /// Feature attributes provider.
+    public var featuresAttributes: [String: FeatureBaggage] = [:]
+
+    // swiftlint:disable function_default_parameter_at_end
+    public init(
+        site: DatadogSite,
+        clientToken: String,
+        service: String,
+        env: String,
+        version: String,
+        variant: String?,
+        source: String,
+        sdkVersion: String,
+        ciAppOrigin: String?,
+        serverTimeOffset: TimeInterval = .zero,
+        applicationName: String,
+        applicationBundleIdentifier: String,
+        sdkInitDate: Date,
+        device: DeviceInfo,
+        userInfo: UserInfo? = nil,
+        trackingConsent: TrackingConsent = .pending,
+        launchTime: LaunchTime? = nil,
+        applicationStateHistory: AppStateHistory,
+        networkConnectionInfo: NetworkConnectionInfo? = nil,
+        carrierInfo: CarrierInfo? = nil,
+        batteryStatus: BatteryStatus? = nil,
+        isLowPowerModeEnabled: Bool = false,
+        featuresAttributes: [String: FeatureBaggage] = [:]
+    ) {
+        self.site = site
+        self.clientToken = clientToken
+        self.service = service
+        self.env = env
+        self.version = version
+        self.variant = variant
+        self.source = source
+        self.sdkVersion = sdkVersion
+        self.ciAppOrigin = ciAppOrigin
+        self.serverTimeOffset = serverTimeOffset
+        self.applicationName = applicationName
+        self.applicationBundleIdentifier = applicationBundleIdentifier
+        self.sdkInitDate = sdkInitDate
+        self.device = device
+        self.userInfo = userInfo
+        self.trackingConsent = trackingConsent
+        self.launchTime = launchTime
+        self.applicationStateHistory = applicationStateHistory
+        self.networkConnectionInfo = networkConnectionInfo
+        self.carrierInfo = carrierInfo
+        self.batteryStatus = batteryStatus
+        self.isLowPowerModeEnabled = isLowPowerModeEnabled
+        self.featuresAttributes = featuresAttributes
+    }
+    // swiftlint:enable function_default_parameter_at_end
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/DatadogSite.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/DatadogSite.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public enum DatadogSite: String {
+    /// US based servers.
+    /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
+    case us1
+    /// US based servers.
+    /// Sends data to [app.datadoghq.com](https://us3.datadoghq.com/).
+    case us3
+    /// US based servers.
+    /// Sends data to [app.datadoghq.com](https://us5.datadoghq.com/).
+    case us5
+    /// Europe based servers.
+    /// Sends data to [app.datadoghq.eu](https://app.datadoghq.eu/).
+    case eu1
+    /// Asia based servers.
+    /// Sends data to [ap1.datadoghq.com](https://ap1.datadoghq.com/).
+    case ap1
+    /// US based servers, FedRAMP compatible.
+    /// Sends data to [app.ddog-gov.com](https://app.ddog-gov.com/).
+    case us1_fed
+    /// US based servers.
+    /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
+    @available(*, deprecated, message: "Renamed to us1")
+    public static let us: DatadogSite = .us1
+    /// Europe based servers.
+    /// Sends data to [app.datadoghq.eu](https://app.datadoghq.eu/).
+    @available(*, deprecated, message: "Renamed to eu1")
+    public static let eu: DatadogSite = .eu1
+    /// Gov servers.
+    /// Sends data to [app.ddog-gov.com](https://app.ddog-gov.com/).
+    @available(*, deprecated, message: "Renamed to us1_fed")
+    public static let gov: DatadogSite = .us1_fed
+}
+
+extension DatadogSite {
+    public var endpoint: URL {
+        switch self {
+        // swiftlint:disable force_unwrapping
+        case .us1: return URL(string: "https://browser-intake-datadoghq.com/")!
+        case .us3: return URL(string: "https://browser-intake-us3-datadoghq.com/")!
+        case .us5: return URL(string: "https://browser-intake-us5-datadoghq.com/")!
+        case .eu1: return URL(string: "https://browser-intake-datadoghq.eu/")!
+        case .ap1: return URL(string: "https://browser-intake-ap1-datadoghq.com/")!
+        case .us1_fed: return URL(string: "https://browser-intake-ddog-gov.com/")!
+        // swiftlint:enable force_unwrapping
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/DateProvider.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/DateProvider.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides current device time information.
+public protocol DateProvider {
+    /// Current device time.
+    ///
+    /// A specific point in time, independent of any calendar or time zone.
+    var now: Date { get }
+}
+
+/// Provides system date.
+public struct SystemDateProvider: DateProvider {
+    public init() { }
+
+    /// Returns current system time.
+    public var now: Date { .init() }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/DeviceInfo.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/DeviceInfo.swift
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Describes current device information.
+public struct DeviceInfo: Codable, Equatable, DictionaryEncodable {
+    // MARK: - Info
+
+    /// Device manufacturer name. Always'Apple'
+    public let brand: String
+
+    /// Device marketing name, e.g. "iPhone", "iPad", "iPod touch".
+    public let name: String
+
+    /// Device model name, e.g. "iPhone10,1", "iPhone13,2".
+    public let model: String
+
+    /// The name of operating system, e.g. "iOS", "iPadOS", "tvOS".
+    public let osName: String
+
+    /// The version of the operating system, e.g. "15.4.1".
+    public let osVersion: String
+
+    /// The build numer of the operating system, e.g.  "15D21" or "13D20".
+    public let osBuildNumber: String?
+
+    /// The architecture of the device
+    public let architecture: String
+
+    public init(
+        name: String,
+        model: String,
+        osName: String,
+        osVersion: String,
+        osBuildNumber: String?,
+        architecture: String
+    ) {
+        self.brand = "Apple"
+        self.name = name
+        self.model = model
+        self.osName = osName
+        self.osVersion = osVersion
+        self.osBuildNumber = osBuildNumber
+        self.architecture = architecture
+    }
+}
+
+#if canImport(UIKit)
+
+import UIKit
+import MachO
+
+extension DeviceInfo {
+    /// Creates device info based on UIKit description.
+    ///
+    /// - Parameters:
+    ///   - processInfo: The current process information.
+    ///   - device: The `UIDevice` description.
+    public init(
+        processInfo: ProcessInfo = .processInfo,
+        device: UIDevice = .current
+    ) {
+        var architecture = "unknown"
+        if let archInfo = NXGetLocalArchInfo()?.pointee {
+            architecture = String(utf8String: archInfo.name) ?? "unknown"
+        }
+
+        let build = try? Sysctl.osVersion()
+
+        #if !targetEnvironment(simulator)
+        let model = try? Sysctl.model()
+        // Real iOS device
+        self.init(
+            name: device.model,
+            model: model ?? device.model,
+            osName: device.systemName,
+            osVersion: device.systemVersion,
+            osBuildNumber: build,
+            architecture: architecture
+        )
+        #else
+        let model = processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] ?? device.model
+        // iOS Simulator - battery monitoring doesn't work on Simulator, so return "always OK" value
+        self.init(
+            name: device.model,
+            model: "\(model) Simulator",
+            osName: device.systemName,
+            osVersion: device.systemVersion,
+            osBuildNumber: build,
+            architecture: architecture
+        )
+        #endif
+    }
+}
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/LaunchTime.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/LaunchTime.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides the application launch time.
+public struct LaunchTime: Codable, Equatable, DictionaryEncodable {
+    /// The app process launch duration (in seconds) measured as the time from process start time
+    /// to receiving `UIApplication.didBecomeActiveNotification` notification.
+    ///
+    /// If the `UIApplication.didBecomeActiveNotification` has not yet been received the value will be `nil`.
+    public let launchTime: TimeInterval?
+
+    /// The date when the application process started.
+    public let launchDate: Date
+
+    /// Returns `true` if the application is pre-warmed.
+    public let isActivePrewarm: Bool
+
+    public init(launchTime: TimeInterval?, launchDate: Date, isActivePrewarm: Bool) {
+        self.launchTime = launchTime
+        self.launchDate = launchDate
+        self.isActivePrewarm = isActivePrewarm
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/NetworkConnectionInfo.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/NetworkConnectionInfo.swift
@@ -1,0 +1,72 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Network connection details.
+public struct NetworkConnectionInfo: Codable, Equatable, DictionaryEncodable {
+    /// Tells if network is reachable.
+    public enum Reachability: String, Codable, CaseIterable {
+        /// The network is reachable.
+        case yes
+        /// The network might be reachable after trying.
+        case maybe
+        /// The network is not reachable.
+        case no
+    }
+
+    /// Network connection interfaces.
+    public enum Interface: String, Codable, CaseIterable {
+        case wifi
+        case wiredEthernet
+        case cellular
+        case loopback
+        case other
+    }
+
+    /// Network reachability status.
+    public let reachability: Reachability
+    /// Available network interfaces.
+    public let availableInterfaces: [Interface]?
+    /// A Boolean indicating whether the connection supports IPv4 traffic.
+    public let supportsIPv4: Bool?
+    /// A Boolean indicating whether the connection supports IPv6 traffic.
+    public let supportsIPv6: Bool?
+    /// A Boolean indicating if the connection uses an interface that is considered expensive, such as Cellular or a Personal Hotspot.
+    public let isExpensive: Bool?
+    /// A Boolean indicating if the connection uses an interface in Low Data Mode.
+    public let isConstrained: Bool?
+
+    public init(
+        reachability: Reachability,
+        availableInterfaces: [Interface]?,
+        supportsIPv4: Bool?,
+        supportsIPv6: Bool?,
+        isExpensive: Bool?,
+        isConstrained: Bool?
+    ) {
+        self.reachability = reachability
+        self.availableInterfaces = availableInterfaces
+        self.supportsIPv4 = supportsIPv4
+        self.supportsIPv6 = supportsIPv6
+        self.isExpensive = isExpensive
+        self.isConstrained = isConstrained
+    }
+}
+
+extension NetworkConnectionInfo {
+    /// Returns an unknown network info with `.maybe` reachability.
+    static var unknown: NetworkConnectionInfo {
+        .init(
+            reachability: .maybe,
+            availableInterfaces: nil,
+            supportsIPv4: nil,
+            supportsIPv6: nil,
+            isExpensive: nil,
+            isConstrained: nil
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/Sysctl.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/Sysctl.swift
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software created by Matt Gallagher on 2016/02/03 and modified by Datadog.
+ * Copyright © 2016 Matt Gallagher ( https://www.cocoawithlove.com ).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * Use of this source code is governed by ISC license: https://github.com/mattgallagher/CwlUtils/blob/master/LICENSE.txt
+ */
+
+import Foundation
+
+/// A "static"-only namespace around a series of functions that operate on buffers returned from the `Darwin.sysctl` function
+internal struct Sysctl {
+    /// Possible errors.
+    enum Error: Swift.Error {
+        case unknown
+        case malformedUTF8
+        case posixError(POSIXErrorCode)
+    }
+
+    /// Access the raw data for an array of sysctl identifiers.
+    private static func data(for keys: [Int32]) throws -> [Int8] {
+        return try keys.withUnsafeBufferPointer { keysPointer throws -> [Int8] in
+            // Preflight the request to get the required data size
+            var requiredSize = 0
+            let preFlightResult = Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), nil, &requiredSize, nil, 0)
+            if preFlightResult != 0 {
+                throw POSIXErrorCode(rawValue: errno).map {
+                    print($0.rawValue)
+                    return Error.posixError($0)
+                } ?? Error.unknown
+            }
+
+            // Run the actual request with an appropriately sized array buffer
+            let data: [Int8] = Array(repeating: 0, count: requiredSize)
+            let result = data.withUnsafeBufferPointer { dataBuffer -> Int32 in
+                return Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), UnsafeMutableRawPointer(mutating: dataBuffer.baseAddress), &requiredSize, nil, 0)
+            }
+            if result != 0 {
+                throw POSIXErrorCode(rawValue: errno).map { Error.posixError($0) } ?? Error.unknown
+            }
+
+            return data
+        }
+    }
+
+    /// Invoke `sysctl` with an array of identifers, interpreting the returned buffer as a `String`. This function will throw `Error.malformedUTF8` if the buffer returned from `sysctl` cannot be interpreted as a UTF8 buffer.
+    private static func string(for keys: [Int32]) throws -> String {
+        let optionalString = try data(for: keys).withUnsafeBufferPointer { dataPointer -> String? in
+            dataPointer.baseAddress.flatMap { String(validatingUTF8: $0) }
+        }
+        guard let s = optionalString else {
+            throw Error.malformedUTF8
+        }
+        return s
+    }
+
+    /// e.g. "MacPro4,1" or "iPhone8,1"
+    /// NOTE: this is *corrected* on iOS devices to fetch hw.machine
+    static func model() throws -> String {
+        #if os(iOS) && !arch(x86_64) && !arch(i386) // iOS device && not Simulator
+            return try Sysctl.string(for: [CTL_HW, HW_MACHINE])
+        #else
+            return try Sysctl.string(for: [CTL_HW, HW_MODEL])
+        #endif
+    }
+
+    /// e.g. "15D21" or "13D20"
+    static func osVersion() throws -> String {
+        try Sysctl.string(for: [CTL_KERN, KERN_OSVERSION])
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/TrackingConsent.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/TrackingConsent.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Possible values for the Data Tracking Consent given by the user of the app.
+///
+/// This value should be used to grant the permission for Datadog SDK to store data collected in
+/// Logging, Tracing or RUM and upload it to Datadog servers.
+public enum TrackingConsent: Codable, DictionaryEncodable {
+    /// The permission to persist and send data to the Datadog servers was granted.
+    /// Any previously stored pending data will be marked as ready for sent.
+    case granted
+    /// Any previously stored pending data will be deleted and all Logging, RUM and Tracing events will
+    /// be dropped from now on, without persisting it in any way.
+    case notGranted
+    /// All Logging, RUM and Tracing events will be persisted in an intermediate location and will be pending there
+    /// until `.granted` or `.notGranted` consent value is set.
+    /// Based on the next consent value, intermediate data will be send to Datadog or deleted.
+    case pending
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Context/UserInfo.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Context/UserInfo.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct UserInfo: Codable, DictionaryEncodable {
+    /// User ID, if any.
+    public let id: String?
+    /// Name representing the user, if any.
+    public let name: String?
+    /// User email, if any.
+    public let email: String?
+    /// User custom attributes, if any.
+    public var extraInfo: [AttributeKey: AttributeValue]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case email
+    }
+
+    public init(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:]
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.extraInfo = extraInfo
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        // Encode static properties:
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(email, forKey: .email)
+
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try extraInfo.forEach {
+            let key = DynamicCodingKey($0)
+            try dynamicContainer.encode(AnyEncodable($1), forKey: key)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode static properties:
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.email = try container.decodeIfPresent(String.self, forKey: .email)
+
+        // Decode other properties into [String: Codable] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.extraInfo = try dynamicContainer.allKeys
+            .filter { CodingKeys(stringValue: $0.stringValue) == nil }
+            .reduce(into: [:]) {
+                $0[$1.stringValue] = try dynamicContainer.decode(AnyCodable.self, forKey: $1)
+            }
+    }
+}
+
+extension UserInfo {
+    public static var empty: Self { .init() }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/CoreRegistry.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/CoreRegistry.swift
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A Registry for all core instances, allowing Features to retrieve the one
+/// they want from anywhere.
+public final class CoreRegistry {
+    /// Returns the default core instance if registered, `NOPDatadogCore` instance otherwise.
+    public static var `default`: DatadogCoreProtocol {
+        instances[defaultInstanceName] ?? NOPDatadogCore()
+    }
+
+    /// The name for the default core instance.
+    ///
+    /// Features should use this name as default parameter.
+    public static let defaultInstanceName = "main"
+
+    @ReadWriteLock
+    internal private(set) static var instances: [String: DatadogCoreProtocol] = [:]
+
+    private init() { }
+
+    /// Register default core instance.
+    ///
+    /// - Parameter instance: The default core instance
+    public static func register(default instance: DatadogCoreProtocol) {
+        register(instance, named: defaultInstanceName)
+    }
+
+    /// Register an instance of core instance with the given name.
+    ///
+    /// - Parameters:
+    ///   - instance: The core instance
+    ///   - name: The name of the given instance.
+    public static func register(_ instance: DatadogCoreProtocol, named name: String) {
+        guard !isRegistered(instanceName: name) else {
+            DD.logger.warn("A core instance with name \(name) has already been registered.")
+            return
+        }
+        instances[name] = instance
+    }
+
+    /// Checks if a core instance with the specified name is currently registered.
+    ///
+    /// - Parameter instanceName: The name of the core instance to check.
+    /// - Returns: `true` if an instance with the given name is registered, otherwise `false`.
+    public static func isRegistered(instanceName: String) -> Bool {
+        return instances[instanceName] != nil
+    }
+
+    /// Unregisters the instance for the given name.
+    ///
+    /// - Parameter name: The name of the instance to unregister.
+    /// - Returns: The instance that was removed, or nil if the key was not present in the registry.
+    @discardableResult
+    public static func unregisterInstance(named name: String) -> DatadogCoreProtocol? {
+        instances.removeValue(forKey: name)
+    }
+
+    /// Unregisters the default instance.
+    ///
+    /// - Returns: The instance that was removed, or nil if the key was not present in the registry.
+    @discardableResult
+    public static func unregisterDefault() -> DatadogCoreProtocol? {
+        unregisterInstance(named: defaultInstanceName)
+    }
+
+    /// Returns the instance for the given name.
+    ///
+    /// - Parameter name: The name of the instance to get.
+    /// - Returns: The core instance if it exists, `NOPDatadogCore` instance otherwise.
+    public static func instance(named name: String) -> DatadogCoreProtocol {
+        instances[name] ?? NOPDatadogCore()
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/DD.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/DD.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Core utilities for monitoring performance and execution of the SDK.
+///
+/// These are meant to be shared by all instances of the SDK and `DatadogCore`.
+/// `DD` bundles static dependencies that must be available and functional right away,
+/// so it is possible to monitor any phase of the SDK execution, including its initialization sequence.
+public struct DD {
+    /// The logger providing methods to print debug information and execution errors from Datadog SDK to user console.
+    ///
+    /// It is meant for debugging purposes when using the SDK, hence **it should log information useful and actionable
+    /// to the SDK user**. Think of possible logs that we may want to receive from our users when asking them to enable
+    /// SDK verbosity and send us their console log.
+    public static var logger: CoreLogger = InternalLogger(
+        dateProvider: SystemDateProvider(),
+        timeZone: .current,
+        printFunction: consolePrint,
+        verbosityLevel: { .debug }
+    )
+
+    /// The telemetry monitor providing methods to send debug information
+    /// and execution errors of the Datadog SDK. It is only available if RUM feature is used.
+    ///
+    /// All collected events are anonymous and get reported to Datadog Telemetry org.
+    /// The actual implementation of `Telemetry` provides sampling and throttling
+    /// capabilities to ensure fair usage of user quota.
+    ///
+    /// Regardless internal optimisations, **it should be used wisely to report only useful
+    /// and actionable events** that are key to SDK observability.
+    public static var telemetry: Telemetry = NOPTelemetry()
+}
+
+/// Function printing `String` content to console.
+public var consolePrint: (String) -> Void = { print($0) }

--- a/Sources/ForageSDK/Vendor/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/DatadogCoreProtocol.swift
@@ -1,0 +1,186 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A Datadog Core holds a set of Features and is responsible for managing their storage
+/// and upload mechanism. It also provides a thread-safe scope for writing events.
+///
+/// Any reference to `DatadogCoreProtocol` must be captured as `weak` within a Feature. This is to avoid
+/// retain cycle of core holding the Feature and vice-versa.
+public protocol DatadogCoreProtocol: AnyObject {
+    /// Registers a Feature instance.
+    ///
+    /// Feature can interact with the core and other Feature through the message bus. Some specific Features
+    /// complying to `DatadogRemoteFeature` can collect and transfer data to a Datadog Product
+    /// (e.g. Logs, RUM, ...). Upon registration, a Remote Feature can retrieve a `FeatureScope` interface
+    /// for writing events to the core. The core will store and upload events efficiently according to the performance
+    /// presets defined on initialization.
+    ///
+    /// - Parameter feature: The Feature instance - it will be retained and held by core.
+    func register<T>(feature: T) throws where T: DatadogFeature
+
+    /// Retrieves previously registered Feature by its name and type.
+    ///
+    /// A Feature type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let feature = core.feature(named: "foo", type: Foo.self)
+    ///     let feature: Foo? = core.feature(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature's name.
+    ///   - type: The Feature instance type.
+    /// - Returns: The Feature if any.
+    func get<T>(feature type: T.Type) -> T? where T: DatadogFeature
+
+    /// Retrieves a Feature Scope by its name.
+    ///
+    /// Feature Scope collects data to Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature retrieves
+    /// its `FeatureScope` interface for writing events to the core. The core will store and upload events efficiently
+    /// according to the performance presets defined on initialization.
+    ///
+    /// - Parameters:
+    ///   - feature: The Feature's name.
+    /// - Returns: The Feature scope if a Feature with given name was registered.
+    func scope(for feature: String) -> FeatureScope?
+
+    /// Sets given attributes for a given Feature for sharing data through `DatadogContext`.
+    ///
+    /// This method provides a passive communication chanel between Features of the Core.
+    /// For an active Feature-to-Feature communication, please use the `send(message:)`
+    /// method.
+    ///
+    /// Setting attributes will update the Core Context and will be shared across Features.
+    /// In the following examples, the Feature `foo` will set an attribute and a second
+    /// Feature `bar` will read it through the event write context.
+    ///
+    ///     // Foo.swift
+    ///     core.set(feature: "foo", attributes: [
+    ///         "id": 1
+    ///     ])
+    ///
+    ///     // Bar.swift
+    ///     core.scope(for: "bar").eventWriteContext { context, writer in
+    ///         let fooID: Int? = context.featuresAttributes["foo"]?.id
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - feature: The Feature's name.
+    ///   - attributes: The Feature's attributes to set.
+    func set(feature: String, attributes: @escaping () -> FeatureBaggage)
+
+    /// Updates given attributes for a given Feature for sharing data through `DatadogContext`.
+    ///
+    /// This method provides a passive communication chanel between Features of the Core.
+    /// For an active Feature-to-Feature communication, please use the `send(message:)`
+    /// method.
+    ///
+    /// Updating attributes will update the Core Context and will be shared across Features.
+    /// In the following examples, the Feature `foo` will update two attributes and a second
+    /// Feature `bar` will read them through the event write context.
+    /// This function does not remove item if `nil` is provided as a value.
+    ///
+    ///     // Foo.swift
+    ///     core.update(feature: "foo", attributes: [
+    ///         "id": 1
+    ///     ])
+    ///     core.update(feature: "foo", attributes: [
+    ///         "name": "bazz"
+    ///     ])
+    ///
+    ///     // Bar.swift
+    ///     core.scope(for: "bar").eventWriteContext { context, writer in
+    ///         let fooID: Int? = context.featuresAttributes["foo"]?.id
+    ///         let fooName: Int? = context.featuresAttributes["foo"]?.name
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - feature: The Feature's name.
+    ///   - attributes: The Feature's attributes to set.
+    func update(feature: String, attributes: @escaping () -> FeatureBaggage)
+
+    /// Sends a message on the bus shared by features registered in this core.
+    ///
+    /// If the message could not be processed by any registered feature, the fallback closure
+    /// will be invoked. Do not make any assumption on which thread the fallback is called.
+    ///
+    /// - Parameters:
+    ///   - message: The message.
+    ///   - fallback: The fallback closure to call when the message could not be
+    ///               processed by any Features on the bus.
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void)
+}
+
+extension DatadogCoreProtocol {
+    /// Sends a message on the bus shared by features registered in this core.
+    ///
+    /// - Parameters:
+    ///   - message: The message.
+    public func send(message: FeatureMessage) {
+        send(message: message, else: {})
+    }
+}
+
+/// Feature scope provides a context and a writer to build a record event.
+public protocol FeatureScope {
+    /// Retrieve the event context and writer.
+    ///
+    /// The Feature scope provides the current Datadog context and event writer
+    /// for the Feature to build and record events.
+    ///
+    /// A Feature has the ability to bypass the current user consent for data collection. The `bypassConsent`
+    /// must be set to `true` only if the Feature is already aware of the user's consent for the event it is about
+    /// to write.
+    ///
+    /// - Parameters:
+    ///   - bypassConsent: `true` to bypass the current core consent and write events as authorized.
+    ///                    Default is `false`, setting `true` must still respect user's consent for
+    ///                    collecting information.
+    ///   - forceNewBatch: `true` to enforce that event will be written to a separate batch than previous events.
+    ///                     Default is `false`, which means the core uses its own heuristic to split events between
+    ///                     batches. This parameter can be leveraged in Features which require a clear separation
+    ///                     of group of events for preparing their upload (a single upload is always constructed from a single batch).
+    ///   - block: The block to execute.
+    func eventWriteContext(bypassConsent: Bool, forceNewBatch: Bool, _ block: @escaping (DatadogContext, Writer) throws -> Void)
+}
+
+/// Feature scope provides a context and a writer to build a record event.
+public extension FeatureScope {
+    /// Retrieve the event context and writer.
+    ///
+    /// The Feature scope provides the current Datadog context and event writer
+    /// for the Feature to build and record events.
+    ///
+    /// - Parameters:
+    ///   - bypassConsent: `true` to bypass the current core consent and write events as authorized.
+    ///                    Default is `false`, setting `true` must still respect user's consent for
+    ///                    collecting information.
+    ///   - forceNewBatch: `true` to enforce that event will be written to a separate batch than previous events.
+    ///                     Default is `false`, which means the core uses its own heuristic to split events between
+    ///                     batches. This parameter can be leveraged in Features which require a clear separation
+    ///                     of group of events for preparing their upload (a single upload is always constructed from a single batch).
+    ///   - block: The block to execute.
+    func eventWriteContext(bypassConsent: Bool = false, forceNewBatch: Bool = false, _ block: @escaping (DatadogContext, Writer) throws -> Void) {
+        self.eventWriteContext(bypassConsent: bypassConsent, forceNewBatch: forceNewBatch, block)
+    }
+}
+
+/// No-op implementation of `DatadogFeatureRegistry`.
+public class NOPDatadogCore: DatadogCoreProtocol {
+    public init() { }
+    /// no-op
+    public func register<T>(feature: T) throws where T: DatadogFeature { }
+    /// no-op
+    public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
+    /// no-op
+    public func scope(for feature: String) -> FeatureScope? { nil }
+    /// no-op
+    public func set(feature: String, attributes: @escaping @autoclosure () -> FeatureBaggage) { }
+    /// no-op
+    public func update(feature: String, attributes: @escaping () -> FeatureBaggage) { }
+    /// no-op
+    public func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/DatadogFeature.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/DatadogFeature.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct DatadogFeatureConfiguration {
+    /// The Feature name.
+    public let name: String
+
+    /// The URL request builder for uploading data in this Feature.
+    ///
+    /// This builder currently use the v1 context, but will be soon migrated to v2
+    public let requestBuilder: FeatureRequestBuilder
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
+    public let messageReceiver: FeatureMessageReceiver
+
+    public init(name: String, requestBuilder: FeatureRequestBuilder, messageReceiver: FeatureMessageReceiver) {
+        self.name = name
+        self.requestBuilder = requestBuilder
+        self.messageReceiver = messageReceiver
+    }
+}
+
+/// A Datadog Feature that can interact with the core through the message-bus.
+public protocol DatadogFeature {
+    /// The feature name.
+    static var name: String { get }
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
+    var messageReceiver: FeatureMessageReceiver { get }
+
+    /// (Optional) `PerformancePresetOverride` allows overriding certain performance presets if needed.
+    var performanceOverride: PerformancePresetOverride? { get }
+}
+
+/// A Datadog Feature with remote data store.
+public protocol DatadogRemoteFeature: DatadogFeature {
+    /// The URL request builder for uploading data.
+    ///
+    /// The `FeatureRequestBuilder` defines an interface for building a single `URLRequest`
+    /// for a list of data events and the current core context.
+    ///
+    /// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
+    /// The request will be transported by `DatadogCore`.
+    var requestBuilder: FeatureRequestBuilder { get }
+}
+
+extension DatadogFeature {
+    public var performanceOverride: PerformancePresetOverride? { nil }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/DatadogExtended.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/DatadogExtended.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ *
+ * This file includes software developed by Alamofire Software Foundation (http://alamofire.org/) and altered by Datadog.
+ * Use of this source code is governed by MIT License: https://github.com/Alamofire/Alamofire/blob/master/LICENSE
+ */
+
+import Foundation
+
+/// Type that acts as a generic extension point for all `DatadogExtended` types.
+public struct DatadogExtension<ExtendedType> {
+    /// Stores the type or meta-type of any extended type.
+    public private(set) var type: ExtendedType
+
+    /// Create an instance from the provided value.
+    ///
+    /// - Parameter type: Instance being extended.
+    public init(_ type: ExtendedType) {
+        self.type = type
+    }
+}
+
+/// Protocol describing the `dd` extension points for Datadog extended types.
+public protocol DatadogExtended {
+    /// Type being extended.
+    associatedtype ExtendedType
+
+    /// Static Datadog extension point.
+    static var dd: DatadogExtension<ExtendedType>.Type { get set }
+    /// Instance Datadog extension point.
+    var dd: DatadogExtension<ExtendedType> { get set }
+}
+
+extension DatadogExtended {
+    /// Static Datadog extension point.
+    public static var dd: DatadogExtension<Self>.Type {
+        get { DatadogExtension<Self>.self }
+        set {}
+    }
+
+    /// Instance Datadog extension point.
+    public var dd: DatadogExtension<Self> {
+        get { DatadogExtension(self) }
+        set {}
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/FixedWidthInteger+Convenience.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/FixedWidthInteger+Convenience.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An extension for FixedWidthInteger that provides a convenient API for
+/// converting numeric values into different units of data storage, such as
+/// bytes, kilobytes, megabytes, and gigabytes.
+public extension FixedWidthInteger {
+    /// A private property that represents the base unit (1024) used for
+    /// converting between data storage units.
+    private var base: Self { 1_024 }
+
+    /// A property that converts the given numeric value into kilobytes.
+    var KB: Self { return self.multipliedReportingOverflow(by: base).partialValue }
+
+    /// A property that converts the given numeric value into megabytes.
+    var MB: Self { return self.KB.multipliedReportingOverflow(by: base).partialValue }
+
+    /// A property that converts the given numeric value into gigabytes.
+    var GB: Self { return self.MB.multipliedReportingOverflow(by: base).partialValue }
+
+    /// A helper property that returns the current value as a direct representation in bytes.
+    var bytes: Self { return self }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/Foundation+Datadog.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/Foundation+Datadog.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+extension Thread: DatadogExtended {}
+extension DatadogExtension where ExtendedType: Thread {
+    /// Returns the name of current thread if available or the nature of thread otherwise: `"main" | "background"`.
+    public var name: String {
+        if let name = Thread.current.name, !name.isEmpty {
+            return name
+        }
+
+        return Thread.isMainThread ? "main" : "background"
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/InternalExtended.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/InternalExtended.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Type that acts as a generic extension point for all `InternalExtended` types.
+public struct InternalExtension<ExtendedType> {
+    /// Stores the type or meta-type of any extended type.
+    public var type: ExtendedType
+
+    /// Create an instance from the provided value.
+    ///
+    /// - Parameter type: Instance being extended.
+    public init(_ type: ExtendedType) {
+        self.type = type
+    }
+}
+
+/// Protocol describing the `_internal` extension points for internal extended types.
+public protocol InternalExtended {
+    /// Type being extended.
+    associatedtype ExtendedType
+
+    /// Static internal extension point.
+    static var _internal: InternalExtension<ExtendedType>.Type { get }
+
+    /// Instance internal extension point.
+    var _internal: InternalExtension<ExtendedType> { get }
+
+    /// Instance internal mutation point.
+    mutating func _internal_mutation(_ mutation: (inout InternalExtension<ExtendedType>) -> Void)
+}
+
+extension InternalExtended {
+    /// Grants access to an internal interface utilized only by other Datadog SDKs.
+    /// **It is not meant for public use** and it might change without prior notice.
+    public static var _internal: InternalExtension<Self>.Type {
+        InternalExtension<Self>.self
+    }
+
+    /// Instance internal extension point.
+    public var _internal: InternalExtension<Self> {
+        InternalExtension(self)
+    }
+
+    /// Instance internal mutaion point.
+    public mutating func _internal_mutation(_ mutation: (inout InternalExtension<Self>) -> Void) {
+        var mutating = InternalExtension(self)
+        mutation(&mutating)
+        self = mutating.type
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/TimeInterval+Convenience.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Extensions/TimeInterval+Convenience.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An extension for TimeInterval that provides a more semantic and expressive
+/// API for converting time representations into TimeInterval's default unit: seconds.
+public extension TimeInterval {
+    /// A helper property that returns the current value as a direct representation in seconds.
+    var seconds: TimeInterval { return TimeInterval(self) }
+
+    /// A property that converts the given number of minutes into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var minutes: TimeInterval { return self.multiplyOrClamp(by: 60) }
+
+    /// A property that converts the given number of hours into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var hours: TimeInterval { return self.multiplyOrClamp(by: 60.minutes) }
+
+    /// A property that converts the given number of days into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var days: TimeInterval { return self.multiplyOrClamp(by: 24.hours) }
+
+    /// A private helper method for multiplying the TimeInterval value by a factor
+    /// and clamping the result to prevent overflow. If the multiplication results in
+    /// overflow, the greatest finite magnitude value of TimeInterval is returned.
+    ///
+    /// - Parameter factor: The multiplier to apply to the time interval.
+    /// - Returns: The multiplied time interval, clamped to the greatest finite magnitude if necessary.
+    private func multiplyOrClamp(by factor: TimeInterval) -> TimeInterval {
+        guard factor != 0 else {
+            return 0
+        }
+        let multiplied = TimeInterval(self) * factor
+        if multiplied / factor != TimeInterval(self) {
+            return TimeInterval.greatestFiniteMagnitude
+        }
+        return multiplied
+    }
+}
+
+/// An extension for FixedWidthInteger that provides a more semantic and expressive
+/// API for converting time representations into TimeInterval's default unit: seconds.
+public extension FixedWidthInteger {
+    /// A helper property that returns the current value as a direct representation in seconds.
+    var seconds: TimeInterval { return TimeInterval(self) }
+
+    /// A property that converts the given numeric value of minutes into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var minutes: TimeInterval {
+        let (result, overflow) = self.multipliedReportingOverflow(by: 60)
+        return overflow ? TimeInterval.greatestFiniteMagnitude : TimeInterval(result)
+    }
+
+    /// A property that converts the given numeric value of hours into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var hours: TimeInterval {
+        let (result, overflow) = self.multipliedReportingOverflow(by: Self(60.minutes))
+        return overflow ? TimeInterval.greatestFiniteMagnitude : TimeInterval(result)
+    }
+
+    /// A property that converts the given numeric value of days into seconds.
+    /// In case of overflow, TimeInterval.greatestFiniteMagnitude is returned.
+    var days: TimeInterval {
+        let (result, overflow) = self.multipliedReportingOverflow(by: Self(24.hours))
+        return overflow ? TimeInterval.greatestFiniteMagnitude : TimeInterval(result)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureBaggage.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureBaggage.swift
@@ -1,0 +1,410 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A `FeatureBaggage` holds keyed values and adds semantics for type-safe access.
+///
+/// Values are uniquely identified by key as `String`, the value type is validated on `get`
+/// either explicity, when specified, or inferred.
+///
+/// ## Defining a Feature Baggage
+/// A baggage is expressible by dictionary literal with `Any?` value type.
+///
+///     var baggage: FeatureBaggage = [
+///         "string": "value",
+///         "integer": 1,
+///         "null": nil
+///     ]
+///
+/// ## Accessing Values
+/// Values are accessible using `subscript` methods with support for dynamic member
+/// lookup.
+///
+///     let baggage: FeatureBaggage = [...]
+///     // get by key and explicit value type
+///     let string = baggage["string", type: String.self]
+///     // get by key and inferred value type
+///     let string: String? = baggage["string"]
+///     // get dynamic member
+///     let string: String? = baggage.string
+///
+/// A baggage can also be mutated:
+///
+///     var baggage: FeatureBaggage = [...]
+///     baggage["string"] = "value"
+///     // set dynamic member
+///     baggage.string = "value"
+///
+/// A Feature Baggage does not ensure thread-safety of values that holds references, make
+/// sure that any value can be accessibe from any thread.
+@dynamicMemberLookup
+public struct FeatureBaggage {
+    /// The attributes dictionary.
+    public private(set) var attributes: [String: Any]
+
+    /// A Boolean value indicating whether the baggage is empty.
+    public var isEmpty: Bool {
+        attributes.isEmpty
+    }
+
+    /// Creates an instance initialized with the given key-value pairs.
+    public init(_ attributes: [String: Any]) {
+        let encoder = AnyEncoder()
+        self.attributes = attributes
+            .compactMapValues {
+                if $0 is Encodable {
+                    return try? encoder.encode(AnyEncodable($0))
+                }
+
+                return $0
+            }
+    }
+
+    /// Returns the value stored in the baggage for the given key.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public func value<T>(forKey key: String, type: T.Type = T.self) -> T? {
+        attributes[key] as? T
+    }
+
+    /// Decodes the value stored in the baggage for the given key.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public func decodeValue<T>(forKey key: String, type: T.Type = T.self) throws -> T? where T: Decodable {
+        let decoder = AnyDecoder()
+        return try decoder.decode(from: attributes[key])
+    }
+
+    /// Updates the value stored in the baggage for the given key, or adds a
+    /// new key-value pair if the key does not exist.
+    ///
+    /// Use this method instead of key-based subscribing when you need to know
+    /// whether the baggage was successfully updated.
+    ///
+    ///     var baggage = ["Heliotrope": 296, "Coral": 16, "Aquamarine": 156]
+    ///     baggage.updateValue(18, forKey: "Coral")
+    ///
+    /// If the given key is not present in the dictionary, this method adds the
+    /// key-value pair.
+    ///
+    /// - Parameters:
+    ///   - value: The new value to add to the dictionary.
+    ///   - key: The key to associate with `value`. If `key` already exists in
+    ///     the dictionary, `value` replaces the existing associated value. If
+    ///     `key` isn't already a key of the dictionary, the `(key, value)` pair
+    ///     is added.
+    public mutating func updateValue(_ value: Any?, forKey key: String) {
+        attributes[key] = value
+    }
+
+    /// Encodes and updates the value stored in the baggage for the given key, or adds a
+    /// new key-value pair if the key does not exist.
+    ///
+    /// Use this method instead of key-based subscribing when you need to know
+    /// whether the baggage was successfully updated. If the update fails, an error
+    /// will be thrown.
+    ///
+    ///     var baggage = ["Heliotrope": 296, "Coral": 16, "Aquamarine": 156]
+    ///     do {
+    ///         baggage.updateValue(18, forKey: "Coral")
+    ///     } catch {
+    ///         print(error)
+    ///     }
+    ///
+    /// If the given key is not present in the dictionary, this method adds the
+    /// key-value pair.
+    ///
+    /// - Parameters:
+    ///   - value: The new encodable value to add to the dictionary.
+    ///   - key: The key to associate with `value`. If `key` already exists in
+    ///     the dictionary, `value` replaces the existing associated value. If
+    ///     `key` isn't already a key of the dictionary, the `(key, value)` pair
+    ///     is added.
+    public mutating func encodeValue<T>(_ value: T, forKey key: String) throws where T: Encodable {
+        let encoder = AnyEncoder()
+        attributes[key] = try encoder.encode(value)
+    }
+
+    /// Returns a  dictionary containing only the key-value pairs that have
+    /// non-`nil` values as the result of transformation by the given closure.
+    ///
+    /// Use this method to receive a attributes with non-optional values when
+    /// your transformation produces optional values.
+    ///
+    /// - Parameter transform: A closure that transforms a value. `transform`
+    ///   accepts each value of the dictionary as its parameter and returns an
+    ///   optional transformed value of the same or of a different type.
+    /// - Returns: A dictionary containing the keys and non-`nil` transformed
+    ///   values of this dictionary.
+    public func compactMapValues<T>(_ transform: (Any) throws -> T?) rethrows -> [String: T] {
+        try attributes.compactMapValues(transform)
+    }
+
+    /// Accesses the value associated with the given key for reading an attribute.
+    ///
+    /// This *key-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil` otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(16)"
+    ///     print(hues["coral", type: String.self])
+    ///     // Prints "null"
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(key: String, type t: T.Type = T.self) -> T? where T: Decodable {
+        try? decodeValue(forKey: key, type: t)
+    }
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// an attribute.
+    ///
+    /// This *key-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil` otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(16)"
+    ///     print(hues["coral", type: String.self])
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// Here, the value for the key `"coral"` is updated from `16` to `18` and a
+    /// new key-value pair is added for the key `"cerise"`.
+    ///
+    ///     hues["coral"] = 18
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(18)"
+    ///
+    ///     hues["cerise"] = "ok"
+    ///     print(hues["cerise", type: String.self])
+    ///     // Prints "Optional("ok")"
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(key: String, type t: T.Type = T.self) -> T? {
+        get { value(forKey: key, type: t) }
+        set { updateValue(newValue, forKey: key) }
+    }
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// an attribute.
+    ///
+    /// This *key-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil` otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(16)"
+    ///     print(hues["coral", type: String.self])
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// Here, the value for the key `"coral"` is updated from `16` to `18` and a
+    /// new key-value pair is added for the key `"cerise"`.
+    ///
+    ///     hues["coral"] = 18
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(18)"
+    ///
+    ///     hues["cerise"] = "ok"
+    ///     print(hues["cerise", type: String.self])
+    ///     // Prints "Optional("ok")"
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(key: String, type t: T.Type = T.self) -> T? where T: Codable {
+        get { try? decodeValue(forKey: key, type: t) }
+        set { try? encodeValue(newValue, forKey: key) }
+    }
+
+    /// Accesses the value associated with the given key for reading an attribute type.
+    ///
+    /// This *dynamic-member-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`) and a key not
+    /// found in the dictionary (`"cerise"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     let coral: Int? = hues.coral
+    ///     print(coral as? Int)
+    ///     // Prints "16"
+    ///     let cerise: Int? = hues.cerise
+    ///     print(cerise)
+    ///     // Prints "null"
+    ///
+    /// - Parameter key: The key to find in the dictionary.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(dynamicMember key: String) -> T? where T: Decodable {
+        try? decodeValue(forKey: key, type: T.self)
+    }
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// an attribute type.
+    ///
+    /// This *dynamic-member-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`) and a key not
+    /// found in the dictionary (`"cerise"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     let coral: Int? = hues.coral
+    ///     print(coral as? Int)
+    ///     // Prints "16"
+    ///     let cerise: Int? = hues.cerise
+    ///     print(cerise)
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// In the following example, the key-value pair for the key `"aquamarine"`
+    /// is removed from the attribute object by assigning `nil` to the
+    /// dynamic-member-based subscript.
+    ///
+    ///     hues.aquamarine = nil
+    ///     print(hues)
+    ///     // Prints "["coral": 18, "heliotrope": 296, "cerise": 330]"
+    ///
+    /// - Parameter key: The key to find in the dictionary.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(dynamicMember key: String) -> T? {
+        get { value(forKey: key, type: T.self) }
+        set { updateValue(newValue, forKey: key) }
+    }
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// an attribute type.
+    ///
+    /// This *dynamic-member-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`) and a key not
+    /// found in the dictionary (`"cerise"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     let coral: Int? = hues.coral
+    ///     print(coral as? Int)
+    ///     // Prints "16"
+    ///     let cerise: Int? = hues.cerise
+    ///     print(cerise)
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// In the following example, the key-value pair for the key `"aquamarine"`
+    /// is removed from the attribute object by assigning `nil` to the
+    /// dynamic-member-based subscript.
+    ///
+    ///     hues.aquamarine = nil
+    ///     print(hues)
+    ///     // Prints "["coral": 18, "heliotrope": 296, "cerise": 330]"
+    ///
+    /// - Parameter key: The key to find in the dictionary.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(dynamicMember key: String) -> T? where T: Codable {
+        get { try? decodeValue(forKey: key, type: T.self) }
+        set { try? encodeValue(newValue, forKey: key) }
+    }
+
+    /// Merges with the values of another FeatureBaggage.
+    ///
+    /// - Parameter baggage: The FeatureBaggage to merge.
+    public mutating func merge(with baggage: FeatureBaggage) {
+        attributes.merge(baggage.attributes) { $1 }
+    }
+}
+
+extension FeatureBaggage: ExpressibleByDictionaryLiteral {
+    /// Creates an instance initialized with the given key-value pairs.
+    public init(dictionaryLiteral elements: (String, Any?)...) {
+        let encoder = AnyEncoder()
+        self.attributes = elements.reduce(into: [:]) { attributes, element in
+            attributes[element.0] = try? encoder.encode(AnyEncodable(element.1))
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureMessage.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureMessage.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The set of messages that can be transimtted on the Features message bus.
+public enum FeatureMessage {
+    /// An error message.
+    case error(
+        message: String,
+        baggage: FeatureBaggage
+    )
+
+    /// An encodable event that will be transmitted
+    /// as-is through a Feature.
+    case event(
+        target: String,
+        event: AnyEncodable
+    )
+
+    /// A custom message with generic encodable
+    /// attributes.
+    case custom(
+        key: String,
+        baggage: FeatureBaggage
+    )
+
+    /// A core context message.
+    ///
+    /// The core will send updated context throught the bus. Do not send new context values
+    /// from a Feature or Integration.
+    case context(DatadogContext)
+
+    /// A telemtry message.
+    ///
+    /// The core can send telemtry data coming from all Features.
+    case telemetry(TelemetryMessage)
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `FeatureMessageReceiver` defines an interface for a Feature to receive messages
+/// from a bus that is shared between Features registered to same instance of the core.
+///
+/// The message is composed of a key and a dictionary of attributes. The message format is a loose
+/// agreement between Features - all messages supported by a Feature should be properly documented.
+public protocol FeatureMessageReceiver {
+    /// Receives messages from the message bus.
+    ///
+    /// The message can be used to build an event or execute custom routine in the Feature.
+    ///
+    /// This method is always called on the same thread managed by core. If the implementation
+    /// of `FeatureMessageReceiver` needs to manage a state it can consider its mutations started
+    /// from `receive(message:from:)` to be thread-safe. The implementation should be mindful of
+    /// not blocking the caller thread to not delay processing of other messages in the system.
+    ///
+    /// - Parameters:
+    ///   - message: The message.
+    ///   - core: An instance of the core from which the message is transmitted.
+    /// - Returns: `true` if the message was processed by the receiver;`false` if it was ignored.
+    @discardableResult
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool
+}
+
+public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
+    public init() { }
+
+    /// no-op: returns `false`
+    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        return false
+    }
+}
+
+public struct CombinedFeatureMessageReceiver: FeatureMessageReceiver {
+    let receivers: [FeatureMessageReceiver]
+
+    /// Creates an instance initialized with the given receivers.
+    public init(_ receivers: FeatureMessageReceiver...) {
+        self.receivers = Array(receivers)
+    }
+
+    /// Creates an instance initialized with the given receivers.
+    public init(_ receivers: [FeatureMessageReceiver]) {
+        self.receivers = receivers
+    }
+
+    /// Receiving a message will loop though receivers and stop on the first that is able to
+    /// consume the given message.
+    ///
+    /// - Parameters:
+    ///   - message: The message.
+    ///   - core: An instance of the core from which the message is transmitted.
+    /// - Returns: `true` if the message was processed by one of the receiver; `false` if it was ignored.
+    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        receivers.contains(where: { $0.receive(message: message, from: core) })
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeaders.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeaders.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+@available(*, deprecated, renamed: "B3HTTPHeaders")
+public typealias OTelHTTPHeaders = B3HTTPHeaders
+
+/// B3 propagation headers as explained in
+/// https://github.com/openzipkin/b3-propagation/blob/master/RATIONALE.md
+public enum B3HTTPHeaders {
+    public enum Multiple {
+        /// The `X-B3-TraceId` header is encoded as 32 or 16 lower-hex characters.
+        /// For example, a 128-bit TraceId header might look like: `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124`.
+        /// Unless propagating only the Sampling State, the `X-B3-TraceId` header is required.
+        /// Currently we support 64-bit only.
+        public static let traceIDField = "X-B3-TraceId"
+
+        /// The `X-B3-SpanId` header is encoded as 16 lower-hex characters.
+        /// For example, a SpanId header might look like: `X-B3-SpanId: a2fb4a1d1a96d312`.
+        /// Unless propagating only the Sampling State, the `X-B3-SpanId` header is required.
+        public static let spanIDField = "X-B3-SpanId"
+
+        /// The `X-B3-ParentSpanId` header may be present on a child span and must be absent on the root span.
+        /// It is encoded as 16 lower-hex characters.
+        /// For example, a ParentSpanId header might look like: `X-B3-ParentSpanId: 0020000000000001`.
+        public static let parentSpanIDField = "X-B3-ParentSpanId"
+
+        /// An accept sampling decision is encoded as `X-B3-Sampled: 1` and a deny as `X-B3-Sampled: 0`.
+        /// Absent means defer the decision to the receiver of this header.
+        /// For example, a Sampled header might look like: `X-B3-Sampled: 1`.
+        ///
+        /// **Note:** Before this specification was written, some tracers propagated `X-B3-Sampled` as true or false as opposed to 1 or 0.
+        /// While you shouldn't encode `X-B3-Sampled` as true or false, a lenient implementation may accept them.
+        public static let sampledField = "X-B3-Sampled"
+    }
+
+    public enum Single {
+        /// A single header named b3 standardized in late 2018 for use in JMS and w3c `tracestate`.
+        /// In simplest terms b3 maps propagation fields into a hyphen delimited string.
+        /// `b3={TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}`, where the last two fields are optional.
+        public static let b3Field = "b3"
+    }
+
+    public enum Constants {
+        public static let sampledValue = "1"
+        public static let unsampledValue = "0"
+        public static let b3Separator = "-"
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeadersReader.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+@available(*, deprecated, renamed: "B3HTTPHeadersReader")
+public typealias OTelHTTPHeadersReader = B3HTTPHeadersReader
+
+public class B3HTTPHeadersReader: TracePropagationHeadersReader {
+    private let httpHeaderFields: [String: String]
+
+    public init(httpHeaderFields: [String: String]) {
+        self.httpHeaderFields = httpHeaderFields
+    }
+
+    public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
+        if let traceIDValue = httpHeaderFields[B3HTTPHeaders.Multiple.traceIDField],
+           let spanIDValue = httpHeaderFields[B3HTTPHeaders.Multiple.spanIDField],
+           let traceID = TraceID(traceIDValue, representation: .hexadecimal),
+           let spanID = TraceID(spanIDValue, representation: .hexadecimal) {
+            return (
+                traceID: traceID,
+                spanID: spanID,
+                parentSpanID: httpHeaderFields[B3HTTPHeaders.Multiple.parentSpanIDField]
+                    .flatMap { TraceID($0, representation: .hexadecimal) }
+            )
+        }
+
+        let b3Value = httpHeaderFields[B3HTTPHeaders.Single.b3Field]?
+            .components(separatedBy: B3HTTPHeaders.Constants.b3Separator)
+
+        if let traceIDValue = b3Value?[safe: 0],
+           let spanIDValue = b3Value?[safe: 1],
+           let traceID = TraceID(traceIDValue, representation: .hexadecimal),
+           let spanID = TraceID(spanIDValue, representation: .hexadecimal) {
+            return (
+                traceID: traceID,
+                spanID: spanID,
+                parentSpanID: b3Value?[safe: 3].flatMap({ TraceID($0, representation: .hexadecimal) })
+            )
+        }
+
+        return nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/B3/B3HTTPHeadersWriter.swift
@@ -1,0 +1,143 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+@available(*, deprecated, renamed: "B3HTTPHeadersWriter")
+public typealias OTelHTTPHeadersWriter = B3HTTPHeadersWriter
+
+/// The `B3HTTPHeadersWriter` class facilitates the injection of trace propagation headers into network requests
+/// targeted at a backend expecting [B3 propagation format](https://github.com/openzipkin/b3-propagation).
+///
+/// Usage:
+///
+///     var request = URLRequest(...)
+///
+///     let writer = B3HTTPHeadersWriter(injectEncoding: .single)
+///     let span = Tracer.shared().startRootSpan(operationName: "network request")
+///     Tracer.shared().inject(spanContext: span.context, writer: writer)
+///
+///     writer.traceHeaderFields.forEach { (field, value) in
+///         request.setValue(value, forHTTPHeaderField: field)
+///     }
+///
+///     // call span.finish() when the request completes
+///
+public class B3HTTPHeadersWriter: TracePropagationHeadersWriter {
+    /// Enumerates B3 header encoding options.
+    ///
+    /// There are two encodings of B3 propagation:
+    /// [Single Header](https://github.com/openzipkin/b3-propagation#single-header)
+    /// and [Multiple Header](https://github.com/openzipkin/b3-propagation#multiple-headers).
+    ///
+    /// Multiple header encoding employs an `X-B3-` prefixed header per item in the trace context.
+    /// Single header delimits the context into a single entry named `B3`.
+    /// The single-header variant takes precedence over the multiple header one when extracting fields.
+    public enum InjectEncoding {
+        /// Encoding that employs `X-B3-*` prefixed headers per item in the trace context.
+        ///
+        /// See: [Multiple Header](https://github.com/openzipkin/b3-propagation#multiple-headers).
+        case multiple
+        /// Encoding that uses a single `B3` header to transport the trace context.
+        ///
+        /// See: [Single Header](https://github.com/openzipkin/b3-propagation#single-header)
+        case single
+    }
+
+    /// A dictionary containing the required HTTP Headers for propagating trace information.
+    ///
+    /// Usage:
+    ///
+    ///     writer.traceHeaderFields.forEach { (field, value) in
+    ///         request.setValue(value, forHTTPHeaderField: field)
+    ///     }
+    ///
+    public private(set) var traceHeaderFields: [String: String] = [:]
+
+    /// The tracing sampler.
+    ///
+    /// The sample rate determines the `X-B3-Sampled` header field value
+    /// and whether `X-B3-TraceId`, `X-B3-SpanId`, and `X-B3-ParentSpanId` are propagated.
+    private let sampler: Sampler
+
+    /// The telemetry header encoding used by the writer.
+    private let injectEncoding: InjectEncoding
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter samplingRate: The sampling rate applied for headers injection.
+    /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:injectEncoding:)` instead.")
+    public convenience init(
+        samplingRate: Float,
+        injectEncoding: InjectEncoding = .single
+    ) {
+        self.init(sampleRate: samplingRate, injectEncoding: injectEncoding)
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
+    public convenience init(
+        sampleRate: Float = 20,
+        injectEncoding: InjectEncoding = .single
+    ) {
+        self.init(
+            sampler: Sampler(samplingRate: sampleRate),
+            injectEncoding: injectEncoding
+        )
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampler: The sampler used for headers injection.
+    /// - Parameter injectEncoding: The B3 header encoding type, with `.single` as the default.
+    public init(
+        sampler: Sampler,
+        injectEncoding: InjectEncoding = .single
+    ) {
+        self.sampler = sampler
+        self.injectEncoding = injectEncoding
+    }
+
+    /// Writes the trace ID, span ID, and optional parent span ID into the trace propagation headers.
+    ///
+    /// - Parameter traceID: The trace ID.
+    /// - Parameter spanID: The span ID.
+    /// - Parameter parentSpanID: The parent span ID, if applicable.
+    public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
+        let samplingPriority = sampler.sample()
+
+        typealias Constants = B3HTTPHeaders.Constants
+
+        switch injectEncoding {
+        case .multiple:
+            traceHeaderFields = [
+                B3HTTPHeaders.Multiple.sampledField: samplingPriority ? Constants.sampledValue : Constants.unsampledValue
+            ]
+
+            if samplingPriority {
+                traceHeaderFields[B3HTTPHeaders.Multiple.traceIDField] = String(traceID, representation: .hexadecimal32Chars)
+                traceHeaderFields[B3HTTPHeaders.Multiple.spanIDField] = String(spanID, representation: .hexadecimal16Chars)
+                traceHeaderFields[B3HTTPHeaders.Multiple.parentSpanIDField] = parentSpanID.map { String($0, representation: .hexadecimal16Chars) }
+            }
+        case .single:
+            if samplingPriority {
+                traceHeaderFields[B3HTTPHeaders.Single.b3Field] = [
+                    String(traceID, representation: .hexadecimal32Chars),
+                    String(spanID, representation: .hexadecimal16Chars),
+                    samplingPriority ? Constants.sampledValue : Constants.unsampledValue,
+                    parentSpanID.map { String($0, representation: .hexadecimal16Chars) }
+                ]
+                .compactMap { $0 }
+                .joined(separator: Constants.b3Separator)
+            } else {
+                traceHeaderFields[B3HTTPHeaders.Single.b3Field] = Constants.unsampledValue
+            }
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/HTTPHeadersReader.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public class HTTPHeadersReader: TracePropagationHeadersReader {
+    private let httpHeaderFields: [String: String]
+
+    public init(httpHeaderFields: [String: String]) {
+        self.httpHeaderFields = httpHeaderFields
+    }
+
+    public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
+        guard let traceIDValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
+              let spanIDValue = httpHeaderFields[TracingHTTPHeaders.parentSpanIDField],
+              let traceID = TraceID(traceIDValue),
+              let spanID = TraceID(spanIDValue)
+        else {
+            return nil
+        }
+
+        return (
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: nil
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/HTTPHeadersWriter.swift
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `HTTPHeadersWriter` class facilitates the injection of trace propagation headers into network requests
+/// targeted at a backend instrumented with Datadog and expecting `x-datadog-*` headers.
+///
+/// Usage:
+///
+///     var request = URLRequest(...)
+///
+///     let writer = HTTPHeadersWriter()
+///     let span = Tracer.shared().startRootSpan(operationName: "network request")
+///     Tracer.shared().inject(spanContext: span.context, writer: writer)
+///
+///     writer.traceHeaderFields.forEach { (field, value) in
+///         request.setValue(value, forHTTPHeaderField: field)
+///     }
+///
+///     // call span.finish() when the request completes
+///
+public class HTTPHeadersWriter: TracePropagationHeadersWriter {
+    /// A dictionary containing the required HTTP Headers for propagating trace information.
+    ///
+    /// Usage:
+    ///
+    ///     writer.traceHeaderFields.forEach { (field, value) in
+    ///         request.setValue(value, forHTTPHeaderField: field)
+    ///     }
+    ///
+    public private(set) var traceHeaderFields: [String: String] = [:]
+
+    /// The tracing sampler.
+    ///
+    /// This value will decide of the `x-datadog-sampling-priority` header field value
+    /// and if `x-datadog-trace-id` and `x-datadog-parent-id` are propagated.
+    private let sampler: Sampler
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter samplingRate: The sampling rate applied for headers injection.
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    public convenience init(samplingRate: Float) {
+        self.init(sampleRate: samplingRate)
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    public convenience init(sampleRate: Float = 20) {
+        self.init(sampler: Sampler(samplingRate: sampleRate))
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampler: The sampler used for headers injection.
+    public init(sampler: Sampler) {
+        self.sampler = sampler
+    }
+
+    /// Writes the trace ID, span ID, and optional parent span ID into the trace propagation headers.
+    ///
+    /// - Parameter traceID: The trace ID.
+    /// - Parameter spanID: The span ID.
+    /// - Parameter parentSpanID: The parent span ID, if applicable.
+    public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
+        let samplingPriority = sampler.sample()
+
+        traceHeaderFields = [
+            TracingHTTPHeaders.samplingPriorityField: samplingPriority ? "1" : "0"
+        ]
+
+        if samplingPriority {
+            traceHeaderFields[TracingHTTPHeaders.traceIDField] = String(traceID)
+            traceHeaderFields[TracingHTTPHeaders.parentSpanIDField] = String(spanID)
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/TracingHTTPHeaders.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/Datadog/TracingHTTPHeaders.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Trace propagation headers as explained in
+/// https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#how-are-rum-resources-linked-to-traces
+public enum TracingHTTPHeaders {
+    /// Trace propagation header.
+    /// It is used both in Tracing and RUM features.
+    public static let traceIDField = "x-datadog-trace-id"
+
+    /// Trace propagation header.
+    /// In RUM - it allows Datadog to generate the first span from the trace.
+    /// In Tracing - it injects the `spanID` of mobile span so downstream spans can be properly linked in distributed tracing.
+    public static let parentSpanIDField = "x-datadog-parent-id"
+
+    /// To make sure that the Agent keeps the trace.
+    /// It is used both in Tracing and RUM features.
+    public static let samplingPriorityField = "x-datadog-sampling-priority"
+
+    /// The Datadog origin of the Trace.
+    ///
+    /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
+    public static let originField = "x-datadog-origin"
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/DatadogURLSessionHandler.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/DatadogURLSessionHandler.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// An interface for processing `URLSession` task interceptions.
+public protocol DatadogURLSessionHandler {
+    /// The interceptor's first party hosts
+    var firstPartyHosts: FirstPartyHosts { get }
+
+    /// Tells the interceptor to modify a URL request.
+    ///
+    /// - Parameters:
+    ///   - request: The request to intercept.
+    ///   - additionalFirstPartyHosts: Additional 1st-party hosts.
+    /// - Returns: The modified request.
+    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest
+
+    /// Tells the interceptor that the session did start.
+    ///
+    /// - Parameter interception: The URLSession interception.
+    func interceptionDidStart(interception: URLSessionTaskInterception)
+
+    /// Tells the interceptor that the session did complete.
+    ///
+    /// - Parameter interception: The URLSession interception.
+    func interceptionDidComplete(interception: URLSessionTaskInterception)
+}
+
+internal struct NOPDatadogURLSessionInterceptor: DatadogURLSessionHandler {
+    /// no-op
+    var firstPartyHosts: FirstPartyHosts { .init() }
+    /// no-op
+    func modify(request: URLRequest, headerTypes: Set<TracingHeaderType>) -> URLRequest { request }
+    /// no-op
+    func interceptionDidStart(interception: URLSessionTaskInterception) { }
+    /// no-op
+    func interceptionDidComplete(interception: URLSessionTaskInterception) { }
+}
+
+extension DatadogCoreProtocol {
+    /// Core extension for registering `URLSession` handlers.
+    ///
+    /// - Parameter urlSessionHandler: The `URLSession` handlers to register.
+    public func register(urlSessionHandler: DatadogURLSessionHandler) throws {
+        let feature = try get(feature: NetworkInstrumentationFeature.self) ?? .init()
+        feature.handlers.append(urlSessionHandler)
+        try register(feature: feature)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/FirstPartyHosts.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/FirstPartyHosts.swift
@@ -1,0 +1,98 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A struct that represents a dictionary of host names and tracing header types.
+public struct FirstPartyHosts: Equatable {
+    fileprivate var hostsWithTracingHeaderTypes: [String: Set<TracingHeaderType>]
+
+    public var hosts: Set<String> {
+        return Set(hostsWithTracingHeaderTypes.keys)
+    }
+
+    /// Creates a `FirstPartyHosts` instance with the given dictionary of host names and tracing header types.
+    ///
+    /// - Parameter hostsWithTracingHeaderTypes: The dictionary of host names and tracing header types.
+    public init(_ hostsWithTracingHeaderTypes: [String: Set<TracingHeaderType>]) {
+        self.init(hostsWithTracingHeaderTypes: hostsWithTracingHeaderTypes)
+    }
+
+    /// Creates a `FirstPartyHosts` instance with the given set of host names by assigning `.datadog` header type to each.
+    ///
+    /// - Parameter hosts: The set of host names.
+    public init(_ hosts: Set<String>) {
+        self.init(
+            hostsWithTracingHeaderTypes: hosts.reduce(into: [:], { partialResult, host in
+                partialResult[host] = [.datadog]
+            })
+        )
+    }
+
+    /// Creates empty (no hosts) `FirstPartyHosts`.
+    public init() {
+        self.init(hostsWithTracingHeaderTypes: [:])
+    }
+
+    internal init(
+        hostsWithTracingHeaderTypes: [String: Set<TracingHeaderType>],
+        hostsSanitizer: HostsSanitizing = HostsSanitizer()
+    ) {
+        self.hostsWithTracingHeaderTypes = hostsSanitizer.sanitized(
+            hostsWithTracingHeaderTypes: hostsWithTracingHeaderTypes,
+            warningMessage: "The first party host with header types configured for Datadog SDK is not valid"
+        )
+    }
+
+    /// The function takes a `URL` and returns a `Set<TracingHeaderType>` of matching values.
+    /// If one than more match is found it will return union of matching values.
+    public func tracingHeaderTypes(for url: URL?) -> Set<TracingHeaderType> {
+        return hostsWithTracingHeaderTypes.compactMap { item -> Set<TracingHeaderType>? in
+            let regex = "^(.*\\.)*\(NSRegularExpression.escapedPattern(for: item.key))$"
+            if url?.host?.range(of: regex, options: .regularExpression) != nil {
+                return item.value
+            }
+            return nil
+        }
+        .reduce(into: Set(), { partialResult, value in
+            partialResult.formUnion(value)
+        })
+    }
+
+    /// Returns `true` if given `URL` matches the first party hosts defined by the user; `false` otherwise.
+    public func isFirstParty(url: URL?) -> Bool {
+        return !tracingHeaderTypes(for: url).isEmpty
+    }
+
+    // Returns `true` if given `String` can be parsed as a URL and matches the first
+    // party hosts defined by the user; `false` otherwise
+    public func isFirstParty(string: String) -> Bool {
+        guard let url = URL(string: string) else {
+            return false
+        }
+        return isFirstParty(url: url)
+    }
+}
+
+public func += (left: inout FirstPartyHosts?, right: FirstPartyHosts) {
+    left = FirstPartyHosts(
+        left?.hostsWithTracingHeaderTypes.merging(right.hostsWithTracingHeaderTypes, uniquingKeysWith: { left, right in
+            left.union(right)
+        }) ?? right.hostsWithTracingHeaderTypes
+    )
+}
+
+public func + (left: FirstPartyHosts, right: FirstPartyHosts?) -> FirstPartyHosts {
+    guard let right = right else {
+        return left
+    }
+
+    return FirstPartyHosts(
+        left.hostsWithTracingHeaderTypes.merging(right.hostsWithTracingHeaderTypes, uniquingKeysWith: { left, right in
+            left.union(right)
+        })
+    )
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/HostsSanitizer.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/HostsSanitizer.swift
@@ -1,0 +1,98 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol HostsSanitizing {
+    func sanitized(hosts: Set<String>, warningMessage: String) -> Set<String>
+    func sanitized(
+        hostsWithTracingHeaderTypes: [String: Set<TracingHeaderType>],
+        warningMessage: String
+    ) -> [String: Set<TracingHeaderType>]
+}
+
+public struct HostsSanitizer: HostsSanitizing {
+    private let urlRegex = #"^(http|https)://(.*)"#
+    private let hostRegex = #"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)+([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])$"#
+    private let ipRegex = #"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"#
+
+    public init() { }
+
+    private func sanitize(host: String, warningMessage: String) -> (String?, String?) {
+        if host.range(of: urlRegex, options: .regularExpression) != nil {
+            // if an URL is given instead of the host, take its `host` part
+            if let sanitizedHost = URL(string: host)?.host {
+                let warning = "'\(host)' is an url and will be sanitized to: '\(sanitizedHost)'."
+                return (sanitizedHost, warning)
+            } else {
+                // otherwise, drop
+                let warning = "'\(host)' is not a valid host name and will be dropped."
+                return (nil, warning)
+            }
+        } else if host.range(of: hostRegex, options: .regularExpression) != nil {
+            // if a valid host name is given, accept it
+            return (host, nil)
+        } else if host.range(of: ipRegex, options: .regularExpression) != nil {
+            // if a valid IP address is given, accept it
+            return (host, nil)
+        } else if host == "localhost" {
+            // if "localhost" given, accept it
+            return (host, nil)
+        } else {
+            // otherwise, drop
+            let warning = "'\(host)' is not a valid host name and will be dropped."
+            return (nil, warning)
+        }
+    }
+
+    private func printWarnings(_ warningMessage: String, _ warnings: [String]) {
+        warnings.forEach { warning in
+            consolePrint(
+                    """
+                    ⚠️ \(warningMessage): \(warning)
+                    """
+            )
+        }
+    }
+
+    public func sanitized(hosts: Set<String>, warningMessage: String) -> Set<String> {
+        var warnings: [String] = []
+
+        let array: [String] = hosts.compactMap { host in
+            let (sanitizedHost, warning) = sanitize(host: host, warningMessage: warningMessage)
+            if let warning = warning {
+                warnings.append(warning)
+            }
+            return sanitizedHost
+        }
+
+        printWarnings(warningMessage, warnings)
+
+        return Set(array)
+    }
+
+    public func sanitized(
+        hostsWithTracingHeaderTypes: [String: Set<TracingHeaderType>],
+        warningMessage: String
+    ) -> [String: Set<TracingHeaderType>] {
+        var warnings: [String] = []
+
+        let sanitized: [String: Set<TracingHeaderType>] = hostsWithTracingHeaderTypes.reduce(into: [:]) { partialResult, item in
+            let host = item.key
+            let (sanitizedHost, warning) = sanitize(host: host, warningMessage: warningMessage)
+            if let warning = warning {
+                warnings.append(warning)
+            }
+            if let sanitizedHost = sanitizedHost {
+                partialResult[sanitizedHost] = item.value
+            }
+        }
+
+        printWarnings(warningMessage, warnings)
+
+        return sanitized
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -1,0 +1,193 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The Network Instrumentation Feature that can be registered into a core if
+/// any hander is provided.
+///
+/// Usage:
+///
+///     let core: DatadogCoreProtocol
+///
+///     let handler: DatadogURLSessionHandler = CustomURLSessionHandler()
+///     core.register(urlSessionInterceptor: handler)
+///
+/// Registering multiple interceptor will aggregate instrumentation.
+internal final class NetworkInstrumentationFeature: DatadogFeature {
+    /// The Feature name: "trace-propagation".
+    static let name = "network-instrumentation"
+
+    /// Network Instrumentation serial queue for safe and serialized access to the
+    /// `URLSessionTask` interceptions.
+    internal let queue = DispatchQueue(
+        label: "com.datadoghq.network-instrumentation",
+        target: .global(qos: .utility)
+    )
+
+    /// A no-op message bus receiver.
+    internal let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+
+    /// The list of registered handlers.
+    ///
+    /// Accessing this list will acquire a read-write lock for fast read operation when mutating
+    /// a `URLRequest`
+    @ReadWriteLock
+    internal var handlers: [DatadogURLSessionHandler] = []
+
+    /// Maps `URLSessionTask` to its `TaskInterception` object.
+    ///
+    /// The interceptions **must** be accessed using the `queue`.
+    private var interceptions: [URLSessionTask: URLSessionTaskInterception] = [:]
+
+    init() throws {
+        try URLSessionSwizzler.bind()
+    }
+
+    deinit {
+        URLSessionSwizzler.unbind()
+    }
+}
+
+extension NetworkInstrumentationFeature {
+    /// Tells the interceptors to modify a URL request.
+    ///
+    /// - Parameters:
+    ///   - request: The request to intercept.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception
+    /// - Returns: The modified request.
+    func intercept(request: URLRequest, additionalFirstPartyHosts: FirstPartyHosts?) -> URLRequest {
+        let headerTypes = firstPartyHosts(with: additionalFirstPartyHosts)
+            .tracingHeaderTypes(for: request.url)
+
+        guard !headerTypes.isEmpty else {
+            return request
+        }
+
+        return handlers.reduce(request) {
+            $1.modify(request: $0, headerTypes: headerTypes)
+        }
+    }
+
+    /// Tells the interceptors that a task was created.
+    ///
+    /// - Parameters:
+    ///   - task: The created task.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
+    func intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts?) {
+        guard let request = task.originalRequest else {
+            return
+        }
+
+        queue.async {
+            let firstPartyHosts = self.firstPartyHosts(with: additionalFirstPartyHosts)
+
+            let interception = URLSessionTaskInterception(
+                request: request,
+                isFirstParty: firstPartyHosts.isFirstParty(url: request.url)
+            )
+
+            if let trace = self.extractTrace(firstPartyHosts: firstPartyHosts, request: request) {
+                interception.register(traceID: trace.traceID, spanID: trace.spanID, parentSpanID: trace.parentSpanID)
+            }
+
+            if let origin = request.value(forHTTPHeaderField: TracingHTTPHeaders.originField) {
+                interception.register(origin: origin)
+            }
+
+            self.interceptions[task] = interception
+            self.handlers.forEach { $0.interceptionDidStart(interception: interception) }
+        }
+    }
+
+    /// Tells the interceptors that metrics were collected for the given task.
+    ///
+    /// - Parameters:
+    ///   - task: The task whose metrics have been collected.
+    ///   - metrics: The collected metrics.
+    func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        queue.async {
+            guard let interception = self.interceptions[task] else {
+                return
+            }
+
+            interception.register(
+                metrics: ResourceMetrics(taskMetrics: metrics)
+            )
+
+            if interception.isDone {
+                self.finish(task: task, interception: interception)
+            }
+        }
+    }
+
+    /// Tells the interceptors that the task has received some of the expected data.
+    ///
+    /// - Parameters:
+    ///   - task: The task that provided data.
+    ///   - data: A data object containing the transferred data.
+    func task(_ task: URLSessionTask, didReceive data: Data) {
+        queue.async { self.interceptions[task]?.register(nextData: data) }
+    }
+
+    /// Tells the interceptors that the task did complete.
+    ///
+    /// - Parameters:
+    ///   - task: The task that has finished transferring data.
+    ///   - error: If an error occurred, an error object indicating how the transfer failed, otherwise NULL.
+    func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
+        queue.async {
+            guard let interception = self.interceptions[task] else {
+                return
+            }
+
+            interception.register(
+                response: task.response,
+                error: error
+            )
+
+            if interception.isDone {
+                self.finish(task: task, interception: interception)
+            }
+        }
+    }
+
+    private func firstPartyHosts(with additionalFirstPartyHosts: FirstPartyHosts?) -> FirstPartyHosts {
+        handlers.reduce(.init()) { $0 + $1.firstPartyHosts } + additionalFirstPartyHosts
+    }
+
+    private func finish(task: URLSessionTask, interception: URLSessionTaskInterception) {
+        interceptions[task] = nil
+        handlers.forEach { $0.interceptionDidComplete(interception: interception) }
+    }
+
+    private func extractTrace(firstPartyHosts: FirstPartyHosts, request: URLRequest) -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
+        guard let headers = request.allHTTPHeaderFields else {
+            return nil
+        }
+
+        let tracingHeaderTypes = firstPartyHosts.tracingHeaderTypes(for: request.url)
+
+        let reader: TracePropagationHeadersReader
+        if tracingHeaderTypes.contains(.datadog) {
+            reader = HTTPHeadersReader(httpHeaderFields: headers)
+        } else if tracingHeaderTypes.contains(.b3) || tracingHeaderTypes.contains(.b3multi) {
+            reader = B3HTTPHeadersReader(httpHeaderFields: headers)
+        } else {
+            reader = W3CHTTPHeadersReader(httpHeaderFields: headers)
+        }
+        return reader.read()
+    }
+}
+
+extension NetworkInstrumentationFeature: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TraceID.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TraceID.swift
@@ -1,0 +1,127 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public typealias SpanID = TraceID
+
+public struct TraceID: RawRepresentable, Equatable, Hashable {
+    /// The `String` representation format of a `TraceID`.
+    public enum Representation {
+        case decimal
+        case hexadecimal
+        case hexadecimal16Chars
+        case hexadecimal32Chars
+    }
+
+    /// The unique integer (64-bit unsigned) ID of the trace containing this span.
+    /// - See also: [Datadog API Reference - Send Traces](https://docs.datadoghq.com/api/?lang=bash#send-traces)
+    public let rawValue: UInt64
+
+    /// Creates a new instance with the specified raw value.
+    ///
+    /// - Parameter rawValue: The raw value to use for the new instance.
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+}
+
+extension TraceID {
+    /// Creates a `TraceID` from a `String` representation.
+    ///
+    /// - Parameters:
+    ///   - string: The `String` representation.
+    ///   - representation: The representation, `.decimal` by default.
+    public init?(_ string: String, representation: Representation = .decimal) {
+        switch representation {
+        case .decimal:
+            guard let rawValue = UInt64(string) else {
+                return nil
+            }
+
+            self.init(rawValue: rawValue)
+        case .hexadecimal, .hexadecimal16Chars, .hexadecimal32Chars:
+            guard let rawValue = UInt64(string, radix: 16) else {
+                return nil
+            }
+
+            self.init(rawValue: rawValue)
+        }
+    }
+}
+
+extension TraceID: ExpressibleByIntegerLiteral {
+    /// Creates an instance initialized to the specified integer value.
+    ///
+    /// Do not call this initializer directly. Instead, initialize a variable or
+    /// constant using an integer literal. For example:
+    ///
+    ///     let id: TraceID = 23
+    ///
+    /// In this example, the assignment to the `id` constant calls this integer
+    /// literal initializer behind the scenes.
+    ///
+    /// - Parameter value: The value to create.
+    public init(integerLiteral value: UInt64) {
+        self.init(rawValue: value)
+    }
+}
+
+extension String {
+    /// Creates a `String` representation of a `TraceID`.
+    ///
+    /// - Parameters:
+    ///   - traceID: The Trace ID
+    ///   - representation: The required representation. `.decimal` by default.
+    public init(_ traceID: TraceID, representation: TraceID.Representation = .decimal) {
+        switch representation {
+        case .decimal:
+            self.init(traceID.rawValue)
+        case .hexadecimal:
+            self.init(traceID.rawValue, radix: 16)
+        case .hexadecimal16Chars:
+            self.init(format: "%016llx", traceID.rawValue)
+        case .hexadecimal32Chars:
+            self.init(format: "%032llx", traceID.rawValue)
+        }
+    }
+}
+
+/// A `TraceID` generator interface.
+public protocol TraceIDGenerator {
+    /// Generates a new and unique `TraceID`.
+    ///
+    /// - Returns: The generated `TraceID`
+    func generate() -> TraceID
+}
+
+/// A Default `TraceID` genarator.
+public struct DefaultTraceIDGenerator: TraceIDGenerator {
+    /// Describes the lower and upper boundary of tracing ID generation.
+    ///
+    /// * Lower: starts with `1` as `0` is reserved for historical reason: 0 == "unset", ref: dd-trace-java:DDId.java.
+    /// * Upper: equals to `2 ^ 63 - 1` as some tracers can't handle the `2 ^ 64 -1` range, ref: dd-trace-java:DDId.java.
+    public static let defaultGenerationRange = (1...UInt64.max >> 1)
+
+    /// The generator's range.
+    let range: ClosedRange<UInt64>
+
+    /// Creates a default generator.
+    /// 
+    /// - Parameter range: The generator's range.
+    public init(range: ClosedRange<UInt64> = Self.defaultGenerationRange) {
+        self.range = range
+    }
+
+    /// Generates a new and unique `TraceID`.
+    ///
+    /// The Trace ID will be generated within the range.
+    ///
+    /// - Returns: The generated `TraceID`
+    public func generate() -> TraceID {
+        return TraceID(rawValue: .random(in: range))
+   }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracePropagationHeadersReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracePropagationHeadersReader.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Interface that defines shared responibilities of HTTP header readers.
+public protocol TracePropagationHeadersReader {
+    func read() -> (
+        traceID: TraceID,
+        spanID: SpanID,
+        parentSpanID: SpanID?
+    )?
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracePropagationHeadersWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracePropagationHeadersWriter.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Write interface for a custom carrier
+public protocol TracePropagationHeadersWriter {
+    var traceHeaderFields: [String: String] { get }
+
+    /// Inject a span context into the custom carrier
+    ///
+    /// - parameter spanContext: context to inject into the custom carrier
+    func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)
+}
+
+extension TracePropagationHeadersWriter {
+    public func write(traceID: TraceID, spanID: SpanID) {
+        write(traceID: traceID, spanID: spanID, parentSpanID: nil)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracingHeaderType.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/TracingHeaderType.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The type of the tracing header injected to requests.
+///
+/// - `datadog` - [Datadog's `x-datadog-*` header](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#how-are-rum-resources-linked-to-traces).
+/// - `b3` - Open Telemetry B3 [Single header](https://github.com/openzipkin/b3-propagation#single-headers).
+/// - `b3multi` - Open Telemetry B3 [Multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers).
+/// - `tracecontext` - W3C [Trace Context header](https://www.w3.org/TR/trace-context/#tracestate-header)
+public enum TracingHeaderType: Hashable {
+    case datadog
+    case b3
+    case b3multi
+    case tracecontext
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public typealias DDURLSessionDelegate = DatadogURLSessionDelegate
+
+/// An interface for forwarding `URLSessionDelegate` calls to `DDURLSessionDelegate`.
+/// The implementation must ensure that required methods are called on the `ddURLSessionDelegate`.
+@objc
+public protocol __URLSessionDelegateProviding: URLSessionDelegate {
+    /// Datadog delegate object.
+    /// The class implementing `DDURLSessionDelegateProviding` must ensure that following method calls are forwarded to `ddURLSessionDelegate`:
+    /// - `func urlSession(_:task:didFinishCollecting:)`
+    /// - `func urlSession(_:task:didCompleteWithError:)`
+    /// - `func urlSession(_:dataTask:didReceive:)`
+    var ddURLSessionDelegate: DatadogURLSessionDelegate { get }
+}
+
+/// The `URLSession` delegate object which enables network requests instrumentation. **It must be
+/// used together with** `DatadogRUM` or `DatadogTrace`.
+///
+/// All requests made with the `URLSession` instrumented with this delegate will be intercepted by the SDK.
+@objc
+open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
+    var interceptor: URLSessionInterceptor? {
+        let core = self.core ?? CoreRegistry.default
+        return URLSessionInterceptor.shared(in: core)
+    }
+
+    /* private */ public let firstPartyHosts: FirstPartyHosts
+
+    /// The instance of the SDK core notified by this delegate.
+    /// 
+    /// It must be a weak reference, because `URLSessionDelegate` can last longer than core instance.
+    /// Any `URLSession` will retain its delegate until `.invalidateAndCancel()` is called.
+    private weak var core: DatadogCoreProtocol?
+
+    @objc
+    override public init() {
+        core = nil
+        firstPartyHosts = .init()
+        super.init()
+    }
+
+    /// Automatically tracked hosts can be customized per instance with this initializer.
+    ///
+    /// **NOTE:** If `trackURLSession(firstPartyHostsWithHeaderTypes:)` is never called, automatic tracking will **not** take place.
+    ///
+    /// - Parameter additionalFirstPartyHostsWithHeaderTypes: these hosts are tracked **in addition to** what was
+    /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHostsWithHeaderTypes:)`
+    public convenience init(additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>]) {
+        self.init(
+            in: nil,
+            additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHostsWithHeaderTypes
+        )
+    }
+
+    /// Automatically tracked hosts can be customized per instance with this initializer.
+    ///
+    /// **NOTE:** If `trackURLSession(firstPartyHosts:)` is never called, automatic tracking will **not** take place.
+    ///
+    /// - Parameter additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
+    /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
+    @objc
+    public convenience init(additionalFirstPartyHosts: Set<String>) {
+        self.init(
+            in: nil,
+            additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
+                partialResult[host] = [.datadog]
+            })
+        )
+    }
+
+    /// Automatically tracked hosts can be customized per instance with this initializer.
+    ///
+    /// **NOTE:** If `trackURLSession(firstPartyHostsWithHeaderTypes:)` is never called, automatic tracking will **not** take place.
+    ///
+    /// - Parameters:
+    ///   - core: Datadog SDK instance (or `nil` to use default SDK instance).
+    ///   - additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
+    ///                                passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
+    public init(
+        in core: DatadogCoreProtocol? = nil,
+        additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>] = [:]
+    ) {
+        self.core = core
+        self.firstPartyHosts = FirstPartyHosts(additionalFirstPartyHostsWithHeaderTypes)
+        super.init()
+    }
+
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        interceptor?.task(task, didFinishCollecting: metrics)
+    }
+
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
+        interceptor?.task(dataTask, didReceive: data)
+    }
+
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
+        interceptor?.task(task, didCompleteWithError: error)
+    }
+}
+
+extension DatadogURLSessionDelegate: __URLSessionDelegateProviding {
+    public var ddURLSessionDelegate: DatadogURLSessionDelegate { self }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionInterceptor.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionInterceptor.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `URLSession` Interceptor provides methods for injecting distributed-traces
+/// headers into a `URLRequest`and to instrument a `URLURLSessionTask` lifcycle,
+/// from its creation to completion.
+///
+/// Any Feature supporting `URLSession` instrumentation will receive interceptions through
+/// their `DatadogURLSessionHandler` implementation.
+public struct URLSessionInterceptor {
+    let feature: NetworkInstrumentationFeature
+
+    /// Returns the Interceptor registerd in core.
+    ///
+    /// This method will return an interceptor if any `DatadogURLSessionHandler` have been
+    /// registered in the given core.
+    public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> URLSessionInterceptor? {
+        guard let feature = core.get(feature: NetworkInstrumentationFeature.self) else {
+            return nil
+        }
+
+        return URLSessionInterceptor(feature: feature)
+    }
+
+    /// Tells the interceptor to modify a URL request.
+    ///
+    /// - Parameters:
+    ///   - request: The request to intercept.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
+    /// - Returns: The modified request.
+    public func intercept(request: URLRequest, additionalFirstPartyHosts: FirstPartyHosts? = nil) -> URLRequest {
+        feature.intercept(request: request, additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    /// Tells the interceptors that a task was created.
+    ///
+    /// - Parameters:
+    ///   - task: The created task.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
+    public func intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts? = nil) {
+        feature.intercept(task: task, additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    /// Tells the interceptor that metrics were collected for the given task.
+    ///
+    /// - Parameters:
+    ///   - task: The task whose metrics have been collected.
+    ///   - metrics: The collected metrics.
+    public func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        feature.task(task, didFinishCollecting: metrics)
+    }
+
+    /// Tells the interceptor that the task has received some of the expected data.
+    ///
+    /// - Parameters:
+    ///   - task: The data task that provided data.
+    ///   - data: A data object containing the transferred data.
+    public func task(_ task: URLSessionTask, didReceive data: Data) {
+        feature.task(task, didReceive: data)
+    }
+
+    /// Tells the interceptor that the task did complete.
+    ///
+    /// - Parameters:
+    ///   - task: The task that has finished transferring data.
+    ///   - error: If an error occurred, an error object indicating how the transfer failed, otherwise NULL.
+    public func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
+        feature.task(task, didCompleteWithError: error)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
@@ -1,0 +1,285 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal class URLSessionSwizzler {
+    /// Counts of bindings of the URL swizzler.
+    ///
+    /// This value will increment for each call to the `bind()` method.
+    /// Calling `unbind()` will decrement the count, when reaching zero, the swizzler is disabled.
+    internal private(set) static var bindingsCount: UInt = 0
+    /// The binding lock.
+    private static var lock = NSLock()
+    /// `URLSession.dataTask(with:completionHandler:)` (for `URLRequest`) swizzling.
+    internal private(set) static var dataTaskWithURLRequestAndCompletion: DataTaskWithURLRequestAndCompletion?
+    /// `URLSession.dataTask(with:)` (for `URLRequest`) swizzling.
+    internal private(set) static var dataTaskWithURLRequest: DataTaskWithURLRequest?
+    /// `URLSession.dataTask(with:completionHandler:)` (for `URL`) swizzling. Only applied on iOS 13 and above.
+    internal private(set) static var dataTaskWithURLAndCompletion: DataTaskWithURLAndCompletion?
+    /// `URLSession.dataTask(with:)` (for `URL`) swizzling. Only applied on iOS 13 and above.
+    internal private(set) static var dataTaskWithURL: DataTaskWithURL?
+
+    static func bind() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard bindingsCount == 0 else {
+            return bindingsCount += 1
+        }
+
+        if #available(iOS 13.0, *) {
+            // Prior to iOS 13.0 we do not apply following swizzlings, as those methods call
+            // the `URLSession.dataTask(with:completionHandler:)` internally which is managed
+            // by the `DataTaskWithURLRequestAndCompletion` swizzling.
+            dataTaskWithURLAndCompletion = try DataTaskWithURLAndCompletion.build()
+            dataTaskWithURL = try DataTaskWithURL.build()
+        }
+
+        dataTaskWithURLRequestAndCompletion = try DataTaskWithURLRequestAndCompletion.build()
+        dataTaskWithURLRequest = try DataTaskWithURLRequest.build()
+
+        dataTaskWithURLRequestAndCompletion?.swizzle()
+        dataTaskWithURLAndCompletion?.swizzle()
+        dataTaskWithURLRequest?.swizzle()
+        dataTaskWithURL?.swizzle()
+
+        bindingsCount += 1
+    }
+
+    static func unbind() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if bindingsCount == 0 {
+            return
+        }
+
+        if bindingsCount > 1 {
+            return bindingsCount -= 1
+        }
+
+        dataTaskWithURLRequestAndCompletion?.unswizzle()
+        dataTaskWithURLRequest?.unswizzle()
+        dataTaskWithURLAndCompletion?.unswizzle()
+        dataTaskWithURL?.unswizzle()
+
+        dataTaskWithURLRequestAndCompletion = nil
+        dataTaskWithURLRequest = nil
+        dataTaskWithURLAndCompletion = nil
+        dataTaskWithURL = nil
+
+        bindingsCount -= 1
+    }
+
+    // MARK: - Swizzlings
+
+    typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+
+    /// Swizzles the `URLSession.dataTask(with:completionHandler:)` for `URLRequest`.
+    class DataTaskWithURLRequestAndCompletion: MethodSwizzler<
+        @convention(c) (URLSession, Selector, URLRequest, CompletionHandler?) -> URLSessionDataTask,
+        @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
+    > {
+        private static let selector = #selector(
+            URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+        )
+
+        private let method: FoundMethod
+
+        static func build() throws -> DataTaskWithURLRequestAndCompletion {
+            return try DataTaskWithURLRequestAndCompletion(
+                selector: self.selector,
+                klass: URLSession.self
+            )
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try Self.findMethod(with: selector, in: klass)
+            super.init()
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
+            swizzle(method) { previousImplementation -> Signature in
+                return { session, request, completionHandler -> URLSessionDataTask in
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.interceptor
+                    else {
+                        return previousImplementation(session, Self.selector, request, completionHandler)
+                    }
+
+                    guard let completionHandler = completionHandler else {
+                        // The `completionHandler` can be `nil` in two cases:
+                        // - on iOS 11 or 12, where `dataTask(with:)` (for `URL` and `URLRequest`) calls
+                        //   the `dataTask(with:completionHandler:)` (for `URLRequest`) internally by nullifying the completion block.
+                        // - when `[session dataTaskWithURL:completionHandler:]` is called in Objective-C with explicitly passing
+                        //   `nil` as the `completionHandler` (it produces a warning, but compiles).
+                        let task = previousImplementation(session, Self.selector, request, completionHandler)
+                        interceptor.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                        return task
+                    }
+
+                    var _task: URLSessionDataTask?
+                    let request = interceptor.intercept(request: request, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                    let task = previousImplementation(session, Self.selector, request) { data, response, error in
+                        completionHandler(data, response, error)
+
+                        if let task = _task { // sanity check, should always succeed
+                            data.map { interceptor.task(task, didReceive: $0) }
+                            interceptor.task(task, didCompleteWithError: error)
+                        }
+                    }
+
+                    _task = task
+                    interceptor.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                    return task
+                }
+            }
+        }
+    }
+
+    /// Swizzles the `URLSession.dataTask(with:completionHandler:)` for `URL`.
+    class DataTaskWithURLAndCompletion: MethodSwizzler<
+        @convention(c) (URLSession, Selector, URL, CompletionHandler?) -> URLSessionDataTask,
+        @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
+    > {
+        private static let selector = #selector(
+            URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask
+        )
+
+        private let method: FoundMethod
+
+        static func build() throws -> DataTaskWithURLAndCompletion {
+            return try DataTaskWithURLAndCompletion(
+                selector: self.selector,
+                klass: URLSession.self
+            )
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try Self.findMethod(with: selector, in: klass)
+            super.init()
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
+            swizzle(method) { previousImplementation -> Signature in
+                return { session, url, completionHandler -> URLSessionDataTask in
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.interceptor
+                    else {
+                        return previousImplementation(session, Self.selector, url, completionHandler)
+                    }
+
+                    guard let completionHandler = completionHandler else {
+                        let task = previousImplementation(session, Self.selector, url, completionHandler)
+                        interceptor.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                        return task
+                    }
+
+                    var _task: URLSessionDataTask?
+                    let task = previousImplementation(session, Self.selector, url) { data, response, error in
+                        completionHandler(data, response, error)
+
+                        if let task = _task { // sanity check, should always succeed
+                            data.map { interceptor.task(task, didReceive: $0) }
+                            interceptor.task(task, didCompleteWithError: error)
+                        }
+                    }
+
+                    _task = task
+                    interceptor.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                    return task
+                }
+            }
+        }
+    }
+
+    /// Swizzles the `URLSession.dataTask(with:)` for `URLRequest`.
+    class DataTaskWithURLRequest: MethodSwizzler<
+        @convention(c) (URLSession, Selector, URLRequest) -> URLSessionDataTask,
+        @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
+    > {
+        private static let selector = #selector(
+            URLSession.dataTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDataTask
+        )
+
+        private let method: FoundMethod
+
+        static func build() throws -> DataTaskWithURLRequest {
+            return try DataTaskWithURLRequest(
+                selector: self.selector,
+                klass: URLSession.self
+            )
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try Self.findMethod(with: selector, in: klass)
+            super.init()
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
+            swizzle(method) { previousImplementation -> Signature in
+                return { session, request -> URLSessionDataTask in
+                    guard let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate else {
+                        return previousImplementation(session, Self.selector, request)
+                    }
+
+                    let request = delegate.interceptor?.intercept(request: request, additionalFirstPartyHosts: delegate.firstPartyHosts) ?? request
+                    let task = previousImplementation(session, Self.selector, request)
+                    if #available(iOS 13.0, *) {
+                        // Prior to iOS 13.0, `dataTask(with:)` (for `URLRequest`) calls the
+                        // the `dataTask(with:completionHandler:)` (for `URLRequest`) internally,
+                        // so the task creation will be notified from `dataTaskWithURLRequestAndCompletion` swizzling.
+                        delegate.interceptor?.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                    }
+                    return task
+                }
+            }
+        }
+    }
+
+    /// Swizzles the `URLSession.dataTask(with:)` for `URL`.
+    class DataTaskWithURL: MethodSwizzler<
+        @convention(c) (URLSession, Selector, URL) -> URLSessionDataTask,
+        @convention(block) (URLSession, URL) -> URLSessionDataTask
+    > {
+        private static let selector = #selector(
+            URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask
+        )
+
+        private let method: FoundMethod
+
+        static func build() throws -> DataTaskWithURL {
+            return try DataTaskWithURL(
+                selector: self.selector,
+                klass: URLSession.self
+            )
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try Self.findMethod(with: selector, in: klass)
+            super.init()
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDataTask
+            swizzle(method) { previousImplementation -> Signature in
+                return { session, url -> URLSessionDataTask in
+                    let task = previousImplementation(session, Self.selector, url)
+                    if let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate {
+                        delegate.interceptor?.intercept(task: task, additionalFirstPartyHosts: delegate.firstPartyHosts)
+                    }
+                    return task
+                }
+            }
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -1,0 +1,242 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public class URLSessionTaskInterception {
+    /// An identifier uniquely identifying the task interception across all `URLSessions`.
+    public let identifier: UUID
+    /// The initial request send during this interception. It is, the request send from `URLSession`, not the one
+    /// given by the user (as the request could have been modified in `URLSessionSwizzler`).
+    public let request: URLRequest
+    /// Tells if the `request` is send to a 1st party host.
+    public let isFirstPartyRequest: Bool
+    /// Task metrics collected during this interception.
+    public private(set) var metrics: ResourceMetrics?
+    /// Task data received during this interception. Can be `nil` if task completed with error.
+    public private(set) var data: Data?
+    /// Task completion collected during this interception.
+    public private(set) var completion: ResourceCompletion?
+    /// Trace information propagated with the task. Not available when Tracing is disabled
+    /// or when the task was created through `URLSession.dataTask(with:url)` on some iOS13+.
+    public private(set) var trace: (
+        traceID: TraceID,
+        spanID: SpanID,
+        parentSpanID: SpanID?
+    )?
+    /// The Datadog origin of the Trace.
+    ///
+    /// Setting the value to 'rum' will indicate that the span is reported as a RUM Resource.
+    public private(set) var origin: String?
+
+    init(request: URLRequest, isFirstParty: Bool) {
+        self.identifier = UUID()
+        self.request = request
+        self.isFirstPartyRequest = isFirstParty
+    }
+
+    func register(metrics: ResourceMetrics) {
+        self.metrics = metrics
+    }
+
+    func register(nextData: Data) {
+        if data != nil {
+            self.data?.append(nextData)
+        } else {
+            self.data = nextData
+        }
+    }
+
+    func register(response: URLResponse?, error: Error?) {
+        self.completion = ResourceCompletion(
+            response: response as? HTTPURLResponse,
+            error: error
+        )
+    }
+
+    public func register(
+        traceID: TraceID,
+        spanID: SpanID,
+        parentSpanID: SpanID?
+    ) {
+        self.trace = (
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentSpanID
+        )
+    }
+
+    public func register(origin: String) {
+        self.origin = origin
+    }
+
+    /// Tells if the interception is done (mean: both metrics and completion were collected).
+    public var isDone: Bool {
+        metrics != nil && completion != nil
+    }
+}
+
+public struct ResourceCompletion {
+    public let httpResponse: HTTPURLResponse?
+    public let error: Error?
+
+    public init(response: URLResponse?, error: Error?) {
+        self.httpResponse = response as? HTTPURLResponse
+        self.error = error
+    }
+}
+
+/// Encapsulates key metrics retrieved either from `URLSessionTaskMetrics` or any other relevant data source.
+/// Reference: https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics
+public struct ResourceMetrics {
+    public struct DateInterval {
+        public let start, end: Date
+        public var duration: TimeInterval { end.timeIntervalSince(start) }
+
+        public static func create(start: Date?, end: Date?) -> DateInterval? {
+            if let start = start, let end = end {
+                return DateInterval(start: start, end: end)
+            }
+            return nil
+        }
+
+        public init(start: Date, end: Date) {
+            self.start = start
+            self.end = end
+        }
+    }
+
+    /// Properties of the fetch phase for the resource:
+    /// - `start` -  the time when the task started fetching the resource from the server,
+    /// - `end` - the time immediately after the task received the last byte of the resource.
+    public let fetch: DateInterval
+
+    /// Properties of the redirection phase for the resource. If the resource is retrieved in multiple transactions,
+    /// only the last one is used to track detailed metrics (`dns`, `connect` etc.).
+    /// All but last are described as a single "redirection" phase.
+    public let redirection: DateInterval?
+
+    /// Properties of the name lookup phase for the resource.
+    public let dns: DateInterval?
+
+    /// Properties of the connect phase for the resource.
+    public let connect: DateInterval?
+
+    /// Properties of the secure connect phase for the resource.
+    public let ssl: DateInterval?
+
+    /// Properties of the TTFB phase for the resource.
+    public let firstByte: DateInterval?
+
+    /// Properties of the download phase for the resource.
+    public let download: DateInterval?
+
+    /// The size of data delivered to delegate or completion handler.
+    public let responseSize: Int64?
+
+    public init(
+        fetch: DateInterval,
+        redirection: DateInterval?,
+        dns: DateInterval?,
+        connect: DateInterval?,
+        ssl: DateInterval?,
+        firstByte: DateInterval?,
+        download: DateInterval?,
+        responseSize: Int64?
+    ) {
+        self.fetch = fetch
+        self.redirection = redirection
+        self.dns = dns
+        self.connect = connect
+        self.ssl = ssl
+        self.firstByte = firstByte
+        self.download = download
+        self.responseSize = responseSize
+    }
+}
+
+extension ResourceMetrics {
+    public init(taskMetrics: URLSessionTaskMetrics) {
+        let fetch = DateInterval(
+            start: taskMetrics.taskInterval.start,
+            end: taskMetrics.taskInterval.end
+        )
+
+        let transactions = taskMetrics.transactionMetrics
+            .filter { $0.resourceFetchType != .localCache } // ignore loads from cache
+
+        // Note: `transactions` contain metrics for each individual
+        // `request → response` transaction done for given resource, e.g.:
+        // * if `200 OK` was received, it will contain 1 transaction,
+        // * if `200 OK` was preceeded by `301` redirection, it will contain 2 transactions.
+        let mainTransaction = transactions.last
+        let redirectionTransactions = transactions.dropLast()
+
+        var redirection: DateInterval? = nil
+
+        if redirectionTransactions.count > 0 {
+            let redirectionStarts = redirectionTransactions.compactMap { $0.fetchStartDate }
+            let redirectionEnds = redirectionTransactions.compactMap { $0.responseEndDate }
+
+            // If several redirections were made, we model them as a single "redirection"
+            // phase starting in the first moment of the youngest and ending
+            // in the last moment of the oldest.
+            if let redirectionPhaseStart = redirectionStarts.first,
+               let redirectionPhaseEnd = redirectionEnds.last {
+                redirection = DateInterval(start: redirectionPhaseStart, end: redirectionPhaseEnd)
+            }
+        }
+
+        var dns: DateInterval? = nil
+        var connect: DateInterval? = nil
+        var ssl: DateInterval? = nil
+        var firstByte: DateInterval? = nil
+        var download: DateInterval? = nil
+        var responseSize: Int64? = nil
+
+        if let mainTransaction = mainTransaction {
+            if let dnsStart = mainTransaction.domainLookupStartDate,
+               let dnsEnd = mainTransaction.domainLookupEndDate {
+                dns = DateInterval(start: dnsStart, end: dnsEnd)
+            }
+
+            if let connectStart = mainTransaction.connectStartDate,
+               let connectEnd = mainTransaction.connectEndDate {
+                connect = DateInterval(start: connectStart, end: connectEnd)
+            }
+
+            if let sslStart = mainTransaction.secureConnectionStartDate,
+               let sslEnd = mainTransaction.secureConnectionEndDate {
+                ssl = DateInterval(start: sslStart, end: sslEnd)
+            }
+
+            if let firstByteStart = mainTransaction.requestStartDate, // Time from start requesting the resource ...
+               let firstByteEnd = mainTransaction.responseStartDate { // ... to receiving the first byte of the response
+                firstByte = DateInterval(start: firstByteStart, end: firstByteEnd)
+            }
+
+            if let downloadStart = mainTransaction.responseStartDate, // Time from the first byte of the response ...
+               let downloadEnd = mainTransaction.responseEndDate {    // ... to receiving the last byte.
+                download = DateInterval(start: downloadStart, end: downloadEnd)
+            }
+
+            if #available(iOS 13.0, tvOS 13, *) {
+                responseSize = mainTransaction.countOfResponseBodyBytesAfterDecoding
+            }
+        }
+
+        self.init(
+            fetch: fetch,
+            redirection: redirection,
+            dns: dns,
+            connect: connect,
+            ssl: ssl,
+            firstByte: firstByte,
+            download: download,
+            responseSize: responseSize
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeaders.swift
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// W3C trace context headers as explained in
+/// https://www.w3.org/TR/trace-context/#traceparent-header
+public enum W3CHTTPHeaders {
+    /// The traceparent header represents the incoming request in a tracing system in a common format, understood by all vendors.
+    /// It's following a convention of `{version-format}-{trace-id}-{parent-id}-{trace-flags}`.
+    ///
+    /// Here’s an example of a traceparent header.
+    /// `traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01`
+    ///
+    /// **version-format**
+    ///
+    /// The following version-format definition is used for version 00.
+    ///
+    /// **trace-id**
+    ///
+    /// This is the ID of the whole trace forest and is used to uniquely identify a distributed trace through a system.
+    /// It is represented as a 16-byte array, for example, `4bf92f3577b34da6a3ce929d0e0e4736`.
+    /// All bytes as zero (`00000000000000000000000000000000`) is considered an invalid value.
+    ///
+    /// **parent-id**
+    ///
+    /// This is the ID of this request as known by the caller
+    /// (in some tracing systems, this is known as the span-id, where a span is the execution of a client request).
+    /// It is represented as an 8-byte array, for example, `00f067aa0ba902b7`.
+    /// All bytes as zero (`0000000000000000`) is considered an invalid value.
+    ///
+    /// **trace-flags**
+    ///
+    /// The current version of this specification only supports a single flag called sampled.
+    /// The sampled flag can be used to ensure that information about requests that were marked
+    /// for recording by the caller will also be recorded by SaaS service downstream so that the caller
+    /// can troubleshoot the behavior of every recorded request.
+    public static let traceparent = "traceparent"
+
+    public enum Constants {
+        public static let version = "00"
+        public static let sampledValue = "01"
+        public static let unsampledValue = "00"
+        public static let separator = "-"
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeadersReader.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public class W3CHTTPHeadersReader: TracePropagationHeadersReader {
+    private let httpHeaderFields: [String: String]
+
+    public init(httpHeaderFields: [String: String]) {
+        self.httpHeaderFields = httpHeaderFields
+    }
+
+    public func read() -> (traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?)? {
+        let values = httpHeaderFields[W3CHTTPHeaders.traceparent]?.components(
+            separatedBy: W3CHTTPHeaders.Constants.separator
+        )
+
+        guard let traceIDValue = values?[safe: 1],
+              let spanIDValue = values?[safe: 2],
+              values?[safe: 3] != W3CHTTPHeaders.Constants.unsampledValue,
+              let traceID = TraceID(traceIDValue, representation: .hexadecimal),
+              let spanID = TraceID(spanIDValue, representation: .hexadecimal)
+        else {
+            return nil
+        }
+
+        return (
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: nil
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/NetworkInstrumentation/W3C/W3CHTTPHeadersWriter.swift
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `W3CHTTPHeadersWriter` class facilitates the injection of trace propagation headers into network requests
+/// targeted at a backend expecting [W3C propagation format](https://github.com/openzipkin/b3-propagation).
+///
+/// Usage:
+///
+///     var request = URLRequest(...)
+///
+///     let writer = W3CHTTPHeadersWriter()
+///     let span = Tracer.shared().startRootSpan(operationName: "network request")
+///     Tracer.shared().inject(spanContext: span.context, writer: writer)
+///
+///     writer.traceHeaderFields.forEach { (field, value) in
+///         request.setValue(value, forHTTPHeaderField: field)
+///     }
+///
+///     // call span.finish() when the request completes
+///
+public class W3CHTTPHeadersWriter: TracePropagationHeadersWriter {
+    /// A dictionary containing the required HTTP Headers for propagating trace information.
+    ///
+    /// Usage:
+    ///
+    ///     writer.traceHeaderFields.forEach { (field, value) in
+    ///         request.setValue(value, forHTTPHeaderField: field)
+    ///     }
+    ///
+    public private(set) var traceHeaderFields: [String: String] = [:]
+
+    /// The tracing sampler.
+    ///
+    /// This value will decide of the `FLAG_SAMPLED` header field value
+    /// and if `trace-id`, `span-id` are propagated.
+    private let sampler: Sampler
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter samplingRate: The sampling rate applied for headers injection.
+    @available(*, deprecated, message: "This will be removed in future versions of the SDK. Use `init(sampleRate:)` instead.")
+    public convenience init(samplingRate: Float) {
+        self.init(sampleRate: samplingRate)
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampleRate: The sampling rate applied for headers injection, with 20% as the default.
+    public convenience init(sampleRate: Float = 20) {
+        self.init(sampler: Sampler(samplingRate: sampleRate))
+    }
+
+    /// Initializes the headers writer.
+    ///
+    /// - Parameter sampler: The sampler used for headers injection.
+    public init(sampler: Sampler) {
+        self.sampler = sampler
+    }
+
+    /// Writes the trace ID, span ID, and optional parent span ID into the trace propagation headers.
+    ///
+    /// - Parameter traceID: The trace ID.
+    /// - Parameter spanID: The span ID.
+    /// - Parameter parentSpanID: The parent span ID, if applicable.
+    public func write(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID?) {
+        typealias Constants = W3CHTTPHeaders.Constants
+
+        traceHeaderFields[W3CHTTPHeaders.traceparent] = [
+            Constants.version,
+            String(traceID, representation: .hexadecimal32Chars),
+            String(spanID, representation: .hexadecimal16Chars),
+            sampler.sample() ? Constants.sampledValue : Constants.unsampledValue
+        ]
+        .joined(separator: Constants.separator)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Storage/PerformancePresetOverride.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Storage/PerformancePresetOverride.swift
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// `PerformancePresetOverride` is a public structure that allows you to customize
+/// performance presets by setting optional limits. If the limits are not provided, the default values from
+/// the `PerformancePreset` object will be used.
+public struct PerformancePresetOverride {
+    /// Overrides the the maximum allowed file size in bytes.
+    /// If not provided, the default value from the `PerformancePreset` object is used.
+    public let maxFileSize: UInt64?
+
+    /// Overrides the maximum allowed object size in bytes.
+    /// If not provided, the default value from the `PerformancePreset` object is used.
+    public let maxObjectSize: UInt64?
+
+    /// Overrides the maximum age qualifying given file for reuse (in seconds).
+    /// If recently used file is younger than this, it is reused - otherwise: new file is created.
+    public let maxFileAgeForWrite: TimeInterval?
+
+    /// Minimum age qualifying given file for upload (in seconds).
+    /// If the file is older than this, it is uploaded (and then deleted if upload succeeded).
+    /// It has an arbitrary offset  (~0.5s) over `maxFileAgeForWrite` to ensure that no upload can start for the file being currently written.
+    public let minFileAgeForRead: TimeInterval?
+
+    /// Overrides the initial upload delay (in seconds).
+    /// At runtime, the upload interval starts with `initialUploadDelay` and then ranges from `minUploadDelay` to `maxUploadDelay` depending
+    /// on delivery success or failure.
+    public let initialUploadDelay: TimeInterval?
+
+    /// Overrides the mininum  interval of data upload (in seconds).
+    public let minUploadDelay: TimeInterval?
+
+    /// Overrides the maximum interval of data upload (in seconds).
+    public let maxUploadDelay: TimeInterval?
+
+    /// Overrides the current interval is change on successful upload. Should be less or equal `1.0`.
+    /// E.g: if rate is `0.1` then `delay` will be changed by `delay * 0.1`.
+    public let uploadDelayChangeRate: Double?
+
+    /// Initializes a new `PerformancePresetOverride` instance with the provided overrides.
+    ///
+    /// - Parameters:
+    ///   - maxFileSize: The maximum allowed file size in bytes, or `nil` to use the default value from `PerformancePreset`.
+    ///   - maxObjectSize: The maximum allowed object size in bytes, or `nil` to use the default value from `PerformancePreset`.
+    ///   - meanFileAge: The mean age qualifying a file for reuse, or `nil` to use the default value from `PerformancePreset`.
+    ///   - uploadDelay: The configuration of time interval for data uploads (initial, minimum, maximum and change rate). Set `nil` to use the default value from `PerformancePreset`.
+    public init(
+        maxFileSize: UInt64?,
+        maxObjectSize: UInt64?,
+        meanFileAge: TimeInterval?,
+        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)?
+    ) {
+        self.maxFileSize = maxFileSize
+        self.maxObjectSize = maxObjectSize
+
+        if let meanFileAge = meanFileAge {
+            // Following constants are the same as in `DatadogCore.PerformancePreset`
+            self.maxFileAgeForWrite = meanFileAge * 0.95 // 5% below the mean age
+            self.minFileAgeForRead = meanFileAge * 1.05 //  5% above the mean age
+        } else {
+            self.maxFileAgeForWrite = nil
+            self.minFileAgeForRead = nil
+        }
+
+        if let uploadDelay = uploadDelay {
+            self.initialUploadDelay = uploadDelay.initial
+            self.minUploadDelay = uploadDelay.range.lowerBound
+            self.maxUploadDelay = uploadDelay.range.upperBound
+            self.uploadDelayChangeRate = uploadDelay.changeRate
+        } else {
+            self.initialUploadDelay = nil
+            self.minUploadDelay = nil
+            self.maxUploadDelay = nil
+            self.uploadDelayChangeRate = nil
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Storage/Writer.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Storage/Writer.swift
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A type, writing data.
+public protocol Writer {
+    /// Encodes given encodable value and metadata, and writes to the destination.
+    /// - Parameter value: Encodable value to write.
+    /// - Parameter metadata: Encodable metadata to write.
+    func write<T: Encodable, M: Encodable>(value: T, metadata: M?)
+}
+
+extension Writer {
+    /// Encodes given encodable value and writes to the destination.
+    /// Uses `write(value:metadata:)` with `nil` metadata.
+    /// - Parameter value: Encodable value to write.
+    public func write<T: Encodable>(value: T) {
+        let metadata: Data? = nil
+        write(value: value, metadata: metadata)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Swizzling/MethodSwizzler.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Swizzling/MethodSwizzler.swift
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+open class MethodSwizzler<TypedIMP, TypedBlockIMP> {
+    public struct FoundMethod: Hashable {
+        let method: Method
+        let klass: AnyClass
+
+        fileprivate init(method: Method, klass: AnyClass) {
+            self.method = method
+            self.klass = klass
+        }
+
+        public static func == (lhs: FoundMethod, rhs: FoundMethod) -> Bool {
+            let methodParity = (lhs.method == rhs.method)
+            let classParity = (NSStringFromClass(lhs.klass) == NSStringFromClass(rhs.klass))
+            return methodParity && classParity
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            let methodName = NSStringFromSelector(method_getName(method))
+            let klassName = NSStringFromClass(klass)
+            let identifier = "\(methodName)|||\(klassName)"
+            hasher.combine(identifier)
+        }
+    }
+
+    private var implementationCache: [FoundMethod: IMP] = [:]
+    var swizzledMethods: [FoundMethod] {
+        return Array(implementationCache.keys)
+    }
+
+    public static func findMethod(with selector: Selector, in klass: AnyClass) throws -> FoundMethod {
+        /// NOTE: RUMM-452 as we never add/remove methods/classes at runtime,
+        /// search operation doesn't have to wrapped in sync {...} although it's visible in the interface
+        var headKlass: AnyClass? = klass
+        while let someKlass = headKlass {
+            if let foundMethod = findMethod(with: selector, in: someKlass) {
+                return FoundMethod(method: foundMethod, klass: someKlass)
+            }
+            headKlass = class_getSuperclass(headKlass)
+        }
+        throw InternalError(description: "\(NSStringFromSelector(selector)) is not found in \(NSStringFromClass(klass))")
+    }
+
+    public init() { }
+
+    func originalImplementation(of found: FoundMethod) -> TypedIMP {
+        return sync {
+            let originalImp: IMP = implementationCache[found] ?? method_getImplementation(found.method)
+            return unsafeBitCast(originalImp, to: TypedIMP.self)
+        }
+    }
+
+    public func swizzle(
+        _ foundMethod: FoundMethod,
+        impProvider: (TypedIMP) -> TypedBlockIMP
+    ) {
+        sync {
+            let currentIMP = method_getImplementation(foundMethod.method)
+            let current_typedIMP = unsafeBitCast(currentIMP, to: TypedIMP.self)
+            let newImpBlock: TypedBlockIMP = impProvider(current_typedIMP)
+            let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+
+            set(newIMP: newImp, for: foundMethod)
+
+            #if DD_SDK_COMPILED_FOR_TESTING
+            activeSwizzlingNames.append(foundMethod.swizzlingName)
+            #endif
+        }
+    }
+
+    /// Removes swizzling and resets the method to its original implementation.
+    public func unswizzle() {
+        for foundMethod in swizzledMethods {
+            let originalTypedIMP = originalImplementation(of: foundMethod)
+            let originalIMP: IMP = unsafeBitCast(originalTypedIMP, to: IMP.self)
+            method_setImplementation(foundMethod.method, originalIMP)
+
+            activeSwizzlingNames.removeAll { $0 == foundMethod.swizzlingName }
+        }
+    }
+
+    // MARK: - Private methods
+
+    @discardableResult
+    private func sync<T>(block: () -> T) -> T {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        return block()
+    }
+
+    private static func findMethod(with selector: Selector, in klass: AnyClass) -> Method? {
+        var methodsCount: UInt32 = 0
+        let methodsCountPtr = withUnsafeMutablePointer(to: &methodsCount) { $0 }
+        guard let methods: UnsafeMutablePointer<Method> = class_copyMethodList(klass, methodsCountPtr) else {
+            return nil
+        }
+        defer {
+            free(methods)
+        }
+        for index in 0..<Int(methodsCount) {
+            let method = methods.advanced(by: index).pointee
+            if method_getName(method) == selector {
+                return method
+            }
+        }
+        return nil
+    }
+
+    private func set(newIMP: IMP, for found: FoundMethod) {
+        if implementationCache[found] == nil {
+            implementationCache[found] = method_getImplementation(found.method)
+        }
+        method_setImplementation(found.method, newIMP)
+    }
+}
+
+internal extension MethodSwizzler.FoundMethod {
+    var swizzlingName: String { "\(klass).\(method_getName(method))" }
+}
+
+/// The list of active swizzlings to ensure integrity in unit tests.
+internal var activeSwizzlingNames: [String] = []

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/CoreLogger.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/CoreLogger.swift
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public enum CoreLoggerLevel: Int, Comparable, CaseIterable {
+    /// Least severe level, meant to self-diagnose possible issues with the SDK.
+    /// It **should be used to log all events which might be important for us in diagnosing the SDK**
+    /// in user apps (e.g.: printing the SDK version or important aspects of configuration).
+    ///
+    /// No emoji prefix should be added by the logger when showing this log to the user.
+    case debug
+
+    /// Level indicating **an user error when using the SDK**. It should be used for
+    /// logging errors that are caused by user fault (e.g. wrong configuration).
+    ///
+    /// The "⚠️" emoji prefix should be added by the logger when showing this log to the user.
+    case warn
+
+    /// Level indicating **an error in the SDK**. It shuld be only used for logging errors
+    /// which are not caused by the user (e.g. SDK logic fault).
+    ///
+    /// The "🔥" emoji prefix should be added by the logger when showing this log to the user.
+    case error
+
+    /// Most severe level for logging errors which **makes some part of the SDK unfunctional**.
+    /// It can be used to indicate either fatal SDK errors or user faults.
+    ///
+    /// The "⛔️" emoji prefix should be added by the logger when showing this log to the user.
+    case critical
+
+    var emojiPrefix: String {
+        switch self {
+        case .debug:    return ""
+        case .warn:     return "⚠️"
+        case .error:    return "🔥"
+        case .critical: return "⛔️"
+        }
+    }
+
+    public static func < (lhs: CoreLoggerLevel, rhs: CoreLoggerLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// The `CoreLogger` protocol defines methods to log debug information and execution errors from Datadog SDK to user console.
+///
+/// It is meant for debugging purposes when using the SDK, hence **it should log information useful and actionable
+/// to the SDK user**. Think of possible logs that we may want to receive from our users when asking them to enable
+/// SDK verbosity and send us their console log.
+public protocol CoreLogger {
+    /// Log the message and error using given severity level.
+    ///
+    /// - Parameters:
+    ///   - level: the severity level
+    ///   - message: the message to be shown
+    ///   - error: eventual `Error` which will be showed in a nice format
+    func log(_ level: CoreLoggerLevel, message: @autoclosure () -> String, error: Error?)
+}
+
+extension CoreLogger {
+    /// Print debug message which is meant to self-diagnose possible issues with the SDK.
+    /// It should be used to log all events which might be important for us in diagnosing the SDK
+    /// in user apps (e.g.: printing the SDK version or important aspects of configuration).
+    ///
+    /// No emoji prefix is added by the logger when priting this log to the console.
+    ///
+    /// - Parameters:
+    ///   - message: the message
+    ///   - error: eventual `Error` which will be printed in nice format
+    public func debug(_ message: @autoclosure () -> String, error: Error? = nil) {
+        log(.debug, message: message(), error: error)
+    }
+
+    /// Print error message which indicates **an user error when using the SDK**. It should be used for
+    /// indicating errors that are caused by user fault (e.g. wrong configuration).
+    ///
+    /// The "⚠️" emoji prefix is added by the logger when priting this log to the console.
+    ///
+    /// - Parameters:
+    ///   - message: the message
+    ///   - error: eventual `Error` which will be printed in nice format
+    public func warn(_ message: @autoclosure () -> String, error: Error? = nil) {
+        log(.warn, message: message(), error: error)
+    }
+
+    /// Print error message which indicates **an error in the SDK**. It shuld be only used for errors
+    /// which are not caused by the user (e.g. SDK user fault).
+    ///
+    /// The "🔥" emoji prefix is added by the logger when priting this log to the console.
+    ///
+    /// - Parameters:
+    ///   - message: the message
+    ///   - error: eventual `Error` which will be printed in nice format
+    public func error(_ message: @autoclosure () -> String, error: Error? = nil) {
+        log(.error, message: message(), error: error)
+    }
+
+    /// Print error message which indicates an error which **makes some part of the SDK unfunctional**.
+    /// It can be used to indicate either fatal SDK errors or user fault.
+    ///
+    /// The "⛔️" emoji prefix is added by the logger when priting this log to the console.
+    ///
+    /// - Parameters:
+    ///   - message: the message
+    ///   - error: eventual `Error` which will be printed in nice format
+    public func critical(_ message: @autoclosure () -> String, error: Error? = nil) {
+        log(.critical, message: message(), error: error)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/InternalLogger.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/InternalLogger.swift
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `CoreLogger` printing to debugger console.
+public struct InternalLogger: CoreLogger {
+    /// The prefix applied to all core logs.
+    private static let prefix = "[DATADOG SDK] 🐶 → "
+
+    /// The date provider for annotating core logs.
+    private let dateProvider: DateProvider
+    /// Formatter used to format the time accordingly for local device.
+    private let dateFormatter: DateFormatterType
+    /// The print function.
+    private let printFunction: (String) -> Void
+    /// V1's verbosity level. Only logs above or equal to this level wil be printed.
+    private let currentVerbosityLevel: () -> CoreLoggerLevel?
+
+    public init(
+        dateProvider: DateProvider,
+        timeZone: TimeZone,
+        printFunction: @escaping (String) -> Void,
+        verbosityLevel: @escaping () -> CoreLoggerLevel?
+    ) {
+        self.dateProvider = dateProvider
+        self.dateFormatter = presentationDateFormatter(withTimeZone: timeZone)
+        self.printFunction = printFunction
+        self.currentVerbosityLevel = verbosityLevel
+    }
+
+    // MARK: - CoreLogger
+
+    public func log(_ level: CoreLoggerLevel, message: @autoclosure () -> String, error: Error?) {
+        guard let verbosityLevel = currentVerbosityLevel(), level >= verbosityLevel else {
+            return // if no `Datadog.verbosityLevel` is set or it is set above this level
+        }
+
+        print(message: message(), error: error, emoji: level.emojiPrefix)
+    }
+
+    // MARK: - Private
+
+    private func print(message: @autoclosure () -> String, error: Error?, emoji: String) {
+        var log = buildMessageString(message: message(), emoji: emoji)
+
+        if let error = error {
+            log += "\n\nError details:\n\(buildErrorString(error: error))"
+        }
+
+        printFunction(log)
+    }
+
+    private func buildMessageString(message: @autoclosure () -> String, emoji: String) -> String {
+        let prefix = InternalLogger.prefix
+        let time = dateFormatter.string(from: dateProvider.now)
+
+        if !emoji.isEmpty {
+            return "\(prefix)\(time) \(emoji) \(message())"
+        } else {
+            return "\(prefix)\(time) \(message())"
+        }
+    }
+
+    private func buildErrorString(error: Error) -> String {
+        let dderror = DDError(error: error)
+        return """
+        → type: \(dderror.type)
+        → message: \(dderror.message)
+        → stack: \(dderror.stack)
+        """
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/Telemetry.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Telemetry/Telemetry.swift
@@ -1,0 +1,273 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public struct ConfigurationTelemetry: Equatable {
+    public let batchSize: Int64?
+    public let batchUploadFrequency: Int64?
+    public let dartVersion: String?
+    public let mobileVitalsUpdatePeriod: Int64?
+    public let sessionSampleRate: Int64?
+    public let telemetrySampleRate: Int64?
+    public let traceSampleRate: Int64?
+    public let trackBackgroundEvents: Bool?
+    public let trackCrossPlatformLongTasks: Bool?
+    public let trackErrors: Bool?
+    public let trackFlutterPerformance: Bool?
+    public let trackFrustrations: Bool?
+    public let trackInteractions: Bool?
+    public let trackLongTask: Bool?
+    public let trackNativeLongTasks: Bool?
+    public let trackNativeViews: Bool?
+    public let trackNetworkRequests: Bool?
+    public let trackViewsManually: Bool?
+    public let useFirstPartyHosts: Bool?
+    public let useLocalEncryption: Bool?
+    public let useProxy: Bool?
+    public let useTracing: Bool?
+}
+
+public enum TelemetryMessage {
+    case debug(id: String, message: String, attributes: [String: Encodable]?)
+    case error(id: String, message: String, kind: String?, stack: String?)
+    case configuration(ConfigurationTelemetry)
+    case metric(name: String, attributes: [String: Encodable])
+}
+
+/// The `Telemetry` protocol defines methods to collect debug information
+/// and detect execution errors of the Datadog SDK.
+public protocol Telemetry {
+    /// Sends a Telemetry message.
+    ///
+    /// - Parameter telemetry: The telemtry message
+    func send(telemetry: TelemetryMessage)
+}
+
+extension Telemetry {
+    /// Collects debug information.
+    ///
+    /// - Parameters:
+    ///   - id: Identity of the debug log, this can be used to prevent duplicates.
+    ///   - message: The debug message.
+    ///   - attributes: Custom attributes attached to the log (optional).
+    public func debug(id: String, message: String, attributes: [String: Encodable]? = nil) {
+        send(telemetry: .debug(id: id, message: message, attributes: attributes))
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - id: Identity of the debug log, this can be used to prevent duplicates.
+    ///   - message: The error message.
+    ///   - kind: The kind of error.
+    ///   - stack: The stack trace.
+    public func error(id: String, message: String, kind: String?, stack: String?) {
+        send(telemetry: .error(id: id, message: message, kind: kind, stack: stack))
+    }
+
+    /// Report a Configuration Telemetry.
+    ///
+    /// The configuration can be partial, the telemetry should support accumulation of
+    /// configuration for lazy initialization of the SDK.
+    ///
+    /// - Parameter configuration: The SDK configuration.
+    public func report(configuration: ConfigurationTelemetry) {
+        send(telemetry: .configuration(configuration))
+    }
+
+    /// Collects debug information.
+    ///
+    /// - Parameters:
+    ///   - message: The debug message.
+    ///   - attributes: Custom attributes attached to the log (optional).
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func debug(_ message: String, attributes: [String: Encodable]? = nil, file: String = #file, line: Int = #line) {
+        debug(id: "\(file):\(line):\(message)", message: message, attributes: attributes)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - stack: The stack trace.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func error(_ message: String, kind: String? = nil, stack: String? = nil, file: String = #file, line: Int = #line) {
+        error(id: "\(file):\(line):\(message)", message: message, kind: kind, stack: stack)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - error: The error.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func error(_ error: DDError, file: String = #file, line: Int = #line) {
+        self.error(error.message, kind: error.type, stack: error.stack, file: file, line: line)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - error: The error.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func error(_ message: String, error: DDError, file: String = #file, line: Int = #line) {
+        self.error("\(message) - \(error.message)", kind: error.type, stack: error.stack, file: file, line: line)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - error: The error.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func error(_ error: Error, file: String = #file, line: Int = #line) {
+        self.error(DDError(error: error), file: file, line: line)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - error: The error.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    public func error(_ message: String, error: Error, file: String = #file, line: Int = #line) {
+        self.error(message, error: DDError(error: error), file: file, line: line)
+    }
+
+    /// Report a Configuration Telemetry.
+    ///
+    /// The configuration can be partial, the telemtry should support accumulation of
+    /// configuration for lazy initialization of the SDK.
+    public func configuration(
+        batchSize: Int64? = nil,
+        batchUploadFrequency: Int64? = nil,
+        dartVersion: String? = nil,
+        mobileVitalsUpdatePeriod: Int64? = nil,
+        sessionSampleRate: Int64? = nil,
+        telemetrySampleRate: Int64? = nil,
+        traceSampleRate: Int64? = nil,
+        trackBackgroundEvents: Bool? = nil,
+        trackCrossPlatformLongTasks: Bool? = nil,
+        trackErrors: Bool? = nil,
+        trackFlutterPerformance: Bool? = nil,
+        trackFrustrations: Bool? = nil,
+        trackInteractions: Bool? = nil,
+        trackLongTask: Bool? = nil,
+        trackNativeLongTasks: Bool? = nil,
+        trackNativeViews: Bool? = nil,
+        trackNetworkRequests: Bool? = nil,
+        trackViewsManually: Bool? = nil,
+        useFirstPartyHosts: Bool? = nil,
+        useLocalEncryption: Bool? = nil,
+        useProxy: Bool? = nil,
+        useTracing: Bool? = nil
+    ) {
+        self.report(configuration: .init(
+            batchSize: batchSize,
+            batchUploadFrequency: batchUploadFrequency,
+            dartVersion: dartVersion,
+            mobileVitalsUpdatePeriod: mobileVitalsUpdatePeriod,
+            sessionSampleRate: sessionSampleRate,
+            telemetrySampleRate: telemetrySampleRate,
+            traceSampleRate: traceSampleRate,
+            trackBackgroundEvents: trackBackgroundEvents,
+            trackCrossPlatformLongTasks: trackCrossPlatformLongTasks,
+            trackErrors: trackErrors,
+            trackFlutterPerformance: trackFlutterPerformance,
+            trackFrustrations: trackFrustrations,
+            trackInteractions: trackInteractions,
+            trackLongTask: trackLongTask,
+            trackNativeLongTasks: trackNativeLongTasks,
+            trackNativeViews: trackNativeViews,
+            trackNetworkRequests: trackNetworkRequests,
+            trackViewsManually: trackViewsManually,
+            useFirstPartyHosts: useFirstPartyHosts,
+            useLocalEncryption: useLocalEncryption,
+            useProxy: useProxy,
+            useTracing: useTracing
+        ))
+    }
+
+    /// Collect metric value.
+    ///
+    /// Metrics are reported as debug telemetry. Unlike regular events, they are not subject to duplicates filtering and
+    /// are get sampled with a different rate. Metric attributes are used to create facets for later querying and graphing.
+    ///
+    /// - Parameters:
+    ///   - name: The name of this metric.
+    ///   - attributes: Parameters associated with this metric.
+    public func metric(name: String, attributes: [String: Encodable]) {
+        send(telemetry: .metric(name: name, attributes: attributes))
+    }
+}
+
+public struct NOPTelemetry: Telemetry {
+    public init() { }
+    /// no-op
+    public func send(telemetry: TelemetryMessage) { }
+}
+
+public struct TelemetryCore: Telemetry {
+    /// A weak core reference.
+    private weak var core: DatadogCoreProtocol?
+
+    /// Creates a Telemetry associated with a core instance.
+    ///
+    /// The `TelemetryCore` keeps a weak reference
+    /// to the provided core.
+    ///
+    /// - Parameter core: The core instance.
+    public init(core: DatadogCoreProtocol) {
+        self.core = core
+    }
+
+    /// Sends a Telemetry message.
+    ///
+    /// The Telemetry message will be transmitted on the message-bus
+    /// of the core.
+    ///
+    /// - Parameter telemetry: The telemtry message.
+    public func send(telemetry: TelemetryMessage) {
+        core?.send(message: .telemetry(telemetry))
+    }
+}
+
+extension ConfigurationTelemetry {
+    public func merged(with other: Self) -> Self {
+        .init(
+            batchSize: other.batchSize ?? batchSize,
+            batchUploadFrequency: other.batchUploadFrequency ?? batchUploadFrequency,
+            dartVersion: other.dartVersion ?? dartVersion,
+            mobileVitalsUpdatePeriod: other.mobileVitalsUpdatePeriod ?? mobileVitalsUpdatePeriod,
+            sessionSampleRate: other.sessionSampleRate ?? sessionSampleRate,
+            telemetrySampleRate: other.telemetrySampleRate ?? telemetrySampleRate,
+            traceSampleRate: other.traceSampleRate ?? traceSampleRate,
+            trackBackgroundEvents: other.trackBackgroundEvents ?? trackBackgroundEvents,
+            trackCrossPlatformLongTasks: other.trackCrossPlatformLongTasks ?? trackCrossPlatformLongTasks,
+            trackErrors: other.trackErrors ?? trackErrors,
+            trackFlutterPerformance: other.trackFlutterPerformance ?? trackFlutterPerformance,
+            trackFrustrations: other.trackFrustrations ?? trackFrustrations,
+            trackInteractions: other.trackInteractions ?? trackInteractions,
+            trackLongTask: other.trackLongTask ?? trackLongTask,
+            trackNativeLongTasks: other.trackNativeLongTasks ?? trackNativeLongTasks,
+            trackNativeViews: other.trackNativeViews ?? trackNativeViews,
+            trackNetworkRequests: other.trackNetworkRequests ?? trackNetworkRequests,
+            trackViewsManually: other.trackViewsManually ?? trackViewsManually,
+            useFirstPartyHosts: other.useFirstPartyHosts ?? useFirstPartyHosts,
+            useLocalEncryption: other.useLocalEncryption ?? useLocalEncryption,
+            useProxy: other.useProxy ?? useProxy,
+            useTracing: other.useTracing ?? useTracing
+        )
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DataCompression.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DataCompression.swift
@@ -1,0 +1,117 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import Compression
+import zlib
+
+/// `Deflate` provides static methods to deflate `Data` for HTTP `deflate` `Content-Encoding`
+/// using the `zlib` structure defined in IETF RFC 1950 with the deflate compression algorithm defined in
+/// IETF RFC 1951.
+///
+/// ref:
+/// - https://zlib.net/
+/// - https://datatracker.ietf.org/doc/html/rfc1950
+/// - https://datatracker.ietf.org/doc/html/rfc1951
+internal struct Deflate {
+    /// Compresses the data into `ZLIB` data format.
+    ///
+    /// The `Compression` library implements the zlib encoder at level 5 only. This compression level
+    /// provides a good balance between compression speed and compression ratio.
+    ///
+    /// The encoded format is the ZLIB Compressed Data Format as described in IETF RFC 1950
+    /// https://datatracker.ietf.org/doc/html/rfc1950
+    ///
+    /// - Parameter data: Source data to deflate
+    /// - Returns:  The compressed data format.
+    static func encode(_ data: Data) -> Data? {
+        // 2 bytes header - defines the compression mode
+        //
+        // +---+---+
+        // |CMF|FLG|
+        // +---+---+
+        //
+        // ref. https://datatracker.ietf.org/doc/html/rfc1950#section-2.2
+        //
+        // The following header value is from `mw99/DataCompression` which applies
+        // the same compression algorithm defined by `COMPRESSION_ZLIB`
+        // ref. https://github.com/mw99/DataCompression
+        let header = Data([0x78, 0x5e])
+
+        guard
+            let raw = compress(data),
+            let checksum = adler32(data),
+            // Returns `nil` when compression expands the data size.
+            data.count > header.count + raw.count + checksum.count
+        else { return nil }
+
+        return header + raw + checksum
+    }
+
+    /// Compresses the data using the `ZLIB` compression algorithm.
+    ///
+    /// The `Compression` library implements the zlib encoder at level 5 only. This compression level
+    /// provides a good balance between compression speed and compression ratio.
+    ///
+    /// The encoded format is the raw DEFLATE format as described in in IETF RFC 1951
+    /// https://datatracker.ietf.org/doc/html/rfc1951
+    ///
+    /// This deflate implementation uses `compression_encode_buffer(_:_:_:_:_:_:)`
+    /// from the `Compression` framework by allocating a destination buffer of source size and copying
+    /// the result into a `Data` structure. In the worst possible case, where the compression expands the
+    /// data size, the destination buffer becomes too small and deflation returns `nil`.
+    ///
+    /// ref. https://developer.apple.com/documentation/compression/1480986-compression_encode_buffer
+    ///
+    /// - Parameter data: Source data to deflate
+    /// - Returns:  The compressed data. If the compressed data size is bigger than the source size,
+    ///             or an error occurs, `nil` is returned.
+    static func compress(_ data: Data) -> Data? {
+        return data.withUnsafeBytes {
+            guard let ptr = $0.bindMemory(to: UInt8.self).baseAddress else {
+                return nil
+            }
+
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.count)
+            defer { buffer.deallocate() }
+
+            // The number of bytes written to the destination buffer after compressing
+            // the input. If the funtion can't compress the entire input to fit into
+            // the provided destination buffer, or an error occurs, 0 is returned.
+            let size = compression_encode_buffer(buffer, data.count, ptr, data.count, nil, COMPRESSION_ZLIB)
+            guard size > 0 else {
+                return nil
+            }
+
+            return Data(bytes: buffer, count: size)
+        }
+    }
+
+    /// Calculates the Adler32 checksum of the given data.
+    ///
+    /// An Adler-32 checksum is almost as reliable as a CRC-32 but can be computed much faster.
+    ///
+    /// - Parameter data: Data to compute the checksum.
+    /// - Returns: The Adler-32 checksum.
+    static func adler32(_ data: Data) -> Data? {
+        let adler: uLong? = data.withUnsafeBytes {
+            guard let ptr = $0.bindMemory(to: Bytef.self).baseAddress else {
+                return nil
+            }
+
+            // The Adler-32 checksum should be initialized to 1 as described in
+            // https://datatracker.ietf.org/doc/html/rfc1950#section-8
+            return zlib.adler32(1, ptr, uInt(data.count))
+        }
+
+        guard let checksum = adler else {
+            return nil
+        }
+
+        var bytes = UInt32(checksum).bigEndian
+        return Data(bytes: &bytes, count: MemoryLayout<UInt32>.size)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DataFormat.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DataFormat.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Describes the format of writing and reading data from files.
+public struct DataFormat {
+    /// Prefixes the batch payload read from file.
+    private let prefixData: Data
+    /// Suffixes the batch payload read from file.
+    private let suffixData: Data
+    /// Separates entities written to file.
+    private let separatorByte: UInt8
+
+    // MARK: - Initialization
+
+    public init(
+        prefix: String,
+        suffix: String,
+        separator: Character
+    ) {
+        self.prefixData = prefix.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+        self.suffixData = suffix.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+        self.separatorByte = separator.asciiValue!   // swiftlint:disable:this force_unwrapping
+    }
+
+    /// Formats the given data sequence by applying the prefix, separator,
+    /// and suffix.
+    ///
+    /// - Parameter data: The data sequence.
+    /// - Returns: the formatted data.
+    public func format(_ data: [Data]) -> Data {
+        // add prefix
+        prefixData +
+        // concat data
+        data.reduce(.init()) { $0 + $1 + [separatorByte] }
+        // drop last separator
+        .dropLast() +
+        // add suffix
+        suffixData
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DefaultJSONEncoder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/DefaultJSONEncoder.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+extension JSONEncoder: DatadogExtended { }
+
+extension DatadogExtension where ExtendedType == JSONEncoder {
+    public static func `default`() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            let formatted = iso8601DateFormatter.string(from: date)
+            try container.encode(formatted)
+        }
+        if #available(iOS 13, tvOS 13, macOS 10.15, *) {
+            encoder.outputFormatting = [.withoutEscapingSlashes]
+        }
+        return encoder
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/Event.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/Event.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Struct representing a single event.
+public struct Event: Equatable {
+    /// Data representing the event.
+    public let data: Data
+
+    /// Metadata associated with the event.
+    /// Metadata is optional and may be `nil` but of very small size.
+    /// This allows us to skip resource intensive operations in case such
+    /// as filtering of the events.
+    public let metadata: Data?
+
+    public init(data: Data, metadata: Data? = nil) {
+        self.data = data
+        self.metadata = metadata
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/FeatureRequestBuilder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/FeatureRequestBuilder.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `FeatureRequestBuilder` defines an interface for building a single `URLRequest`
+/// for a list of data events and the current core context.
+///
+/// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
+/// The request will be transported by `DatadogCore`.
+public protocol FeatureRequestBuilder {
+    /// Builds an `URLRequest` for a list of events and the current core context to be uploaded
+    /// to the Feature's Intake.
+    ///
+    /// The returned request must include all necessary information, i.e. HTTP headers and
+    /// URL queries required by the Feature's Intake. The request will be sent by the core.
+    ///
+    /// **Note:** When `Error` is thrown, underlying data will be dropped permanently and never retried. The
+    /// implementation should make a wise consideration of throwing vs recovering strategy.
+    ///
+    /// - Parameters:
+    ///   - context: The current core context.
+    ///   - events: The events data to be uploaded.
+    /// - Returns: The URL request.
+    func request(for events: [Event], with context: DatadogContext) throws -> URLRequest
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/URLRequestBuilder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/URLRequestBuilder.swift
@@ -1,0 +1,158 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Builds `URLRequest` for sending data to Datadog.
+public struct URLRequestBuilder {
+    public enum QueryItem {
+        /// `ddsource={source}` query item
+        case ddsource(source: String)
+        /// `ddtags={tag1},{tag2},...` query item
+        case ddtags(tags: [String])
+    }
+
+    public struct HTTPHeader {
+        public static let contentTypeHeaderField = "Content-Type"
+        public static let contentEncodingHeaderField = "Content-Encoding"
+        public static let userAgentHeaderField = "User-Agent"
+        public static let ddAPIKeyHeaderField = "DD-API-KEY"
+        public static let ddEVPOriginHeaderField = "DD-EVP-ORIGIN"
+        public static let ddEVPOriginVersionHeaderField = "DD-EVP-ORIGIN-VERSION"
+        public static let ddRequestIDHeaderField = "DD-REQUEST-ID"
+
+        public enum ContentType {
+            case applicationJSON
+            case textPlainUTF8
+            case multipartFormData(boundary: String)
+
+            public var toString: String {
+                switch self {
+                case .applicationJSON: return "application/json"
+                case .textPlainUTF8: return "text/plain;charset=UTF-8"
+                case .multipartFormData(let boundary): return "multipart/form-data; boundary=\(boundary)"
+                }
+            }
+        }
+
+        let field: String
+        let value: () -> String
+
+        public init(field: String, value: @escaping () -> String) {
+            self.field = field
+            self.value = value
+        }
+
+        // MARK: - Standard Headers
+
+        /// Standard "Content-Type" header.
+        public static func contentTypeHeader(contentType: ContentType) -> HTTPHeader {
+            return HTTPHeader(field: contentTypeHeaderField, value: { contentType.toString })
+        }
+
+        /// Standard "User-Agent" header.
+        public static func userAgentHeader(appName: String, appVersion: String, device: DeviceInfo) -> HTTPHeader {
+            var sanitizedAppName = appName
+
+            if let regex = try? NSRegularExpression(pattern: "[^a-zA-Z0-9 -]+") {
+                sanitizedAppName = regex.stringByReplacingMatches(
+                    in: appName,
+                    range: NSRange(appName.startIndex..<appName.endIndex, in: appName),
+                    withTemplate: ""
+                )
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            let agent = "\(sanitizedAppName)/\(appVersion) CFNetwork (\(device.name); \(device.osName)/\(device.osVersion))"
+            return HTTPHeader(field: userAgentHeaderField, value: { agent })
+        }
+
+        // MARK: - Datadog Headers
+
+        /// Datadog request authentication header.
+        public static func ddAPIKeyHeader(clientToken: String) -> HTTPHeader {
+            return HTTPHeader(field: ddAPIKeyHeaderField, value: { clientToken })
+        }
+
+        /// An observability and troubleshooting Datadog header for tracking the origin which is sending the request.
+        public static func ddEVPOriginHeader(source: String) -> HTTPHeader {
+            return HTTPHeader(field: ddEVPOriginHeaderField, value: { source })
+        }
+
+        /// An observability and troubleshooting Datadog header for tracking the origin which is sending the request.
+        public static func ddEVPOriginVersionHeader(sdkVersion: String) -> HTTPHeader {
+            return HTTPHeader(field: ddEVPOriginVersionHeaderField, value: { sdkVersion })
+        }
+
+        /// An optional Datadog header for debugging Intake requests by their ID.
+        public static func ddRequestIDHeader() -> HTTPHeader {
+            return HTTPHeader(field: ddRequestIDHeaderField, value: { UUID().uuidString })
+        }
+    }
+    /// Upload `URL`.
+    private let url: URL
+    /// HTTP headers.
+    private let headers: [HTTPHeader]
+
+    // MARK: - Initialization
+
+    public init(
+        url: URL,
+        queryItems: [QueryItem],
+        headers: [HTTPHeader]
+    ) {
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+        if !queryItems.isEmpty {
+            urlComponents?.queryItems = queryItems.map { .init($0) }
+        }
+
+        self.url = urlComponents?.url ?? url
+        self.headers = headers
+    }
+
+    /// Creates `URLRequest` for uploading given `body` to Datadog.
+    ///
+    /// - Parameter body: HTTP body to be attached to request
+    /// - Parameter compress: if `body` should be compressed into ZLIB Compressed Data Format (IETF RFC 1950)
+    /// - Returns: the `URLRequest` object.
+    public func uploadRequest(with body: Data, compress: Bool = true) -> URLRequest {
+        var request = URLRequest(url: url)
+        var headers: [String: String] = [:]
+        self.headers.forEach { headers[$0.field] = $0.value() }
+        request.httpMethod = "POST"
+
+        if compress, let deflatedBody = Deflate.encode(body) {
+            headers[HTTPHeader.contentEncodingHeaderField] = "deflate"
+            request.httpBody = deflatedBody
+        } else {
+            request.httpBody = body
+            if compress {
+                DD.telemetry.debug(
+                    """
+                    Failed to compress request payload
+                    - url: \(url)
+                    - uncompressed-size: \(body.count)
+                    """
+                )
+            }
+        }
+
+        request.allHTTPHeaderFields = headers
+        return request
+    }
+}
+
+extension URLQueryItem {
+    init(_ query: URLRequestBuilder.QueryItem) {
+        switch query {
+        case .ddsource(let source):
+            self = URLQueryItem(name: "ddsource", value: source)
+        case .ddtags(let tags):
+            self = URLQueryItem(name: "ddtags", value: tags.joined(separator: ","))
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Upload/UploadPerformancePreset.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Upload/UploadPerformancePreset.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol UploadPerformancePreset {
+    /// Initial upload delay (in seconds).
+    /// At runtime, the upload interval starts with `initialUploadDelay` and then ranges from `minUploadDelay` to `maxUploadDelay` depending
+    /// on delivery success or failure.
+    var initialUploadDelay: TimeInterval { get }
+    /// Mininum  interval of data upload (in seconds).
+    var minUploadDelay: TimeInterval { get }
+    /// Maximum interval of data upload (in seconds).
+    var maxUploadDelay: TimeInterval { get }
+    /// If upload succeeds or fails, current interval is changed by this rate. Should be less or equal `1.0`.
+    /// E.g: if rate is `0.1` then `delay` can be increased or decreased by `delay * 0.1`.
+    var uploadDelayChangeRate: Double { get }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Utils/DDError.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Utils/DDError.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Common representation of Swift `Error` used by different features.
+public struct DDError: Equatable, Codable {
+    /// Common error key encoding threads information in Crash Reporting.
+    /// See "RFC - iOS Crash Reports Minimization" for more context.
+    public static let threads = "error.threads"
+    /// Common error key encoding binary images information in Crash Reporting.
+    /// See "RFC - iOS Crash Reports Minimization" for more context.
+    public static let binaryImages = "error.binary_images"
+    /// Common error key encoding crash meta information in Crash Reporting.
+    /// See "RFC - iOS Crash Reports Minimization" for more context.
+    public static let meta = "error.meta"
+    /// Common error key encoding boolean flag - `true` if any stack trace was truncated, otherwise `false`.
+    /// See "RFC - iOS Crash Reports Minimization" for more context.
+    public static let wasTruncated = "error.was_truncated"
+
+    public let type: String
+    public let message: String
+    public let stack: String
+
+    public init(type: String, message: String, stack: String) {
+        self.type = type
+        self.message = message
+        self.stack = stack
+    }
+}
+
+extension DDError {
+    public init(error: Error) {
+        if isNSErrorOrItsSubclass(error) {
+            let nsError = error as NSError
+            self.type = "\(nsError.domain) - \(nsError.code)"
+            if nsError.userInfo[NSLocalizedDescriptionKey] != nil {
+                self.message = nsError.localizedDescription
+            } else {
+                self.message = nsError.description
+            }
+            self.stack = "\(nsError)"
+        } else {
+            let swiftError = error
+            self.type = "\(Swift.type(of: swiftError))"
+            self.message = "\(swiftError)"
+            self.stack = "\(swiftError)"
+        }
+    }
+}
+
+private func isNSErrorOrItsSubclass(_ error: Error) -> Bool {
+    var mirror: Mirror? = Mirror(reflecting: error)
+
+    while mirror != nil {
+        if mirror?.subjectType == NSError.self {
+            return true
+        }
+        mirror = mirror?.superclassMirror
+    }
+    return false
+}
+
+/// An exception thrown due to programmer error when calling SDK public API.
+/// It makes the SDK non-functional and print the error to developer in debugger console..
+/// When thrown, check if configuration passed to `Datadog.initialize(...)` is correct
+/// and if you do not call any other SDK methods before it returns.
+public struct ProgrammerError: Error, CustomStringConvertible {
+    public let description: String
+    public init(description: String) {
+        self.description = "🔥 Datadog SDK usage error: \(description)"
+    }
+}
+
+/// An exception thrown internally by SDK.
+/// It is always handled by SDK (keeps it functional) and never passed to the user until `Datadog.verbosity` is set (then it might be printed in debugger console).
+/// `InternalError` might be thrown due to programmer error (API misuse) or SDK internal inconsistency or external issues (e.g.  I/O errors). The SDK
+/// should always recover from that failures.
+public struct InternalError: Error, CustomStringConvertible {
+    public let description: String
+
+    public init(description: String) {
+        self.description = description
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Utils/DateFormatting.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Utils/DateFormatting.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol DateFormatterType {
+    func string(from date: Date) -> String
+}
+
+extension ISO8601DateFormatter: DateFormatterType {}
+extension DateFormatter: DateFormatterType {}
+
+/// Date formatter producing `ISO8601` string representation of a given date.
+/// Should be used to encode dates in messages send to the server.
+public let iso8601DateFormatter: DateFormatterType = {
+    // As there is a known crash in iOS 11.0 and 11.1 when using `.withFractionalSeconds` option in `ISO8601DateFormatter`,
+    // we use different `DateFormatterType` implementation depending on the OS version. The problem was fixed by Apple in iOS 11.2.
+    if #available(iOS 11.2, *) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter
+    } else {
+        let iso8601Formatter = DateFormatter()
+        iso8601Formatter.locale = Locale(identifier: "en_US_POSIX")
+        iso8601Formatter.timeZone = TimeZone(abbreviation: "UTC")! // swiftlint:disable:this force_unwrapping
+        iso8601Formatter.calendar = Calendar(identifier: .gregorian)
+        iso8601Formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" // ISO8601 format
+        return iso8601Formatter
+    }
+}()
+
+/// Date formatter producing string representation of a given date for user-facing features (like console output).
+public func presentationDateFormatter(withTimeZone timeZone: TimeZone = .current) -> DateFormatterType {
+    let formatter = DateFormatter()
+    formatter.timeZone = timeZone
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.dateFormat = "HH:mm:ss.SSS"
+    return formatter
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Utils/Sampler.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Utils/Sampler.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sampler, deciding if events should be sent do Datadog or dropped.
+public struct Sampler {
+    /// Value between `0.0` and `100.0`, where `0.0` means NO event will be sent and `100.0` means ALL events will be sent.
+    public let samplingRate: Float
+
+    public init(samplingRate: Float) {
+        self.samplingRate = max(0, min(100, samplingRate))
+    }
+
+    /// Based on the sampling rate, it returns random value deciding if an event should be "sampled" or not.
+    /// - Returns: `true` if event should be sent to Datadog and `false` if it should be dropped.
+    public func sample() -> Bool {
+        return Float.random(in: 0.0..<100.0) < samplingRate
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Utils/SwiftExtensions.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Utils/SwiftExtensions.swift
@@ -1,0 +1,117 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+// MARK: - Optional
+
+extension Optional {
+    public func ifNotNil(_ closure: (Wrapped) throws -> Void) rethrows {
+        if case .some(let unwrappedValue) = self {
+            try closure(unwrappedValue)
+        }
+    }
+}
+
+extension Double {
+    public func divideIfNotZero(by divider: Self) -> Self? {
+        if divider == 0 {
+            return nil
+        }
+        return self / divider
+    }
+
+    public var inverted: Self {
+        return self == 0 ? 0 : 1 / self
+    }
+}
+
+// MARK: - UUID
+
+extension UUID {
+    /// An UUID with all zeroes (`00000000-0000-0000-0000-000000000000`).
+    /// Used to represent "null" in types that cannot be given a proper UUID (e.g. rejected RUM session).
+    public static let nullUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000000") ?? UUID()
+}
+
+// MARK: - TimeInterval
+
+extension TimeInterval {
+    public init(fromMilliseconds milliseconds: Int64) {
+        self = Double(milliseconds) / 1_000
+    }
+
+    /// `TimeInterval` represented in milliseconds (capped to `.min` or `.max` respectively to its sign).
+    public var toMilliseconds: UInt64 {
+        let milliseconds = self * 1_000
+        return UInt64(withNoOverflow: milliseconds)
+    }
+
+    /// `TimeInterval` represented in milliseconds (capped to `.min` or `.max` respectively to its sign).
+    public var toInt64Milliseconds: Int64 {
+        let miliseconds = self * 1_000
+        return Int64(withNoOverflow: miliseconds)
+    }
+
+    /// `TimeInterval` represented in nanoseconds (capped to `.min` or `.max` respectively to its sign).
+    /// Note: as `TimeInterval` yields sub-millisecond precision the nanoseconds precission will be lost.
+    public var toNanoseconds: UInt64 {
+        let nanoseconds = self * 1_000_000_000
+        return UInt64(withNoOverflow: nanoseconds)
+    }
+
+    /// `TimeInterval` represented in nanoseconds (capped to `.min` or `.max` respectively to its sign).
+    /// Note: as `TimeInterval` yields sub-millisecond precision the nanoseconds precission will be lost.
+    public var toInt64Nanoseconds: Int64 {
+        let nanoseconds = self * 1_000_000_000
+        return Int64(withNoOverflow: nanoseconds)
+    }
+}
+
+// MARK: - Safe floating point to integer conversion
+
+public enum FixedWidthIntegerError<T: BinaryFloatingPoint>: Error {
+    case overflow(overflowingValue: T)
+}
+
+extension FixedWidthInteger {
+    /* NOTE: RUMM-182
+     Self(:) is commonly used for conversion, however it fatalError() in case of conversion failure
+     Self(exactly:) does the exact same thing internally yet it returns nil instead of fatalError()
+     It is not trivial to guess if the conversion would fail or succeed, therefore we use Self(exactly:)
+     so that we don't need to guess in order to save the app from crashing
+
+     IMPORTANT: If you pass floatingPoint to Self(exactly:) without rounded(), it may return nil
+     */
+    public init<T: BinaryFloatingPoint>(withReportingOverflow floatingPoint: T) throws {
+        guard let converted = Self(exactly: floatingPoint.rounded()) else {
+            throw FixedWidthIntegerError<T>.overflow(overflowingValue: floatingPoint)
+        }
+        self = converted
+    }
+
+    /// Converts floating point value to fixed width integer with preventing overflow (and crash).
+    /// In case of overflow, the value is converted to `.min` or `.max` respectively to its sign.
+    /// - Parameter floatingPoint: the value to convert
+    public init<T: BinaryFloatingPoint>(withNoOverflow floatingPoint: T) {
+        if let converted = Self(exactly: floatingPoint.rounded()) {
+            self = converted
+        } else { // overflow occured
+            switch floatingPoint.sign {
+            case .minus: self = .min
+            case .plus: self = .max
+            }
+        }
+    }
+}
+
+// MARK: - Array
+
+extension Array {
+    public subscript (safe index: Index) -> Element? {
+        0 <= index && index < count ? self[index] : nil
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogInternal/Utils/UIKitExtensions.swift
+++ b/Sources/ForageSDK/Vendor/DatadogInternal/Utils/UIKitExtensions.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+
+extension DatadogExtension where ExtendedType == UIApplication {
+    /// `UIApplication.shared` does not compile in some environments (e.g. notification service app extension), resulting with:
+    /// _"shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead"_.
+    ///
+    /// As a workaround, this `managedShared` utility provides a key-path access to the `UIApplication.shared` to make the compiler pass.
+    public static var managedShared: UIApplication? {
+        return UIApplication
+            .value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication // swiftlint:disable:this unsafe_uiapplication_shared
+    }
+}
+
+extension UIApplication: DatadogExtended { }
+#endif

--- a/Sources/ForageSDK/Vendor/DatadogLogs/ConsoleLogger.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/ConsoleLogger.swift
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// `Logger` printing logs to console.
+internal final class ConsoleLogger: LoggerProtocol {
+    struct Configuration {
+        /// Time zone for rendering logs.
+        let timeZone: TimeZone
+        /// The format of rendering logs in console.
+        let format: Logger.Configuration.ConsoleLogFormat
+    }
+
+    /// Date provider for logs.
+    private let dateProvider: DateProvider
+    /// Time formatter for rendering log's date in console.
+    private let timeFormatter: DateFormatterType
+    /// The prefix to use when rendering log.
+    private let prefix: String
+    /// The function used to render log.
+    private let printFunction: (String) -> Void
+
+    init(
+        configuration: Configuration,
+        dateProvider: DateProvider,
+        printFunction: @escaping (String) -> Void
+    ) {
+        self.dateProvider = dateProvider
+        self.timeFormatter = presentationDateFormatter(withTimeZone: configuration.timeZone)
+
+        switch configuration.format {
+        case .short:
+            self.prefix = ""
+        case .shortWith(let prefix):
+            self.prefix = "\(prefix) "
+        }
+
+        self.printFunction = printFunction
+    }
+
+    // MARK: - Logging
+
+    func log(level: LogLevel, message: String, error: Error?, attributes: [String: Encodable]?) {
+        var errorString: String? = nil
+        if let error = error {
+            let ddError = DDError(error: error)
+            errorString = buildErrorString(error: ddError)
+        }
+
+        internalLog(level: level, message: message, errorString: errorString)
+    }
+
+    private func internalLog(level: LogLevel, message: String, errorString: String?) {
+        let time = timeFormatter.string(from: dateProvider.now)
+        let status = level.asLogStatus.rawValue.uppercased()
+
+        var log = "\(self.prefix)\(time) [\(status)] \(message)"
+
+        if let errorString = errorString {
+            log += "\n\nError details:\n\(errorString)"
+        }
+
+        printFunction(log)
+    }
+
+    private func buildErrorString(error: DDError) -> String {
+        return """
+        → type: \(error.type)
+        → message: \(error.message)
+        → stack: \(error.stack)
+        """
+    }
+
+    // MARK: - Attributes (no-op for this logger)
+
+    func addAttribute(forKey key: AttributeKey, value: AttributeValue) {}
+    func removeAttribute(forKey key: AttributeKey) {}
+
+    // MARK: - Tags (no-op for this logger)
+
+    func addTag(withKey key: String, value: String) {}
+    func removeTag(withKey key: String) {}
+    func add(tag: String) {}
+    func remove(tag: String) {}
+}
+
+extension ConsoleLogger: InternalLoggerProtocol {
+    func log(level: LogLevel, message: String, errorKind: String?, errorMessage: String?, stackTrace: String?, attributes: [String: Encodable]?) {
+        var errorString: String? = nil
+        if errorKind != nil || errorMessage != nil || stackTrace != nil {
+            // Cross platform frameworks don't necessarilly send all values for errors. Send empty strings
+            // for any values that are empty.
+            let ddError = DDError(type: errorKind ?? "", message: errorMessage ?? "", stack: stackTrace ?? "")
+            errorString = buildErrorString(error: ddError)
+        }
+
+        internalLog(level: level, message: message, errorString: errorString)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Feature/LogsFeature.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Feature/LogsFeature.swift
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+internal struct LogsFeature: DatadogRemoteFeature {
+    static let name = "logging"
+
+    let requestBuilder: FeatureRequestBuilder
+
+    let messageReceiver: FeatureMessageReceiver
+
+    let logEventMapper: LogEventMapper?
+
+    /// Time provider.
+    let dateProvider: DateProvider
+
+    init(
+        logEventMapper: LogEventMapper?,
+        dateProvider: DateProvider,
+        customIntakeURL: URL? = nil
+    ) {
+        self.init(
+            logEventMapper: logEventMapper,
+            requestBuilder: RequestBuilder(customIntakeURL: customIntakeURL),
+            messageReceiver: CombinedFeatureMessageReceiver(
+                LogMessageReceiver(logEventMapper: logEventMapper),
+                CrashLogReceiver(dateProvider: dateProvider),
+                WebViewLogReceiver()
+            ),
+            dateProvider: dateProvider
+        )
+    }
+
+    init(
+        logEventMapper: LogEventMapper?,
+        requestBuilder: FeatureRequestBuilder,
+        messageReceiver: FeatureMessageReceiver,
+        dateProvider: DateProvider
+    ) {
+        self.logEventMapper = logEventMapper
+        self.requestBuilder = requestBuilder
+        self.messageReceiver = messageReceiver
+        self.dateProvider = dateProvider
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Feature/MessageReceivers.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Feature/MessageReceivers.swift
@@ -1,0 +1,304 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Creates Logging Feature Configuration.
+/// - Parameters:
+///   - intake: The Logging intake URL.
+///   - logEventMapper: The log event mapper.
+/// - Returns: The Logging feature configuration.
+internal func createLoggingConfiguration(
+    intake: URL,
+    dateProvider: DateProvider,
+    logEventMapper: LogEventMapper?
+) -> DatadogFeatureConfiguration {
+    return DatadogFeatureConfiguration(
+        name: "logging",
+        requestBuilder: LoggingRequestBuilder(intake: intake),
+        messageReceiver: CombinedFeatureMessageReceiver(
+            LogMessageReceiver(logEventMapper: logEventMapper),
+            CrashLogReceiver(dateProvider: dateProvider),
+            WebViewLogReceiver()
+        )
+    )
+}
+
+/// The Logging URL Request Builder for formatting and configuring the `URLRequest`
+/// to upload logs data.
+internal struct LoggingRequestBuilder: FeatureRequestBuilder {
+    /// The logs intake.
+    let intake: URL
+
+    /// The logs request body format.
+    let format = DataFormat(prefix: "[", suffix: "]", separator: ",")
+
+    func request(for events: [Event], with context: DatadogContext) -> URLRequest {
+        let builder = URLRequestBuilder(
+            url: intake,
+            queryItems: [
+                .ddsource(source: context.source)
+            ],
+            headers: [
+                .contentTypeHeader(contentType: .applicationJSON),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device
+                ),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.ciAppOrigin ?? context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader(),
+            ]
+        )
+
+        let data = format.format(events.map { $0.data })
+        return builder.uploadRequest(with: data)
+    }
+}
+
+/// Defines keys referencing RUM messages supported on the bus.
+internal enum LoggingMessageKeys {
+    /// The key references a log entry message.
+    static let log = "log"
+
+    /// The key references a crash message.
+    static let crash = "crash"
+
+    /// The key references a browser log message.
+    static let browserLog = "browser-log"
+}
+
+/// Receiver to consume a Log message
+internal struct LogMessageReceiver: FeatureMessageReceiver {
+    /// The log event mapper
+    let logEventMapper: LogEventMapper?
+
+    /// Process messages receives from the bus.
+    ///
+    /// - Parameters:
+    ///   - message: The Feature message
+    ///   - core: The core from which the message is transmitted.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard
+            case let .custom(key, attributes) = message, key == LoggingMessageKeys.log,
+            let loggerName: String = attributes["loggerName"],
+            let date: Date = attributes["date"],
+            let message: String = attributes["message"],
+            let level: LogLevel = attributes["level"],
+            let threadName: String = attributes["threadName"]
+        else {
+            return false
+        }
+
+        let userAttributes: [String: AnyCodable] = attributes["userAttributes"] ?? [:]
+        let internalAttributes: [String: AnyCodable]? = attributes["internalAttributes"]
+
+        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: false) { context, writer in
+            let builder = LogEventBuilder(
+                service: attributes["service"] ?? context.service,
+                loggerName: loggerName,
+                networkInfoEnabled: attributes["networkInfoEnabled"] ?? false,
+                eventMapper: logEventMapper
+            )
+
+            builder.createLogEvent(
+                date: date,
+                level: level,
+                message: message,
+                error: attributes["error"],
+                attributes: .init(
+                    userAttributes: userAttributes,
+                    internalAttributes: internalAttributes
+                ),
+                tags: [],
+                context: context,
+                threadName: threadName,
+                callback: writer.write
+            )
+        }
+
+        return true
+    }
+}
+
+/// Receiver to consume a Crash Log message as Log.
+internal struct CrashLogReceiver: FeatureMessageReceiver {
+    private struct CrashReport: Decodable {
+        /// The date of the crash occurrence.
+        let date: Date?
+        /// Crash report type - used to group similar crash reports.
+        /// In Datadog Error Tracking this corresponds to `error.type`.
+        let type: String
+        /// Crash report message - if possible, it should provide additional troubleshooting information in addition to the crash type.
+        /// In Datadog Error Tracking this corresponds to `error.message`.
+        let message: String
+        /// Unsymbolicated stack trace related to the crash (this can be either uncaugh exception backtrace or stack trace of the halted thread).
+        /// In Datadog Error Tracking this corresponds to `error.stack`.
+        let stack: String
+        /// All threads running in the process.
+        let threads: AnyCodable
+        /// List of binary images referenced from all stack traces.
+        let binaryImages: AnyCodable
+        /// Meta information about the crash and process.
+        let meta: AnyCodable
+        /// If any stack trace information was truncated due to crash report minimization.
+        let wasTruncated: Bool
+    }
+
+    private struct CrashContext: Decodable {
+        /// Interval between device and server time.
+        let serverTimeOffset: TimeInterval
+        /// The name of the service that data is generated from.
+        let service: String
+        /// The name of the environment that data is generated from.
+        let env: String
+        /// The version of the application that data is generated from.
+        let version: String
+        /// Current device information.
+        let device: DeviceInfo
+        /// The version of Datadog iOS SDK.
+        let sdkVersion: String
+        /// Network information.
+        ///
+        /// Represents the current state of the device network connectivity and interface.
+        /// The value can be `unknown` if the network interface is not available or if it has not
+        /// yet been evaluated.
+        let networkConnectionInfo: NetworkConnectionInfo?
+        /// Carrier information.
+        ///
+        /// Represents the current telephony service info of the device.
+        /// This value can be `nil` of no service is currently registered, or if the device does
+        /// not support telephony services.
+        let carrierInfo: CarrierInfo?
+        /// Current user information.
+        let userInfo: UserInfo?
+    }
+
+    /// Time provider.
+    let dateProvider: DateProvider
+
+    /// Process messages receives from the bus.
+    ///
+    /// - Parameters:
+    ///   - message: The Feature message
+    ///   - core: The core from which the message is transmitted.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard
+            case let .custom(key, attributes) = message, key == LoggingMessageKeys.crash,
+            let report = attributes["report", type: CrashReport.self],
+            let context = attributes["context", type: CrashContext.self]
+        else {
+            return false
+        }
+
+        // The `report.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
+        // to the server time before processing. Following use of the current correction is not ideal, but this is the best
+        // approximation we can get.
+        let date = (report.date ?? dateProvider.now)
+            .addingTimeInterval(context.serverTimeOffset)
+
+        var errorAttributes: [AttributeKey: AttributeValue] = [:]
+        errorAttributes[DDError.threads] = report.threads
+        errorAttributes[DDError.binaryImages] = report.binaryImages
+        errorAttributes[DDError.meta] = report.meta
+        errorAttributes[DDError.wasTruncated] = report.wasTruncated
+
+        let user = context.userInfo
+        let deviceInfo = context.device
+
+        let event = LogEvent(
+            date: date,
+            status: .emergency,
+            message: report.message,
+            error: .init(
+                kind: report.type,
+                message: report.message,
+                stack: report.stack
+            ),
+            serviceName: context.service,
+            environment: context.env,
+            loggerName: "crash-reporter",
+            loggerVersion: context.sdkVersion,
+            threadName: nil,
+            applicationVersion: context.version,
+            dd: .init(
+                device: .init(architecture: deviceInfo.architecture)
+            ),
+            os: .init(
+                name: context.device.name,
+                version: context.device.osVersion,
+                build: context.device.osBuildNumber
+            ),
+            userInfo: .init(
+                id: user?.id,
+                name: user?.name,
+                email: user?.email,
+                extraInfo: user?.extraInfo ?? [:]
+            ),
+            networkConnectionInfo: context.networkConnectionInfo,
+            mobileCarrierInfo: context.carrierInfo,
+            attributes: .init(userAttributes: [:], internalAttributes: errorAttributes),
+            tags: nil
+        )
+
+        // crash reporting is considering the user consent from previous session, if an event reached
+        // the message bus it means that consent was granted and we can safely bypass current consent.
+        core.scope(for: LogsFeature.name)?.eventWriteContext(bypassConsent: true, forceNewBatch: false) { _, writer in
+            writer.write(value: event)
+        }
+
+        return true
+    }
+}
+
+/// Receiver to consume a Log event coming from Browser SDK.
+internal struct WebViewLogReceiver: FeatureMessageReceiver {
+    /// Process messages receives from the bus.
+    ///
+    /// - Parameters:
+    ///   - message: The Feature message
+    ///   - core: The core from which the message is transmitted.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .custom(key, baggage) = message, key == LoggingMessageKeys.browserLog else {
+            return false
+        }
+
+        var event = baggage.attributes
+
+        let versionKey = LogEventEncoder.StaticCodingKeys.applicationVersion.rawValue
+        let envKey = LogEventEncoder.StaticCodingKeys.environment.rawValue
+        let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
+        let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
+
+        core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+            let ddTags = "\(versionKey):\(context.version),\(envKey):\(context.env)"
+
+            if let tags = event[tagsKey] as? String, !tags.isEmpty {
+                event[tagsKey] = "\(ddTags),\(tags)"
+            } else {
+                event[tagsKey] = ddTags
+            }
+
+            if let timestampInMs = event[dateKey] as? Int64 {
+                let serverTimeOffsetInMs = context.serverTimeOffset.toInt64Milliseconds
+                let correctedTimestamp = timestampInMs + serverTimeOffsetInMs
+                event[dateKey] = correctedTimestamp
+            }
+
+            if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
+                let mappedBaggage = Dictionary(uniqueKeysWithValues: baggage.map { key, value in (mapRUMContextAttributeKeyToLogAttributeKey(key), value) })
+                event.merge(mappedBaggage as [String: Any]) { $1 }
+            }
+
+            writer.write(value: AnyEncodable(event))
+        }
+
+        return true
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Feature/RUMContextMapping.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Feature/RUMContextMapping.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// RUM context in `DatadogContext.featureAttributes` uses different keys than the ones we need to set
+/// in log event for Log <> RUM link. This function does necessary re-mapping to isolate this logic temporarily until
+/// we discuss standard solution.
+internal func mapRUMContextAttributeKeyToLogAttributeKey(_ originalKey: String) -> String {
+    switch originalKey {
+    case "application.id":
+        return "application_id"
+    case "session.id":
+        return "session_id"
+    default:
+        return originalKey
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Feature/RequestBuilder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Feature/RequestBuilder.swift
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// The Logging URL Request Builder for formatting and configuring the `URLRequest`
+/// to upload logs data.
+internal struct RequestBuilder: FeatureRequestBuilder {
+    /// A custom logs intake.
+    let customIntakeURL: URL?
+
+    /// The logs request body format.
+    let format = DataFormat(prefix: "[", suffix: "]", separator: ",")
+
+    init(customIntakeURL: URL? = nil) {
+        self.customIntakeURL = customIntakeURL
+    }
+
+    func request(for events: [Event], with context: DatadogContext) -> URLRequest {
+        let builder = URLRequestBuilder(
+            url: url(with: context),
+            queryItems: [
+                .ddsource(source: context.source)
+            ],
+            headers: [
+                .contentTypeHeader(contentType: .applicationJSON),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device
+                ),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.ciAppOrigin ?? context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader(),
+            ]
+        )
+
+        let data = format.format(events.map { $0.data })
+        return builder.uploadRequest(with: data)
+    }
+
+    private func url(with context: DatadogContext) -> URL {
+        customIntakeURL ?? context.site.endpoint.appendingPathComponent("api/v2/logs")
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventBuilder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventBuilder.swift
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+
+/// Builds `LogEvent` from data received from the user and provided internally by the SDK.
+internal struct LogEventBuilder {
+    /// The `service` value for logs.
+    /// See: [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    let service: String
+    /// The `logger.name` value for logs.
+    let loggerName: String?
+    /// Whether to send the network info in `network.client.*` log attributes.
+    let networkInfoEnabled: Bool
+    /// Allows for modifying (or dropping) logs before they get sent.
+    let eventMapper: LogEventMapper?
+
+    /// Creates `LogEvent`.
+    ///
+    /// To ensure that logs include precise and correct information, some parameters must be collected synchronously on the caller thread
+    /// whereas other don't. For example, it is important to sign logs with a `date` read exactly from the moment of public API call, but
+    /// network info and other parts of the SDK `context` can be provided asynchronously.
+    ///
+    /// This is to guarantee the right order of logs in Datadog app when using multiple loggers on the same thread and to make sure
+    /// that reported application context is accurate for the moment of log creation.
+    ///
+    /// - Parameters:
+    ///   - date: date of creating the log
+    ///   - level: the severity level of the log
+    ///   - message: the message of the log
+    ///   - error: eventual error to associate with log
+    ///   - attributes: attributes to associate with log (user and internal attributes, separate)
+    ///   - tags: tags to associate with log
+    ///   - context: SDK context from the moment of creating log
+    ///   - threadName: the name of the thread on which the log is created.
+    ///   - callback: The callback to return the modified `LogEvent`.
+    ///
+    /// - Note: `date` and `threadName` must be collected on the user thread.
+    func createLogEvent(
+        date: Date,
+        level: LogLevel,
+        message: String,
+        error: DDError?,
+        attributes: LogEvent.Attributes,
+        tags: Set<String>,
+        context: DatadogContext,
+        threadName: String,
+        callback: @escaping (LogEvent) -> Void
+    ) {
+        let userInfo = context.userInfo ?? .empty
+
+        let log = LogEvent(
+            date: date.addingTimeInterval(context.serverTimeOffset),
+            status: level.asLogStatus,
+            message: message,
+            error: error.map {
+                .init(
+                    kind: $0.type,
+                    message: $0.message,
+                    stack: $0.stack
+                )
+            },
+            serviceName: service,
+            environment: context.env,
+            loggerName: loggerName ?? context.applicationBundleIdentifier,
+            loggerVersion: context.sdkVersion,
+            threadName: threadName,
+            applicationVersion: context.version,
+            dd: LogEvent.Dd(
+                device: LogEvent.DeviceInfo(architecture: context.device.architecture)
+            ),
+            os: .init(
+                name: context.device.name,
+                version: context.device.osVersion,
+                build: context.device.osBuildNumber
+            ),
+            userInfo: .init(
+                id: userInfo.id,
+                name: userInfo.name,
+                email: userInfo.email,
+                extraInfo: userInfo.extraInfo
+            ),
+            networkConnectionInfo: networkInfoEnabled ? context.networkConnectionInfo : nil,
+            mobileCarrierInfo: networkInfoEnabled ? context.carrierInfo : nil,
+            attributes: attributes,
+            tags: !tags.isEmpty ? Array(tags) : nil
+        )
+
+        eventMapper?.map(event: log, callback: callback) ?? callback(log)
+    }
+}
+
+internal extension LogLevel {
+    var asLogStatus: LogEvent.Status {
+        switch self {
+        case .debug:    return .debug
+        case .info:     return .info
+        case .notice:   return .notice
+        case .warn:     return .warn
+        case .error:    return .error
+        case .critical: return .critical
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventEncoder.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventEncoder.swift
@@ -1,0 +1,263 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// `Encodable` representation of log. It gets sanitized before encoding.
+/// All mutable properties are subject of sanitization.
+public struct LogEvent: Encodable {
+    /// The Log event status definitions.
+    public enum Status: String, Encodable, CaseIterable, Equatable {
+        case debug
+        case info
+        case notice
+        case warn
+        case error
+        case critical
+        case emergency
+    }
+
+    /// Custom attributes associated with a the log event.
+    public struct Attributes {
+        /// Log custom attributes, They are subject for sanitization.
+        public var userAttributes: [String: Encodable]
+        /// Log attributes added internally by the SDK. They are not a subject for sanitization.
+        internal let internalAttributes: [String: Encodable]?
+    }
+
+    /// User information associated with a the log event.
+    public struct UserInfo {
+        /// User ID, if any.
+        public let id: String?
+        /// Name representing the user, if any.
+        public let name: String?
+        /// User email, if any.
+        public let email: String?
+        /// User custom attributes, if any.
+        public var extraInfo: [String: Encodable]
+    }
+
+    /// Error description associated with a log event.
+    public struct Error {
+        /// The Log error kind
+        public var kind: String?
+        /// The Log error message
+        public var message: String?
+        /// The Log error stack
+        public var stack: String?
+    }
+
+    /// Device information.
+    public struct DeviceInfo: Codable {
+        /// The architecture of the device
+        public let architecture: String
+    }
+
+    /// Operating System description.
+    public struct OperatingSystem: Codable {
+        /// Operating system name, e.g. Android, iOS
+        public let name: String
+        /// Full operating system version, e.g. 8.1.1
+        public let version: String
+        /// Operating system build number, e.g. 15D21
+        public let build: String?
+    }
+
+    /// Datadog specific attributes.
+    public struct Dd: Codable {
+        /// Device information
+        public let device: DeviceInfo
+    }
+
+    /// The log's timestamp
+    public let date: Date
+    /// The log status
+    public let status: Status
+    /// The log message
+    public var message: String
+    /// The associated log error
+    public var error: Error?
+    /// The service name configured for Logs.
+    public let serviceName: String
+    /// The current log environement.
+    public let environment: String
+    /// The configured logger name.
+    public let loggerName: String
+    /// The current logger version.
+    public let loggerVersion: String
+    /// The thread's name this log event has been sent from.
+    public let threadName: String?
+    /// The current application version.
+    public let applicationVersion: String
+    /// Datadog specific attributes
+    public let dd: Dd
+    /// The associated log error
+    public let os: OperatingSystem
+    /// Custom user information configured globally for the SDK.
+    public var userInfo: UserInfo
+    /// The network connection information from the moment the log was sent.
+    public let networkConnectionInfo: NetworkConnectionInfo?
+    /// The mobile carrier information from the moment the log was sent.
+    public let mobileCarrierInfo: CarrierInfo?
+    /// The attributes associated with this log.
+    public var attributes: LogEvent.Attributes
+    /// Tags associated with this log.
+    public var tags: [String]?
+
+    public func encode(to encoder: Encoder) throws {
+        let sanitizedLog = LogEventSanitizer().sanitize(log: self)
+        try LogEventEncoder().encode(sanitizedLog, to: encoder)
+    }
+}
+
+/// Encodes `Log` to given encoder.
+internal struct LogEventEncoder {
+    /// Coding keys for permanent `Log` attributes.
+    enum StaticCodingKeys: String, CodingKey {
+        case date
+        case status
+        case message
+        case serviceName = "service"
+        case environment = "env"
+        case tags = "ddtags"
+        case os = "os"
+
+        // MARK: - Error
+
+        case errorKind = "error.kind"
+        case errorMessage = "error.message"
+        case errorStack = "error.stack"
+
+        // MARK: - Application info
+
+        case applicationVersion = "version"
+
+        // MARK: - Dd info
+        case dd = "_dd"
+
+        // MARK: - Logger info
+
+        case loggerName = "logger.name"
+        case loggerVersion = "logger.version"
+        case threadName = "logger.thread_name"
+
+        // MARK: - User info
+
+        case userId = "usr.id"
+        case userName = "usr.name"
+        case userEmail = "usr.email"
+
+        // MARK: - Network connection info
+
+        case networkReachability = "network.client.reachability"
+        case networkAvailableInterfaces = "network.client.available_interfaces"
+        case networkConnectionSupportsIPv4 = "network.client.supports_ipv4"
+        case networkConnectionSupportsIPv6 = "network.client.supports_ipv6"
+        case networkConnectionIsExpensive = "network.client.is_expensive"
+        case networkConnectionIsConstrained = "network.client.is_constrained"
+
+        // MARK: - Mobile carrier info
+
+        case mobileNetworkCarrierName = "network.client.sim_carrier.name"
+        case mobileNetworkCarrierISOCountryCode = "network.client.sim_carrier.iso_country"
+        case mobileNetworkCarrierRadioTechnology = "network.client.sim_carrier.technology"
+        case mobileNetworkCarrierAllowsVoIP = "network.client.sim_carrier.allows_voip"
+    }
+
+    /// Coding keys for dynamic `Log` attributes specified by user.
+    private struct DynamicCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { return nil }
+        init(_ string: String) { self.stringValue = string }
+    }
+
+    func encode(_ log: LogEvent, to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StaticCodingKeys.self)
+        try container.encode(log.date, forKey: .date)
+        try container.encode(log.status, forKey: .status)
+        try container.encode(log.message, forKey: .message)
+        try container.encode(log.serviceName, forKey: .serviceName)
+        try container.encode(log.os, forKey: .os)
+
+        // Encode log.error properties
+        if let someError = log.error {
+            try container.encode(someError.kind, forKey: .errorKind)
+            try container.encode(someError.message, forKey: .errorMessage)
+            try container.encode(someError.stack, forKey: .errorStack)
+        }
+
+        // Encode logger info
+        try container.encode(log.loggerName, forKey: .loggerName)
+        try container.encode(log.loggerVersion, forKey: .loggerVersion)
+        try container.encode(log.threadName, forKey: .threadName)
+
+        // Encode application info
+        try container.encode(log.applicationVersion, forKey: .applicationVersion)
+
+        try container.encode(log.dd, forKey: .dd)
+
+        // Encode user info
+        try log.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }
+        try log.userInfo.name.ifNotNil { try container.encode($0, forKey: .userName) }
+        try log.userInfo.email.ifNotNil { try container.encode($0, forKey: .userEmail) }
+
+        // Encode network info
+        if let networkConnectionInfo = log.networkConnectionInfo {
+            try container.encode(networkConnectionInfo.reachability, forKey: .networkReachability)
+            try container.encode(networkConnectionInfo.availableInterfaces, forKey: .networkAvailableInterfaces)
+            try container.encode(networkConnectionInfo.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
+            try container.encode(networkConnectionInfo.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
+            try container.encode(networkConnectionInfo.isExpensive, forKey: .networkConnectionIsExpensive)
+            try networkConnectionInfo.isConstrained.ifNotNil {
+                try container.encode($0, forKey: .networkConnectionIsConstrained)
+            }
+        }
+
+        // Encode mobile carrier info
+        if let carrierInfo = log.mobileCarrierInfo {
+            try carrierInfo.carrierName.ifNotNil {
+                try container.encode($0, forKey: .mobileNetworkCarrierName)
+            }
+            try carrierInfo.carrierISOCountryCode.ifNotNil {
+                try container.encode($0, forKey: .mobileNetworkCarrierISOCountryCode)
+            }
+            try container.encode(carrierInfo.radioAccessTechnology, forKey: .mobileNetworkCarrierRadioTechnology)
+            try container.encode(carrierInfo.carrierAllowsVOIP, forKey: .mobileNetworkCarrierAllowsVoIP)
+        }
+
+        // Encode attributes...
+        var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+
+        // 1. user info attributes
+        try log.userInfo.extraInfo.forEach {
+            let key = DynamicCodingKey("usr.\($0)")
+            try attributesContainer.encode(AnyEncodable($1), forKey: key)
+        }
+
+        // 2. user attributes
+        let encodableUserAttributes = Dictionary(
+            uniqueKeysWithValues: log.attributes.userAttributes.map { name, value in (name, AnyEncodable(value)) }
+        )
+        try encodableUserAttributes.forEach { try attributesContainer.encode($0.value, forKey: DynamicCodingKey($0.key)) }
+
+        // 3. internal attributes
+        if let internalAttributes = log.attributes.internalAttributes {
+            let encodableInternalAttributes = Dictionary(
+                uniqueKeysWithValues: internalAttributes.map { name, value in (name, AnyEncodable(value)) }
+            )
+            try encodableInternalAttributes.forEach { try attributesContainer.encode($0.value, forKey: DynamicCodingKey($0.key)) }
+        }
+
+        // Encode tags
+        var tags = log.tags ?? []
+        tags.append("env:\(log.environment)") // include default env tag
+        tags.append("version:\(log.applicationVersion)") // include default version tag
+        let tagsString = tags.joined(separator: ",")
+        try container.encode(tagsString, forKey: .tags)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventSanitizer.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Log/LogEventSanitizer.swift
@@ -1,0 +1,169 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sanitizes `Log` representation received from the user, so it can match Datadog log constraints.
+internal struct LogEventSanitizer {
+    internal struct Constraints {
+        /// Attribute names reserved for Datadog.
+        /// If any of those is used by the user, the attribute will be ignored.
+        static let reservedAttributeNames: Set<String> = [
+            "host", "message", "status", "service", "source", "ddtags",
+            "dd.trace_id", "dd.span_id",
+            "application_id", "session_id", "view.id", "user_action.id",
+        ]
+        /// Allowed first character of a tag name (given as ASCII values ranging from lowercased `a` to `z`) .
+        /// Tags with name starting with different character will be dropped.
+        static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97...122)
+        /// Maximum length of the tag.
+        /// Tags exceeting this length will be trunkated.
+        static let maxTagLength: Int = 200
+        /// Tag keys reserved for Datadog.
+        /// If any of those is used by user, the tag will be ignored.
+        static let reservedTagKeys: Set<String> = [
+            "host", "device", "source", "service", "env"
+        ]
+        /// Maximum number of attributes in log.
+        /// If this number is exceeded, extra attributes will be ignored.
+        static let maxNumberOfTags: Int = 100
+    }
+
+    private let attributesSanitizer = AttributesSanitizer(featureName: "Log")
+
+    func sanitize(log: LogEvent) -> LogEvent {
+        let sanitizedAttributes = sanitize(attributes: log.attributes)
+        let sanitizedTags = sanitize(tags: log.tags)
+
+        var sanitizedLog = log
+        sanitizedLog.attributes = sanitizedAttributes
+        sanitizedLog.tags = sanitizedTags
+        return sanitizedLog
+    }
+
+    // MARK: - Attributes sanitization
+
+    private func sanitize(attributes rawAttributes: LogEvent.Attributes) -> LogEvent.Attributes {
+        // Sanitizes only `userAttributes`, `internalAttributes` remain untouched
+        var userAttributes = rawAttributes.userAttributes
+        userAttributes = removeInvalidAttributes(userAttributes)
+        userAttributes = removeReservedAttributes(userAttributes)
+        userAttributes = attributesSanitizer.sanitizeKeys(for: userAttributes)
+        let userAttributesLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes - (rawAttributes.internalAttributes?.count ?? 0)
+        userAttributes = attributesSanitizer.limitNumberOf(attributes: userAttributes, to: userAttributesLimit)
+
+        return LogEvent.Attributes(
+            userAttributes: userAttributes,
+            internalAttributes: rawAttributes.internalAttributes
+        )
+    }
+
+    private func removeInvalidAttributes(_ attributes: [String: Encodable]) -> [String: Encodable] {
+        // Attribute name cannot be empty
+        return attributes.filter { attribute in
+            if attribute.key.isEmpty {
+                DD.logger.error("Attribute key is empty. This attribute will be ignored.")
+                return false
+            }
+            return true
+        }
+    }
+
+    private func removeReservedAttributes(_ attributes: [String: Encodable]) -> [String: Encodable] {
+        return attributes.filter { attribute in
+            if Constraints.reservedAttributeNames.contains(attribute.key) {
+                DD.logger.error("'\(attribute.key)' is a reserved attribute name. This attribute will be ignored.")
+                return false
+            }
+            return true
+        }
+    }
+
+    // MARK: - Tags sanitization
+
+    private func sanitize(tags rawTags: [String]?) -> [String]? {
+        if let rawTags = rawTags {
+            let tags = rawTags
+                .map { $0.lowercased() }
+                .filter { startsWithAllowedCharacter(tag: $0) }
+                .map { replaceIllegalCharactersIn(tag: $0) }
+                .map { removeTrailingCommasIn(tag: $0) }
+                .map { limitToMaxLength(tag: $0) }
+                .filter { isNotReserved(tag: $0) }
+            return limitToMaxNumberOfTags(tags)
+        } else {
+            return nil
+        }
+    }
+
+    private func startsWithAllowedCharacter(tag: String) -> Bool {
+        guard let firstCharacter = tag.first?.asciiValue else {
+            DD.logger.error("Tag is empty and will be ignored.")
+            return false
+        }
+
+        // Tag must start with a letter
+        if Constraints.allowedTagNameFirstCharacterASCIIRange.contains(firstCharacter) {
+            return true
+        } else {
+            DD.logger.error("Tag '\(tag)' starts with an invalid character and will be ignored.")
+            return false
+        }
+    }
+
+    private func replaceIllegalCharactersIn(tag: String) -> String {
+        let sanitized = tag.replacingOccurrences(of: #"[^a-z0-9_:.\/-]"#, with: "_", options: .regularExpression)
+        if sanitized != tag {
+            DD.logger.warn("Tag '\(tag)' was modified to '\(sanitized)' to match Datadog constraints.")
+        }
+        return sanitized
+    }
+
+    private func removeTrailingCommasIn(tag: String) -> String {
+        // If present, remove trailing commas `:`
+        var sanitized = tag
+        while sanitized.last == ":" { _ = sanitized.removeLast() }
+        if sanitized != tag {
+            DD.logger.warn("Tag '\(tag)' was modified to '\(sanitized)' to match Datadog constraints.")
+        }
+        return sanitized
+    }
+
+    private func limitToMaxLength(tag: String) -> String {
+        if tag.count > Constraints.maxTagLength {
+            let sanitized = String(tag.prefix(Constraints.maxTagLength))
+            DD.logger.warn("Tag '\(tag)' was modified to '\(sanitized)' to match Datadog constraints.")
+            return sanitized
+        } else {
+            return tag
+        }
+    }
+
+    private func isNotReserved(tag: String) -> Bool {
+        if let colonIndex = tag.firstIndex(of: ":") {
+            let key = String(tag.prefix(upTo: colonIndex))
+            if Constraints.reservedTagKeys.contains(key) {
+                DD.logger.warn("'\(key)' is a reserved tag key. This tag will be ignored.")
+                return false
+            } else {
+                return true
+            }
+        } else {
+            return true
+        }
+    }
+
+    private func limitToMaxNumberOfTags(_ tags: [String]) -> [String] {
+        // Only `Constraints.maxNumberOfTags` of tags are allowed.
+        if tags.count > Constraints.maxNumberOfTags {
+            let extraTagsCount = tags.count - Constraints.maxNumberOfTags
+            DD.logger.warn("Number of tags exceeds the limit of \(Constraints.maxNumberOfTags). \(extraTagsCount) attribute(s) will be ignored.")
+            return tags.dropLast(extraTagsCount)
+        } else {
+            return tags
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/LogOutputs/LogFileOutput.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/LogOutputs/LogFileOutput.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// `LogOutput` writing logs to file.
+internal struct LogFileOutput: LogOutput {
+    let fileWriter: Writer
+
+    func write(log: LogEvent) {
+        fileWriter.write(value: log)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/LogOutputs/LogOutput.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/LogOutputs/LogOutput.swift
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An interface for writing logs to some destination.
+internal protocol LogOutput {
+    func write(log: LogEvent)
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Logger.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Logger.swift
@@ -1,0 +1,200 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Datadog logger.
+public struct Logger {
+    public struct Configuration {
+        /// Format to use when printing logs to console.
+        public enum ConsoleLogFormat {
+            /// Prints short representation of log.
+            case short
+            /// Prints short representation of log with given prefix.
+            case shortWith(prefix: String)
+        }
+
+        /// The service name  (default value is set to application bundle identifier)
+        public var service: String?
+
+        /// The logger custom name (default value is set to main bundle identifier)
+        public var name: String?
+
+        /// Enriches logs with network connection info.
+        ///
+        /// This means: reachability status, connection type, mobile carrier name and many more will be added to each log.
+        /// For full list of network info attributes see `NetworkConnectionInfo` and `CarrierInfo`.
+        ///
+        /// `false` by default.
+        public var networkInfoEnabled: Bool
+
+        /// Enables the logs integration with RUM.
+        ///
+        /// If enabled all the logs will be enriched with the current RUM View information and
+        /// it will be possible to see all the logs sent during a specific View lifespan in the RUM Explorer.
+        ///
+        /// `true` by default.
+        public var bundleWithRumEnabled: Bool
+
+        /// Enables the logs integration with active span API from Tracing.
+        ///
+        /// If enabled all the logs will be bundled with the `DatadogTracer.shared().activeSpan` trace and
+        /// it will be possible to see all the logs sent during that specific trace.
+        ///
+        /// `true` by default.
+        public var bundleWithTraceEnabled: Bool
+
+        /// Sets the sample rate for remote logging.
+        ///
+        /// **When set to `0`, no log entries will be sent to Datadog servers.**
+        /// A value of`100` means all logs will be processed.
+        ///
+        /// When setting the `remoteSampleRate` to `0`
+        ///
+        /// Default is `100`, meaning that all logs will be sent.
+        public var remoteSampleRate: Float
+
+        /// Set the minimum log level reported to Datadog servers.
+        /// Any log with a level equal or above the threshold will be sent.
+        ///
+        /// Note: this setting doesn't impact logs printed to the console if `printLogsToConsole(_:)`
+        /// is used - all logs will be printed, no matter of their level.
+        ///
+        /// `LogLevel.debug` by default
+        public var remoteLogThreshold: LogLevel
+
+        /// Format to use when printing logs to console - either `.short` or `.json`.
+        ///
+        /// Do not print to console by default.
+        public var consoleLogFormat: ConsoleLogFormat?
+
+        /// Overrides the current process info.
+        internal var processInfo: ProcessInfo = .processInfo
+
+        /// Creates a Logger Configuration.
+        /// 
+        /// - Parameters:
+        ///   - service: The service name  (default value is set to application bundle identifier)
+        ///   - name: The logger custom name (default value is set to main bundle identifier)
+        ///   - networkInfoEnabled: Enriches logs with network connection info. `false` by default.
+        ///   - bundleWithRUM: Enables the logs integration with RUM. `true` by default.
+        ///   - bundleWithTraceEnabled: Enables the logs integration with active span API from Tracing. `true` by default
+        ///   - remoteSampleRate: The sample rate for remote logging. **When set to `0`, no log entries will be sent to Datadog servers.**
+        ///   - remoteLogThreshold: Set the minimum log level reported to Datadog servers. .debug by default.
+        ///   - consoleLogFormat: Format to use when printing logs to console - either `.short` or `.json`.
+        public init(
+            service: String? = nil,
+            name: String? = nil,
+            networkInfoEnabled: Bool = false,
+            bundleWithRumEnabled: Bool = true,
+            bundleWithTraceEnabled: Bool = true,
+            remoteSampleRate: Float = 100,
+            remoteLogThreshold: LogLevel = .debug,
+            consoleLogFormat: ConsoleLogFormat? = nil
+        ) {
+            self.service = service
+            self.name = name
+            self.networkInfoEnabled = networkInfoEnabled
+            self.bundleWithRumEnabled = bundleWithRumEnabled
+            self.bundleWithTraceEnabled = bundleWithTraceEnabled
+            self.remoteSampleRate = remoteSampleRate
+            self.remoteLogThreshold = remoteLogThreshold
+            self.consoleLogFormat = consoleLogFormat
+        }
+    }
+
+    // MARK: - Logger Creation
+
+    /// Creates a Logger complying with `LoggerProtocol`.
+    ///
+    /// - Parameters:
+    ///   - configuration: The logger configuration.
+    ///   - core: The instance of Datadog SDK to enable Logs in (global instance by default).
+    /// - Returns: A logger instance.
+    public static func create(
+        with configuration: Configuration = .init(),
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) -> LoggerProtocol {
+        do {
+            return try createOrThrow(with: configuration, in: core)
+        } catch {
+            DD.logger.critical("Failed to build `Logger`.", error: error)
+            return NOPLogger()
+        }
+    }
+
+    /// Creates a Logger complying with `LoggerProtocol` or throw an error.
+    ///
+    /// - Parameters:
+    ///   - configuration: The logger configuration.
+    ///   - core: The instance of Datadog SDK to enable Logs in (global instance by default).
+    /// - Returns: A logger instance.
+    private static func createOrThrow(with configuration: Configuration, in core: DatadogCoreProtocol) throws -> LoggerProtocol {
+        if core is NOPDatadogCore {
+            throw ProgrammerError(
+                description: "`Datadog.initialize()` must be called prior to `Logger.builder.build()`."
+            )
+        }
+
+        guard let feature = core.get(feature: LogsFeature.self) else {
+            throw ProgrammerError(
+                description: "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
+            )
+        }
+
+        let debug = configuration.processInfo.arguments.contains(LaunchArguments.Debug)
+
+        let remoteLogger: RemoteLogger? = {
+            guard configuration.remoteSampleRate > 0 else {
+                return nil
+            }
+
+            return RemoteLogger(
+                core: core,
+                configuration: RemoteLogger.Configuration(
+                    service: configuration.service,
+                    name: configuration.name,
+                    networkInfoEnabled: configuration.networkInfoEnabled,
+                    threshold: configuration.remoteLogThreshold,
+                    eventMapper: feature.logEventMapper,
+                    sampler: Sampler(samplingRate: debug ? 100 : configuration.remoteSampleRate)
+                ),
+                dateProvider: feature.dateProvider,
+                rumContextIntegration: configuration.bundleWithRumEnabled,
+                activeSpanIntegration: configuration.bundleWithTraceEnabled
+            )
+        }()
+
+        let consoleLogger: ConsoleLogger? = {
+            guard let consoleLogFormat = configuration.consoleLogFormat else {
+                return nil
+            }
+
+            return ConsoleLogger(
+                configuration: ConsoleLogger.Configuration(
+                    timeZone: .current,
+                    format: consoleLogFormat
+                ),
+                dateProvider: feature.dateProvider,
+                printFunction: consolePrint
+            )
+        }()
+
+        switch (remoteLogger, consoleLogger) {
+        case (let remoteLogger?, nil):
+            return remoteLogger
+
+        case (nil, let consoleLogger?):
+            return consoleLogger
+
+        case (let remoteLogger?, let consoleLogger?):
+            return CombinedLogger(combinedLoggers: [remoteLogger, consoleLogger])
+
+        case (nil, nil): // when user explicitly produces a no-op logger
+            return NOPLogger()
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/LoggerProtocol+Internal.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/LoggerProtocol+Internal.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Internal Logger for Cross-Platform access.
+public protocol InternalLoggerProtocol {
+    /// General purpose logging method.
+    /// Sends a log with certain `level`, `message`, `errorKind`,  `errorMessage`,  `stackTrace` and `attributes`.
+    ///
+    /// This method is meant for non-native or cross platform frameworks (such as React Native or Flutter) to send error information
+    /// to Datadog. Although it can be used directly, it is recommended to use other methods declared on `Logger`.
+    ///
+    /// - Parameters:
+    ///   - level: the log level
+    ///   - message: the message to be logged
+    ///   - errorKind: the kind of error reported
+    ///   - errorMessage: the message attached to the error
+    ///   - stackTrace: a string representation of the error's stack trace
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func log(
+        level: LogLevel,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        stackTrace: String?,
+        attributes: [String: Encodable]?
+    )
+}
+
+private struct NOPInternalLogger: InternalLoggerProtocol {
+    func log(
+        level: LogLevel,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        stackTrace: String?,
+        attributes: [String: Encodable]?
+    ) { }
+}
+
+/// Extends `LoggerProtocol` with additional methods designed for Datadog cross-platform SDKs.
+extension LoggerProtocol {
+    /// Grants access to an internal interface utilized only by Datadog cross-platform SDKs.
+    /// **It is not meant for public use** and it might change without prior notice.
+    public var _internal: InternalLoggerProtocol {
+        self as? InternalLoggerProtocol ?? NOPInternalLogger()
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/LoggerProtocol.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/LoggerProtocol.swift
@@ -1,0 +1,230 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Log levels ordered by their severity, with `.debug` being the least severe and
+/// `.critical` being the most severe.
+public enum LogLevel: Int, Codable {
+    case debug
+    case info
+    case notice
+    case warn
+    case error
+    case critical
+}
+
+/// Datadog Logger.
+///
+/// Usage:
+///
+///     import DatadogLogs
+///
+///     // Initialise the Logs module
+///
+///     // logger reference
+///     var logger = Logger.create()
+public protocol LoggerProtocol {
+    /// General purpose logging method.
+    /// Sends a log with certain `level`, `message`, `error` and `attributes`.
+    ///
+    /// Although it can be used directly, it is more convenient and recommended to use specific methods declared on `Logger`:
+    /// * `debug(_:error:attributes:)`
+    /// * `info(_:error:attributes:)`
+    /// * ...
+    ///
+    /// - Parameters:
+    ///   - level: the log level
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func log(level: LogLevel, message: String, error: Error?, attributes: [String: Encodable]?)
+
+    // MARK: - Attributes
+
+    /// Adds a custom attribute to all future logs sent by this logger.
+    /// - Parameters:
+    ///   - key: the attribute key. See `AttributeKey` documentation for information on nesting attributes with dot `.` syntax.
+    ///   - value: the attribute value that conforms to `Encodable`. See `AttributeValue` documentation
+    ///   for information on nested encoding containers limitation.
+    func addAttribute(forKey key: AttributeKey, value: AttributeValue)
+
+    /// Removes the custom attribute from all future logs sent by this logger.
+    ///
+    /// Previous logs won't lose this attribute if sent prior to this call.
+    /// - Parameter key: the key of an attribute that will be removed.
+    func removeAttribute(forKey key: AttributeKey)
+
+    // MARK: - Tags
+
+    /// Adds a `"key:value"` tag to all future logs sent by this logger.
+    ///
+    /// Tags must start with a letter and
+    /// * may contain: alphanumerics, underscores, minuses, colons, periods and slashes;
+    /// * other special characters are converted to underscores;
+    /// * must be lowercase
+    /// * and can be at most 200 characters long (tags exceeding this limit will be truncated to first 200 characters).
+    ///
+    /// See also: [Defining Tags](https://docs.datadoghq.com/tagging/#defining-tags)
+    ///
+    /// - Parameter key: tag key
+    /// - Parameter value: tag value
+    func addTag(withKey key: String, value: String)
+
+    /// Remove all tags with the given key from all future logs sent by this logger.
+    ///
+    /// Previous logs won't lose this tag if created prior to this call.
+    ///
+    /// - Parameter key: the key of the tag to remove
+    func removeTag(withKey key: String)
+
+    /// Adds the tag to all future logs sent by this logger.
+    ///
+    /// Tags must start with a letter and
+    /// * may contain: alphanumerics, underscores, minuses, colons, periods and slashes;
+    /// * other special characters are converted to underscores;
+    /// * must be lowercase
+    /// * and can be at most 200 characters long (tags exceeding this limit will be truncated to first 200 characters).
+    ///
+    /// See also: [Defining Tags](https://docs.datadoghq.com/tagging/#defining-tags)
+    ///
+    /// - Parameter tag: value of the tag
+    func add(tag: String)
+
+    /// Removes the tag from all future logs sent by this logger.
+    ///
+    /// Previous logs won't lose the this tag if created prior to this call.
+    ///
+    /// - Parameter tag: the value of the tag to remove
+    func remove(tag: String)
+}
+
+public extension LoggerProtocol {
+    /// Sends a DEBUG log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func debug(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .debug, message: message, error: error, attributes: attributes)
+    }
+
+    /// Sends an INFO log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func info(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .info, message: message, error: error, attributes: attributes)
+    }
+
+    /// Sends a NOTICE log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func notice(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .notice, message: message, error: error, attributes: attributes)
+    }
+
+    /// Sends a WARN log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func warn(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .warn, message: message, error: error, attributes: attributes)
+    }
+
+    /// Sends an ERROR log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func error(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .error, message: message, error: error, attributes: attributes)
+    }
+
+    /// Sends a CRITICAL log message.
+    /// - Parameters:
+    ///   - message: the message to be logged
+    ///   - error: the error information (optional)
+    ///   - attributes: a dictionary of attributes (optional) to add for this message. If an attribute with
+    /// the same key already exist in this logger, it will be overridden (only for this message).
+    func critical(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
+        log(level: .critical, message: message, error: error, attributes: attributes)
+    }
+}
+
+internal struct NOPLogger: LoggerProtocol {
+    func log(level: LogLevel, message: String, error: Error?, attributes: [String: Encodable]?) {}
+    func addAttribute(forKey key: AttributeKey, value: AttributeValue) {}
+    func removeAttribute(forKey key: AttributeKey) {}
+    func addTag(withKey key: String, value: String) {}
+    func removeTag(withKey key: String) {}
+    func add(tag: String) {}
+    func remove(tag: String) {}
+}
+
+/// Combines multiple loggers together into single `LoggerProtocol` interface.
+internal struct CombinedLogger: LoggerProtocol {
+    let combinedLoggers: [LoggerProtocol]
+
+    func log(level: LogLevel, message: String, error: Error?, attributes: [String: Encodable]?) {
+        combinedLoggers.forEach { $0.log(level: level, message: message, error: error, attributes: attributes) }
+    }
+
+    func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
+        combinedLoggers.forEach { $0.addAttribute(forKey: key, value: value) }
+    }
+
+    func removeAttribute(forKey key: AttributeKey) {
+        combinedLoggers.forEach { $0.removeAttribute(forKey: key) }
+    }
+
+    func addTag(withKey key: String, value: String) {
+        combinedLoggers.forEach { $0.addTag(withKey: key, value: value) }
+    }
+
+    func removeTag(withKey key: String) {
+        combinedLoggers.forEach { $0.removeTag(withKey: key) }
+    }
+
+    func add(tag: String) {
+        combinedLoggers.forEach { $0.add(tag: tag) }
+    }
+
+    func remove(tag: String) {
+        combinedLoggers.forEach { $0.remove(tag: tag) }
+    }
+}
+
+extension CombinedLogger: InternalLoggerProtocol {
+    func log(
+        level: LogLevel,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        stackTrace: String?,
+        attributes: [String: Encodable]?) {
+        combinedLoggers.forEach {
+            $0._internal.log(
+                level: level,
+                message: message,
+                errorKind: errorKind,
+                errorMessage: errorMessage,
+                stackTrace: stackTrace,
+                attributes: attributes
+            )
+        }
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Logs.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Logs.swift
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// iOS Log Collection
+///
+/// Send logs to Datadog from your iOS applications with Datadog’s dd-sdk-ios client-side logging library and leverage the following features:
+/// - Log to Datadog in JSON format natively.
+/// - Use default and add custom attributes to each log sent.
+/// - Record real client IP addresses and User-Agents.
+/// - Leverage optimized network usage with automatic bulk posts.
+public struct Logs {
+    /// The Logs general configuration.
+    ///
+    /// This configuration will be applied to all Logger instances.
+    public struct Configuration {
+        public typealias EventMapper = (LogEvent) -> LogEvent?
+        /// Sets the custom mapper for `LogEvent`. This can be used to modify logs before they are send to Datadog.
+        ///
+        /// The implementation should obtain a mutable version of the `LogEvent`, modify it and return it. Returning `nil` will result
+        /// with dropping the Log event entirely, so it won't be send to Datadog.
+        public var eventMapper: EventMapper?
+
+        /// Overrides the custom server endpoint where Logs are sent.
+        public var customEndpoint: URL?
+
+        /// Overrides the date provider.
+        internal var dateProvider: DateProvider = SystemDateProvider()
+
+        /// Overrides the event mapper
+        internal var _internalEventMapper: LogEventMapper? = nil
+
+        /// Creates a Logs configuration object.
+        ///
+        /// - Parameters:
+        ///   - eventMapper: The custom mapper for `LogEvent`. This can be used to modify logs before they are send to Datadog.
+        ///   - customEndpoint: Overrides the custom server endpoint where Logs are sent.
+        public init(
+            eventMapper: EventMapper? = nil,
+            customEndpoint: URL? = nil
+        ) {
+            self.eventMapper = eventMapper
+            self.customEndpoint = customEndpoint
+        }
+    }
+
+    /// Enables the Datadog Logs feature.
+    ///
+    /// - Parameters:
+    ///   - configuration: The Logs configuration.
+    ///   - core: The instance of Datadog SDK to enable Logs in (global instance by default).
+    public static func enable(
+        with configuration: Configuration = .init(),
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
+        let logEventMapper = configuration._internalEventMapper ?? configuration.eventMapper.map(SyncLogEventMapper.init)
+
+        let feature = LogsFeature(
+            logEventMapper: logEventMapper,
+            dateProvider: configuration.dateProvider,
+            customIntakeURL: configuration.customEndpoint
+        )
+
+        do {
+            try core.register(feature: feature)
+        } catch {
+            consolePrint("\(error)")
+        }
+    }
+}
+
+extension Logs.Configuration: InternalExtended { }
+extension InternalExtension where ExtendedType == Logs.Configuration {
+    /// Sets the custom mapper for `LogEvent`. This can be used to modify logs before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper taking `LogEvent` as input and invoke callback closure with modifier `LogEvent`.
+    public mutating func setLogEventMapper(_ mapper: LogEventMapper) {
+        type._internalEventMapper = mapper
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/RemoteLogger.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/RemoteLogger.swift
@@ -1,0 +1,183 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// `Logger` sending logs to Datadog.
+internal final class RemoteLogger: LoggerProtocol {
+    struct Configuration {
+        /// The `service` value for logs.
+        /// See: [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+        let service: String?
+        /// The `logger.name` value for logs.
+        let name: String?
+        /// Whether to send the network info in `network.client.*` log attributes.
+        let networkInfoEnabled: Bool
+        /// Only logs equal or above this threshold will be sent.
+        let threshold: LogLevel
+        /// Allows for modifying (or dropping) logs before they get sent.
+        let eventMapper: LogEventMapper?
+        /// Sampler for remote logger. Default is using `100.0` sampling rate.
+        let sampler: Sampler
+    }
+
+    /// `DatadogCore` instance managing this logger.
+    internal let core: DatadogCoreProtocol
+    /// Configuration specific to this logger.
+    internal let configuration: Configuration
+    /// Date provider for logs.
+    private let dateProvider: DateProvider
+    /// Integration with RUM. It is used to correlate Logs with RUM events by injecting RUM context to `LogEvent`.
+    /// Can be `false` if the integration is disabled for this logger.
+    internal let rumContextIntegration: Bool
+    /// Integration with Tracing. It is used to correlate Logs with Spans by injecting `Span` context to `LogEvent`.
+    /// Can be `false` if the integration is disabled for this logger.
+    internal let activeSpanIntegration: Bool
+    /// Logger-specific attributes.
+    @ReadWriteLock
+    private var attributes: [String: Encodable] = [:]
+    /// Logger-specific tags.
+    @ReadWriteLock
+    private var tags: Set<String> = []
+
+    init(
+        core: DatadogCoreProtocol,
+        configuration: Configuration,
+        dateProvider: DateProvider,
+        rumContextIntegration: Bool,
+        activeSpanIntegration: Bool
+    ) {
+        self.core = core
+        self.configuration = configuration
+        self.dateProvider = dateProvider
+        self.rumContextIntegration = rumContextIntegration
+        self.activeSpanIntegration = activeSpanIntegration
+    }
+
+    // MARK: - Attributes
+
+    func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
+        _attributes.mutate { $0[key] = value }
+    }
+
+    func removeAttribute(forKey key: AttributeKey) {
+        _attributes.mutate { $0.removeValue(forKey: key) }
+    }
+
+    // MARK: - Tags
+
+    func addTag(withKey key: String, value: String) {
+        _tags.mutate { $0.insert("\(key):\(value)") }
+    }
+
+    func removeTag(withKey key: String) {
+        _tags.mutate { $0 = $0.filter { !$0.hasPrefix("\(key):") } }
+    }
+
+    func add(tag: String) {
+        _tags.mutate { $0.insert(tag) }
+    }
+
+    func remove(tag: String) {
+        _tags.mutate { $0.remove(tag) }
+    }
+
+    // MARK: - Logging
+
+    func log(level: LogLevel, message: String, error: Error?, attributes: [String: Encodable]?) {
+        internalLog(level: level, message: message, error: error.map { DDError(error: $0) }, attributes: attributes)
+    }
+
+    func internalLog(level: LogLevel, message: String, error: DDError?, attributes: [String: Encodable]?) {
+        guard configuration.sampler.sample() else {
+            return
+        }
+        guard level.rawValue >= configuration.threshold.rawValue else {
+            return
+        }
+
+        // on user thread:
+        let date = dateProvider.now
+        let threadName = Thread.current.dd.name
+
+        // capture current tags and attributes before opening the write event context
+        let tags = self.tags
+        var logAttributes = attributes
+        let isCrash = logAttributes?.removeValue(forKey: CrossPlatformAttributes.errorLogIsCrash) as? Bool ?? false
+        let userAttributes = self.attributes
+            .merging(logAttributes ?? [:]) { $1 } // prefer message attributes
+
+        // SDK context must be requested on the user thread to ensure that it provides values
+        // that are up-to-date for the caller.
+        self.core.scope(for: LogsFeature.name)?.eventWriteContext { context, writer in
+            var internalAttributes: [String: Encodable] = [:]
+            let contextAttributes = context.featuresAttributes
+
+            if self.rumContextIntegration, let attributes: [String: AnyCodable?] = contextAttributes["rum"]?.ids {
+                let attributes = attributes.compactMapValues { $0 }
+                let mappedAttributes = Dictionary(uniqueKeysWithValues: attributes.map { key, value in (mapRUMContextAttributeKeyToLogAttributeKey(key), value) })
+                internalAttributes.merge(mappedAttributes) { $1 }
+            }
+
+            if self.activeSpanIntegration, let attributes = contextAttributes["tracing"] {
+                let attributes = attributes.compactMapValues(AnyEncodable.init)
+                internalAttributes.merge(attributes) { $1 }
+            }
+
+            let builder = LogEventBuilder(
+                service: self.configuration.service ?? context.service,
+                loggerName: self.configuration.name,
+                networkInfoEnabled: self.configuration.networkInfoEnabled,
+                eventMapper: self.configuration.eventMapper
+            )
+
+            builder.createLogEvent(
+                date: date,
+                level: level,
+                message: message,
+                error: error,
+                attributes: .init(
+                    userAttributes: userAttributes,
+                    internalAttributes: internalAttributes
+                ),
+                tags: tags,
+                context: context,
+                threadName: threadName
+            ) { log in
+                writer.write(value: log)
+
+                guard (log.status == .error || log.status == .critical) && !isCrash else {
+                    return
+                }
+
+                self.core.send(
+                    message: .error(
+                        message: log.error?.message ?? log.message,
+                        baggage: [
+                            "type": log.error?.kind,
+                            "stack": log.error?.stack,
+                            "source": "logger",
+                            "attributes": userAttributes
+                        ]
+                    )
+                )
+            }
+        }
+    }
+}
+
+extension RemoteLogger: InternalLoggerProtocol {
+    func log(level: LogLevel, message: String, errorKind: String?, errorMessage: String?, stackTrace: String?, attributes: [String: Encodable]?) {
+        var ddError: DDError?
+        if errorKind != nil || errorMessage != nil || stackTrace != nil {
+            // Cross platform frameworks don't necessarilly send all values for errors. Send empty strings
+            // for any values that are empty.
+            ddError = DDError(type: errorKind ?? "", message: errorMessage ?? "", stack: stackTrace ?? "")
+        }
+
+        internalLog(level: level, message: message, error: ddError, attributes: attributes)
+    }
+}

--- a/Sources/ForageSDK/Vendor/DatadogLogs/Scrubbing/LogEventMapper.swift
+++ b/Sources/ForageSDK/Vendor/DatadogLogs/Scrubbing/LogEventMapper.swift
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Data scrubbing interface.
+///
+/// It takes `LogEvent` and call the callback with the modified `LogEvent`.
+/// Not calling the callback will drop the event.
+public protocol LogEventMapper {
+    /// Maps a log event for data scrubbing.
+    ///
+    /// This method allow async call to the callback closure.
+    ///
+    /// - Parameters:
+    ///   - event: The event to map.
+    ///   - callback: The mapper callback with the new event.
+    func map(event: LogEvent, callback: @escaping (LogEvent) -> Void)
+}
+
+/// Synchronous log event mapper.
+///
+/// The class take a flat-map closure parameter for event scrubbing
+internal final class SyncLogEventMapper: LogEventMapper {
+    let mapper: (LogEvent) -> LogEvent?
+
+    init(_ mapper: @escaping (LogEvent) -> LogEvent?) {
+        self.mapper = mapper
+    }
+
+    func map(event: LogEvent, callback: @escaping (LogEvent) -> Void) {
+        mapper(event).map(callback)
+    }
+}


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Add/install Datadog logging SDK to forage-ios-sdk
- Add interface for handling logs across the SDK 

Note: this does not emit crash reports ; we'll need to enable sentry or [this feature](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/?tab=cocoapods)  (under RUM) to send crash reports

TODOs:
- [x] Don't emit logs to datadog when running from simulator
- [x] Don't log to console in the client's debug/console area
<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

#55 is based off of this PR 
This is a patch-level change.

Should not be released without #79 
