### PR TITLE
[FX-387] Implement onFocusChange and onTextChange for PAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,22 +91,41 @@ private let panNumberTextField: ForagePANTextField = {
 }()
 ```
 
-ForagePANTextField uses a delegate `ForagePANTextFieldDelegate` to communicate the updates to the client side.
+ForagePANTextField uses a delegate `ForageElementDelegate` to communicate the updates to the client side.
 
 ```swift
 panNumberTextField.delegate = self
 ```
 ```swift
-public protocol ForagePANTextFieldDelegate: AnyObject {
-    func panNumberStatus(_ view: UIView, cardStatus: CardStatus)
-}
-
-public enum CardStatus: String {
-    case valid
-    case invalid
-    case identifying
+public protocol ForageElementDelegate: AnyObject {
+    func focusDidChange(_ state: ObservableState)
+    func textFieldDidChange(_ state: ObservableState)
 }
 ```
+
+The ObservableState object has the values:
+```swift
+public protocol ObservableState {
+    /// isFirstResponder is true if the input is focused, false otherwise.
+    var isFirstResponder: Bool { get }
+    
+    /// isEmpty is true if the input is empty, false otherwise.
+    var isEmpty: Bool { get }
+    
+    /// isValid is true when the input text does not fail any validation checks with the exception of target length;
+    /// false if any of the validation checks other than target length fail.
+    var isValid: Bool { get }
+    
+    /// isComplete is true when all validation checks pass and the input is ready to be submitted.
+    var isComplete: Bool { get }
+}
+```
+
+The ForagePINTextField exposes a function to programmatically gain focus:
+```swift
+func becomeFirstResponder() -> Bool
+```
+
 
 To send the PAN number, we can use ForageSDK to perform the request.
 
@@ -169,6 +188,7 @@ pinNumberTextField.delegate = self
 ```swift
 public protocol ForageElementDelegate: AnyObject {
     func focusDidChange(_ state: ObservableState)
+    func textFieldDidChange(_ state: ObservableState)
 }
 ```
 

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -344,14 +344,14 @@ class CardNumberView: UIView {
     }
     
     private func updateState(state: ObservableState) {
-        if (state.isComplete && state.isValid) {
+        if (state.isEmpty) {
+            statusLabel.text = "Enter Card Number"
+            statusLabel.textColor = .gray
+        } else if (state.isComplete && state.isValid) {
             statusLabel.text = "Card Number Valid"
             statusLabel.textColor = .green
         } else if (state.isValid && !state.isComplete) {
             statusLabel.text = "Identifying Card Number"
-            statusLabel.textColor = .gray
-        } else if (state.isEmpty) {
-            statusLabel.text = "Enter Card Number"
             statusLabel.textColor = .gray
         } else {
             statusLabel.text = "Card Number Invalid"

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -63,9 +63,9 @@ class CardNumberView: UIView {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(sendInfo(_:)), for: .touchUpInside)
         button.backgroundColor = .systemBlue
-        button.isEnabled = false
-        button.isUserInteractionEnabled = false
-        button.alpha = 0.5
+        button.isEnabled = true
+        button.isUserInteractionEnabled = true
+        button.alpha = 1
         button.accessibilityIdentifier = "bt_send_ebt_number"
         button.isAccessibilityElement = true
         return button

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -37,7 +37,7 @@ class CardNumberView: UIView {
         return label
     }()
     
-    private let panNumberTextField: ForagePANTextField = {
+    public let panNumberTextField: ForagePANTextField = {
         let tf = ForagePANTextField()
         tf.placeholder = "PAN Number"
         tf.accessibilityIdentifier = "tf_ebt_number"

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberViewController.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberViewController.swift
@@ -17,6 +17,11 @@ class CardNumberViewController: BaseViewCodeViewController<CardNumberView> {
         customView.render()
         customView.delegate = self
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.customView.panNumberTextField.becomeFirstResponder()
+    }
 }
 
 // MARK: - CardNumberViewDelegate

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -9,13 +9,6 @@ import VGSCollectSDK
 import Foundation
 
 /**
- Card type
- */
-private enum CardType: String {
-    case ebt = "ebt"
-}
-
-/**
  Interface for Forage SDK Services
  */
 protocol ForageSDKService: AnyObject {
@@ -75,7 +68,7 @@ extension ForageSDK: ForageSDKService {
             authorization: bearerToken,
             merchantAccount: merchantAccount,
             panNumber: panNumber,
-            type: CardType.ebt.rawValue,
+            type: CardType.EBT.rawValue,
             reusable: true,
             customerID: customerID
         )

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -10,43 +10,181 @@ import XCTest
 
 final class ForagePANTextFieldTests: XCTestCase {
     
-    override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+    var observableState: ObservableState?
+    
+    class mockState: ObservableState {
+        var _isFirstResponder = false
+        var isFirstResponder: Bool {
+            get {
+                return _isFirstResponder
+            }
+        }
+        
+        var _isEmpty = false
+        var isEmpty: Bool {
+            get {
+                return _isEmpty
+            }
+        }
+        
+        var _isValid = false
+        var isValid: Bool {
+            get {
+                return _isValid
+            }
+        }
+        
+        var _isComplete = false
+        var isComplete: Bool {
+            get {
+                return _isComplete
+            }
+        }
+        
+        init(isFirstResponder: Bool, isEmpty: Bool, isValid: Bool, isComplete: Bool) {
+            self._isFirstResponder = isFirstResponder
+            self._isEmpty = isEmpty
+            self._isValid = isValid
+            self._isComplete = isComplete
+        }
     }
     
-    var cardStatus: CardStatus = .invalid
+    override func setUp() {
+        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        observableState = nil
+    }
+    
+    
     
     func test_givenValidCard_shouldReturnValid() {
         let foragePanTextField = ForagePANTextField()
         foragePanTextField.delegate = self
+        
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "5076801234123412")
-        XCTAssertEqual(CardStatus.valid, cardStatus)
+        
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertTrue(foragePanTextField.isValid)
+        XCTAssertTrue(foragePanTextField.isComplete)
     }
     
     func test_givenValidCard_withMoreDigits_shouldReturnInvalid() {
         let foragePanTextField = ForagePANTextField()
         foragePanTextField.delegate = self
+        
+        // Add a valid card
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "5076801234123412")
+        
+        // Check for valid state
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertTrue(foragePanTextField.isValid)
+        XCTAssertTrue(foragePanTextField.isComplete)
+        
+        // Try to exceed the max length of this valid card
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "50768012341234123")
-        XCTAssertEqual(CardStatus.invalid, cardStatus)
+        
+        // Check that we didn't let the card go past max length and that we are still valid
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertTrue(foragePanTextField.isValid)
+        XCTAssertTrue(foragePanTextField.isComplete)
+    }
+    
+    func test_givenTooFewDigits_shouldBeValid() {
+        let foragePanTextField = ForagePANTextField()
+        foragePanTextField.delegate = self
+        
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "12341")
+        
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertTrue(foragePanTextField.isValid)
+        XCTAssertFalse(foragePanTextField.isComplete)
+        
     }
     
     func test_givenInvalidCard_shouldReturnInvalid() {
         let foragePanTextField = ForagePANTextField()
         foragePanTextField.delegate = self
+        
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "123412")
-        XCTAssertEqual(CardStatus.invalid, cardStatus)
+        
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertFalse(foragePanTextField.isValid)
+        XCTAssertFalse(foragePanTextField.isComplete)
+        
     }
     
     func test_givenInvalidCard_shouldReturnIdentifying() {
         let foragePanTextField = ForagePANTextField()
         foragePanTextField.delegate = self
+        
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "50768012341234")
-        XCTAssertEqual(CardStatus.identifying, cardStatus)
+        
+        XCTAssertFalse(foragePanTextField.isEmpty)
+        XCTAssertFalse(foragePanTextField.isFirstResponder)
+        XCTAssertTrue(foragePanTextField.isValid)
+        XCTAssertFalse(foragePanTextField.isComplete)
+        
+    }
+    
+    func test_forageElementDelegate_focusDidChange() {
+        let foragePanTextField = ForagePANTextField()
+        
+        let expectedIsFirstResponder = true
+        let expectedIsEmpty = false
+        let expectedIsValid = true
+        let expectedIsComplete = false
+        
+        foragePanTextField.delegate = self
+        foragePanTextField.delegate?.focusDidChange(
+            mockState(
+                isFirstResponder: expectedIsFirstResponder,
+                isEmpty: expectedIsEmpty,
+                isValid: expectedIsValid,
+                isComplete: expectedIsComplete
+            )
+        )
+        
+        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
+        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
+        XCTAssertEqual(expectedIsValid, observableState?.isValid)
+        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
+    }
+    
+    func test_forageElementDelegate_textFieldDidChange() {
+        let foragePanTextField = ForagePANTextField()
+        
+        let expectedIsFirstResponder = false
+        let expectedIsEmpty = true
+        let expectedIsValid = false
+        let expectedIsComplete = true
+        
+        foragePanTextField.delegate = self
+        foragePanTextField.delegate?.textFieldDidChange(
+            mockState(
+                isFirstResponder: expectedIsFirstResponder,
+                isEmpty: expectedIsEmpty,
+                isValid: expectedIsValid,
+                isComplete: expectedIsComplete
+            )
+        )
+        
+        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
+        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
+        XCTAssertEqual(expectedIsValid, observableState?.isValid)
+        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
     }
 }
 
-extension ForagePANTextFieldTests: ForagePANTextFieldDelegate {
-    func panNumberStatus(_ view: UIView, cardStatus: CardStatus) {
-        self.cardStatus = cardStatus
+extension ForagePANTextFieldTests: ForageElementDelegate {
+    func focusDidChange(_ state: ObservableState) {
+        observableState = state
+    }
+    
+    func textFieldDidChange(_ state: ObservableState) {
+        observableState = state
     }
 }

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -15,6 +15,7 @@ final class ForagePINTextFieldTests: XCTestCase {
     
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        observableState = nil
     }
     
     class mockState: ObservableState {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -81,10 +81,10 @@ final class ForagePINTextFieldTests: XCTestCase {
     func test_forageElementDelegate_textFieldDidChange() {
         let foragePinTextField = ForagePINTextField()
         
-        let expectedIsFirstResponder = true
-        let expectedIsEmpty = false
-        let expectedIsValid = true
-        let expectedIsComplete = false
+        let expectedIsFirstResponder = false
+        let expectedIsEmpty = true
+        let expectedIsValid = false
+        let expectedIsComplete = true
         
         foragePinTextField.delegate = self
         foragePinTextField.delegate?.textFieldDidChange(


### PR DESCRIPTION
## What
Have the PAN element implement `ForageElement` and wire up the `onFocusChange` and `onTextChange` events.

## Test Plan
Added unit tests to check new implementation and adjust qa-tests to check for the updated state values that are displayed in the sample app.


https://github.com/teamforage/forage-ios-sdk/assets/89605898/3808cc29-40d2-45c3-8199-cfa3ef3d5d48

