### PR TITLE
[FX-269] Add support for optional reusable param

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
     customerID: String,
+    reusable: Bool?,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
 )
 ```
@@ -150,7 +151,8 @@ ForageSDK.shared.tokenizeEBTCard(
     merchantAccount: merchantID,
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
-    customerID: UUID.init().uuidString) { result in
+    customerID: UUID.init().uuidString,
+    reusable: true) { result in
         // handle callback here
     }
 ```

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -18,4 +18,6 @@ class ClientSharedData {
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     var customerID: String = UUID.init().uuidString
+    // whether the payment method is reusable
+    var reusable: Bool = true
 }

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -18,6 +18,5 @@ class ClientSharedData {
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     var customerID: String = UUID.init().uuidString
-    // whether the payment method is reusable
-    var reusable: Bool = true
+    var isReusablePaymentMethod: Bool = true
 }

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -142,6 +142,17 @@ class CardNumberView: UIView {
         return label
     }()
     
+    private let reusableLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        label.numberOfLines = 0
+        label.accessibilityIdentifier = "lbl_reusable"
+        label.isAccessibilityElement = true
+        return label
+    }()
+    
     private let errorLabel: UILabel = {
         let label = UILabel()
         label.text = ""
@@ -159,7 +170,8 @@ class CardNumberView: UIView {
         ForageSDK.shared.tokenizeEBTCard(
             bearerToken: ClientSharedData.shared.bearerToken,
             merchantAccount: ClientSharedData.shared.merchantID,
-            customerID: ClientSharedData.shared.customerID) { result in
+            customerID: ClientSharedData.shared.customerID,
+            reusable: ClientSharedData.shared.reusable) { result in
                 self.printResult(result: result)
             }
     }
@@ -187,6 +199,8 @@ class CardNumberView: UIView {
                 self.tokenLabel.text = "token=\(response.card.token)"
                 self.last4Label.text = "last4=\(response.card.last4)"
                 self.customerIDLabel.text = "customerID=\(response.customerID ?? "NO CUST ID")"
+                self.reusableLabel.text = "reusable=\(response.reusable)"
+
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)
@@ -197,6 +211,7 @@ class CardNumberView: UIView {
                 self.tokenLabel.text = ""
                 self.last4Label.text = ""
                 self.customerIDLabel.text = ""
+                self.reusableLabel.text = ""
                 self.updateButtonState(isEnabled: false, button: self.nextButton)
             }
             
@@ -215,6 +230,7 @@ class CardNumberView: UIView {
         contentView.addSubview(tokenLabel)
         contentView.addSubview(last4Label)
         contentView.addSubview(customerIDLabel)
+        contentView.addSubview(reusableLabel)
         contentView.addSubview(errorLabel)
         contentView.addSubview(sendPanButton)
         contentView.addSubview(nextButton)
@@ -307,8 +323,17 @@ class CardNumberView: UIView {
             padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
-        errorLabel.anchor(
+        reusableLabel.anchor(
             top: customerIDLabel.safeAreaLayoutGuide.bottomAnchor,
+            leading: contentView.safeAreaLayoutGuide.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
+        )
+        
+        errorLabel.anchor(
+            top: reusableLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -171,7 +171,7 @@ class CardNumberView: UIView {
             bearerToken: ClientSharedData.shared.bearerToken,
             merchantAccount: ClientSharedData.shared.merchantID,
             customerID: ClientSharedData.shared.customerID,
-            reusable: ClientSharedData.shared.reusable) { result in
+            reusable: ClientSharedData.shared.isReusablePaymentMethod) { result in
                 self.printResult(result: result)
             }
     }
@@ -199,8 +199,11 @@ class CardNumberView: UIView {
                 self.tokenLabel.text = "token=\(response.card.token)"
                 self.last4Label.text = "last4=\(response.card.last4)"
                 self.customerIDLabel.text = "customerID=\(response.customerID ?? "NO CUST ID")"
-                self.reusableLabel.text = "reusable=\(response.reusable)"
-
+                if let reusable = response.reusable {
+                    self.reusableLabel.text = "reusable=\(String(describing: reusable))"
+                } else {
+                    self.reusableLabel.text = "reusable not in response"
+                }
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -23,6 +23,7 @@ protocol ForageSDKService: AnyObject {
         bearerToken: String,
         merchantAccount: String,
         customerID: String,
+        reusable: Bool?,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
     
     /// Check balance for a given EBT Card
@@ -62,6 +63,7 @@ extension ForageSDK: ForageSDKService {
         bearerToken: String,
         merchantAccount: String,
         customerID: String,
+        reusable: Bool? = true,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
         let request = ForagePANRequestModel(
@@ -69,8 +71,8 @@ extension ForageSDK: ForageSDKService {
             merchantAccount: merchantAccount,
             panNumber: panNumber,
             type: CardType.EBT.rawValue,
-            reusable: true,
-            customerID: customerID
+            customerID: customerID,
+            reusable: reusable ?? true
         )
         service?.tokenizeEBTCard(request: request, completion: completion)
     }

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -50,7 +50,7 @@ extension ForageAPI: ServiceProtocol {
 
             let bodyParameters: Parameters = [
                 "type": model.type,
-                "reusable": model.reusable,
+                "reusable": model.reusable ?? true,
                 "card": card,
                 "customer_id": model.customerID
             ]

--- a/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
@@ -13,6 +13,6 @@ internal struct ForagePANRequestModel: Codable {
     let merchantAccount: String
     let panNumber: String
     let type: String
-    let reusable: Bool
     let customerID: String
+    let reusable: Bool?
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
@@ -40,7 +40,7 @@ public struct PaymentMethodModel: Codable {
     public let balance: BalanceModel?
     public let card: ForageCard
     public let customerID: String?
-    public let reusable: Bool
+    public let reusable: Bool?
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentMethodModel.swift
@@ -40,6 +40,7 @@ public struct PaymentMethodModel: Codable {
     public let balance: BalanceModel?
     public let card: ForageCard
     public let customerID: String?
+    public let reusable: Bool
     
     private enum CodingKeys : String, CodingKey {
         case paymentMethodIdentifier = "ref"
@@ -47,5 +48,6 @@ public struct PaymentMethodModel: Codable {
         case card
         case balance
         case customerID = "customer_id"
+        case reusable
     }
 }

--- a/Sources/ForageSDK/Foundation/Network/Provider.swift
+++ b/Sources/ForageSDK/Foundation/Network/Provider.swift
@@ -101,7 +101,7 @@ internal class Provider {
                 completion(.failure(error))
             }
         }
-        
+                
         processData(model: model, data: data, response: httpResponse, error: error) { (result) in
             switch result {
             case .success(let data):

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -30,8 +30,8 @@ final class ForageServiceTests: XCTestCase {
             merchantAccount: "merchantID123",
             panNumber: "5076801234123412",
             type: "ebt",
-            reusable: true,
-            customerID: "test-ios-customer-id"
+            customerID: "test-ios-customer-id",
+            reusable: true
         )
         
         let expectation = XCTestExpectation(description: "Tokenize EBT Card - should succeed")
@@ -62,8 +62,8 @@ final class ForageServiceTests: XCTestCase {
             merchantAccount: "merchantID123",
             panNumber: "5076801234123412",
             type: "ebt",
-            reusable: true,
-            customerID: "test-ios-customer-id"
+            customerID: "test-ios-customer-id",
+            reusable: true
         )
         
         let expectation = XCTestExpectation(description: "Tokenize EBT Card - result should be failure")
@@ -133,6 +133,7 @@ final class ForageServiceTests: XCTestCase {
                 XCTAssertEqual(paymentMethod.balance?.snap, "100.00")
                 XCTAssertEqual(paymentMethod.balance?.cash, "100.00")
                 XCTAssertEqual(paymentMethod.card.token, "tok_sandbox_vJp2BwDc6R6Z16mgzCxuXk")
+                XCTAssertEqual(paymentMethod.reusable, true)
                 expectation.fulfill()
             case .failure:
                 XCTFail("Expected success")

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -48,6 +48,7 @@ class ForageMocks {
               "created":"2022-11-29T03:31:52.349193-08:00",
               "token":"tok_sandbox_72VEC9LasHbMYiiVWP9zms"
            },
+           "reusable":true,
            "customer_id":"test-ios-customer-id"
         }
 """
@@ -90,7 +91,8 @@ class ForageMocks {
                 "created": "2023-02-23T14:25:37.531327-08:00",
                 "token": "tok_sandbox_vJp2BwDc6R6Z16mgzCxuXk",
                 "state": "PA"
-            }
+            },
+            "reusable":true
         }
 """
         return Data(response.utf8)


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->
- Add optional reusable param to README
- Add/display reusable value to Card Number View

### TODO
- [ ] update unit tests - will add them after #63 gets merged.

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

@devinmorgan  I considered moving [individual params (reusable, customerID, merchantAccount) to an object](https://linear.app/joinforage/issue/FX-363/android-move-reusable-and-customerid-args-into-optionsconfig) – but the position of the params will still matter even if we separate the params into a separate struct

<img width="311" alt="image" src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/d445d7fd-2c47-4a99-b3e6-7b3b5b5e67f6">


## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- Test when reusable is missing from the call to `tokenizeEBTCard`, `reusable` is true ✅ 
- Test when reusable is true, is `reusable` true in the response (in the Card Number View) ✅ 
<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/f1f6a56d-e67e-45e2-bc61-f5cd489115de" width="200px">

- Test when reusable is false, is `reusable` false... ✅ 


<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/ff060eb9-5c6f-4f02-8efb-6e4a6bae995d" width="200px">


- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is. This is a minor-level version change since the reusable flag is optional