### PR TITLE
[FX-392] Move merchantAccount + bearerToken to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,27 @@
 
 The ForageSDK processes Electronic Benefits Transfer (EBT) payments in your e-commerce application. It provides secure user interfaces for collecting and tokenizing an EBT cardholder's PAN and accepting an EBT cardholder's PIN to execute a balance check and process a payment.
 
-Table of contents
-=================
+# Table of contents
 
 <!--ts-->
-   * [Integration](#integration)
-      * [CocoaPods](#cocoapods)
-      * [Swift Package Manager](#swift-package-manager) 
-   * [Usage](#usage)
-      * [Create ForageSDK instance](#create-foragesdk-instance)
-      * [Forage UI Elements](#forage-ui-elements)
-      * [ForagePANTextField](#foragepantextfield)
-      * [ForagePINTextField](#foragepintextfield)
-      * [Demo Application](#demo-application)
-   * [Dependencies](#dependencies)
-<!--te-->
+
+- [ForageSDK](#foragesdk)
+- [Table of contents](#table-of-contents)
+  - [Integration](#integration)
+    - [CocoaPods](#cocoapods)
+    - [Swift Package Manager](#swift-package-manager)
+    - [Step-by-step](#step-by-step)
+  - [Usage](#usage)
+    - [Import SDK into your file](#import-sdk-into-your-file)
+    - [Create ForageSDK instance](#create-foragesdk-instance)
+  - [Forage UI Elements](#forage-ui-elements)
+    - [ForagePANTextField](#foragepantextfield)
+    - [Tokenize card number](#tokenize-card-number)
+    - [ForagePINTextField](#foragepintextfield)
+    - [Balance](#balance)
+    - [Capture payment](#capture-payment)
+  - [Demo Application](#demo-application)
+  - [Dependencies](#dependencies)
 
 ## Integration
 
@@ -58,6 +64,7 @@ Click on `Add Package` button. And, on the next screen, select the package `Fora
 ## Usage
 
 ### Import SDK into your file
+
 ```swift
 import ForageSDK
 ```
@@ -68,7 +75,11 @@ To initialize a ForageSDK instance, you need to provide the environment.
 
 ```swift
 ForageSDK.setup(
-    ForageSDK.Config(environment: .sandbox)
+    ForageSDK.Config(
+        environment: .sandbox,
+        merchantAccount: "mid/abcd123",
+        bearerToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
+    )
 )
 ```
 
@@ -81,7 +92,6 @@ ForageSDK provides two UI Elements to securely communicate with the Forage API.
 A component that securely accepts the PAN number. This field validates the PAN number based on the [StateIIN list](https://www.nacha.org/sites/default/files/2019-05/State-IINs-04-10-19.pdf)
 
 ![Screen Shot 2022-10-31 at 10 19 27](https://user-images.githubusercontent.com/115553362/199017253-ee05dcf0-01c8-41dc-9662-9da525e573c9.png)
-
 
 ```swift
 private let panNumberTextField: ForagePANTextField = {
@@ -96,6 +106,7 @@ ForagePANTextField uses a delegate `ForageElementDelegate` to communicate the up
 ```swift
 panNumberTextField.delegate = self
 ```
+
 ```swift
 public protocol ForageElementDelegate: AnyObject {
     func focusDidChange(_ state: ObservableState)
@@ -104,28 +115,29 @@ public protocol ForageElementDelegate: AnyObject {
 ```
 
 The ObservableState object has the values:
+
 ```swift
 public protocol ObservableState {
     /// isFirstResponder is true if the input is focused, false otherwise.
     var isFirstResponder: Bool { get }
-    
+
     /// isEmpty is true if the input is empty, false otherwise.
     var isEmpty: Bool { get }
-    
+
     /// isValid is true when the input text does not fail any validation checks with the exception of target length;
     /// false if any of the validation checks other than target length fail.
     var isValid: Bool { get }
-    
+
     /// isComplete is true when all validation checks pass and the input is ready to be submitted.
     var isComplete: Bool { get }
 }
 ```
 
 The ForagePINTextField exposes a function to programmatically gain focus:
+
 ```swift
 func becomeFirstResponder() -> Bool
 ```
-
 
 To send the PAN number, we can use ForageSDK to perform the request.
 
@@ -135,8 +147,6 @@ To send the PAN number, we can use ForageSDK to perform the request.
 // Signature
 
 func tokenizeEBTCard(
-    bearerToken: String,
-    merchantAccount: String,
     customerID: String,
     reusable: Bool?,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
@@ -147,8 +157,6 @@ func tokenizeEBTCard(
 // Usage
 
 ForageSDK.shared.tokenizeEBTCard(
-    bearerToken: bearerToken,
-    merchantAccount: merchantID,
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     customerID: UUID.init().uuidString,
@@ -174,6 +182,7 @@ private let pinNumberTextField: ForagePINTextField = {
 ```
 
 To identify the type of pin we are handling in the component, you can use the `pinType` property. We have support for these types:
+
 ```swift
 public enum PinType: String {
     case snap
@@ -187,6 +196,7 @@ ForagePINTextField uses a delegate `ForageElementDelegate` to communicate the up
 ```swift
 pinNumberTextField.delegate = self
 ```
+
 ```swift
 public protocol ForageElementDelegate: AnyObject {
     func focusDidChange(_ state: ObservableState)
@@ -195,24 +205,26 @@ public protocol ForageElementDelegate: AnyObject {
 ```
 
 The ObservableState object has the values:
+
 ```swift
 public protocol ObservableState {
     /// isFirstResponder is true if the input is focused, false otherwise.
     var isFirstResponder: Bool { get }
-    
+
     /// isEmpty is true if the input is empty, false otherwise.
     var isEmpty: Bool { get }
-    
+
     /// isValid is true when the input text does not fail any validation checks with the exception of target length;
     /// false if any of the validation checks other than target length fail.
     var isValid: Bool { get }
-    
+
     /// isComplete is true when all validation checks pass and the input is ready to be submitted.
     var isComplete: Bool { get }
 }
 ```
 
 The ForagePINTextField exposes a function to programmatically gain focus:
+
 ```swift
 func becomeFirstResponder() -> Bool
 ```
@@ -225,8 +237,6 @@ To send the PIN number, we can use the ForageSDK to perform the request.
 // Signature
 
 func checkBalance(
-    bearerToken: String,
-    merchantAccount: String,
     paymentMethodReference: String,
     foragePinTextEdit: ForagePINTextField,
     completion: @escaping (Result<BalanceModel, Error>) -> Void
@@ -237,8 +247,6 @@ func checkBalance(
 // Usage
 
 ForageSDK.shared.checkBalance(
-    bearerToken: bearerToken,
-    merchantAccount: merchantID,
     paymentMethodReference: paymentMethodReference,
     foragePinTextEdit: pinNumberTextField) { result in
         // handle callback here
@@ -251,8 +259,6 @@ ForageSDK.shared.checkBalance(
 // Signature
 
 func capturePayment(
-    bearerToken: String,
-    merchantAccount: String,
     paymentReference: String,
     foragePinTextEdit: ForagePINTextField,
     completion: @escaping (Result<PaymentModel, Error>) -> Void
@@ -263,8 +269,6 @@ func capturePayment(
 // Usage
 
 ForageSDK.shared.capturePayment(
-    bearerToken: bearerToken,
-    merchantAccount: merchantID,
     paymentReference: paymentReference,
     foragePinTextEdit: pinNumberTextField) { result in
         // handle callback here
@@ -272,17 +276,19 @@ ForageSDK.shared.capturePayment(
 ```
 
 ## Demo Application
+
 Demo application for using our components on iOS is <a href="https://github.com/teamforage/forage-ios-sdk/tree/main/Sample">here</a>.
 
 To get the application running,
 
 1. Clone this repo and open the Sample Project in the Sample folder.
 2. Ensure that you have a valid FNS number for the Forage API, which can be found on the dashboard ([sandbox](https://dashboard.sandbox.joinforage.app/login/) | [prod](https://dashboard.joinforage.app/login/)).
-3. [Create a bearer token](https://docs.joinforage.app/recipes/generate-a-token) with pinpad_only scope.
+3. [Create a bearer token](https://docs.joinforage.app/recipes/generate-a-token) with `pinpad_only` scope.
 4. Run the Sample app project and provide your FNS number and bearer token on the first screen.
-  1. These credentials will be passed through to all the SDK calls inside the sample app.
+5. These credentials will be passed through to all the SDK calls inside the sample app.
 
 ## Dependencies
+
 - iOS 10+
 - Swift 5
 - 3rd party libraries:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ To initialize a ForageSDK instance, you need to provide the environment.
 ForageSDK.setup(
     ForageSDK.Config(
         environment: .sandbox,
-        merchantAccount: "mid/abcd123",
-        bearerToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
+        merchantID: "mid/abcd123",
+        sessionToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
     )
 )
 ```
@@ -282,10 +282,11 @@ Demo application for using our components on iOS is <a href="https://github.com/
 To get the application running,
 
 1. Clone this repo and open the Sample Project in the Sample folder.
-2. Ensure that you have a valid FNS number for the Forage API, which can be found on the dashboard ([sandbox](https://dashboard.sandbox.joinforage.app/login/) | [prod](https://dashboard.joinforage.app/login/)).
-3. [Create a bearer token](https://docs.joinforage.app/recipes/generate-a-token) with `pinpad_only` scope.
-4. Run the Sample app project and provide your FNS number and bearer token on the first screen.
-5. These credentials will be passed through to all the SDK calls inside the sample app.
+2. Ensure that you have a valid Merchant ID for the Forage API, which can be found on the dashboard ([sandbox](https://dashboard.sandbox.joinforage.app/login/) | [prod](https://dashboard.joinforage.app/login/)).
+3. [Create an authentication token](https://docs.joinforage.app/docs/authentication#authentication-tokens) with `pinpad_only` scope.
+4. [Create a session token](https://docs.joinforage.app/docs/authentication#session-tokens).
+5. Run the Sample app project and provide your Merchant ID and session token on the first screen.
+6. These credentials will be passed through to all the SDK calls inside the sample app.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To initialize a ForageSDK instance, you need to provide the environment.
 ForageSDK.setup(
     ForageSDK.Config(
         environment: .sandbox,
-        merchantID: "mid/abcd123",
+        merchantID: "1234567",
         sessionToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
     )
 )

--- a/Sample/SampleForageSDK/AppDelegate.swift
+++ b/Sample/SampleForageSDK/AppDelegate.swift
@@ -15,8 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ForageSDK.setup(
             ForageSDK.Config(
                 environment: ClientSharedData.shared.environment,
-                merchantAccount: ClientSharedData.shared.merchantID,
-                bearerToken: ClientSharedData.shared.bearerToken
+                merchantID: ClientSharedData.shared.merchantID,
+                sessionToken: ClientSharedData.shared.sessionToken
             )
         )
 

--- a/Sample/SampleForageSDK/AppDelegate.swift
+++ b/Sample/SampleForageSDK/AppDelegate.swift
@@ -13,9 +13,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         ForageSDK.setup(
-            ForageSDK.Config(environment: .sandbox)
+            ForageSDK.Config(
+                environment: ClientSharedData.shared.environment,
+                merchantAccount: ClientSharedData.shared.merchantID,
+                bearerToken: ClientSharedData.shared.bearerToken
+            )
         )
-        
+
         // Override point for customization after application launch.
         return true
     }

--- a/Sample/SampleForageSDK/Base.lproj/Main.storyboard
+++ b/Sample/SampleForageSDK/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Jfb-Vk-J3O">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Jfb-Vk-J3O">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,21 +18,21 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PUg-Ds-slB">
-                                <rect key="frame" x="0.0" y="88" width="414" height="290"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="290"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EsB-kA-2gw">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="119"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bearer token" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQn-BZ-Hem">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Session token" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQn-BZ-Hem">
                                                 <rect key="frame" x="10" y="10" width="394" height="35"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="lbl_bearer_token" label="Bearer token label"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="lbl_session_token" label="Session token label"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Jp-Qt-zxc">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Jp-Qt-zxc">
                                                 <rect key="frame" x="24" y="53" width="366" height="42"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="tf_bearer_token" label="Bearer token text field"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="tf_session_token" label="Session token text field"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="42" id="jkn-Le-Frm"/>
                                                 </constraints>
@@ -60,7 +61,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-tP-yg0">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oqE-tP-yg0">
                                                 <rect key="frame" x="24" y="53" width="366" height="42"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="tf_merchant_id" label="Merchant Id text field"/>
                                                 <constraints>
@@ -120,8 +121,8 @@
                     </view>
                     <navigationItem key="navigationItem" title="Checkout" id="AGk-Bg-aGt"/>
                     <connections>
-                        <outlet property="bearerTokenTextField" destination="2Jp-Qt-zxc" id="bjP-aI-SrQ"/>
                         <outlet property="merchantIdTextField" destination="oqE-tP-yg0" id="7OC-JT-kZ4"/>
+                        <outlet property="sessionTokenTextField" destination="2Jp-Qt-zxc" id="bjP-aI-SrQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -134,7 +135,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Jfb-Vk-J3O" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="WSc-Ya-E9Q">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -14,7 +14,7 @@ class ClientSharedData {
     var environment: EnvironmentTarget = .sandbox
     var paymentMethodReference: String = ""
     var merchantID: String = ""
-    var bearerToken: String = ""
+    var sessionToken: String = ""
     var paymentReference: [FundingType : String] = [:]
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.

--- a/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/ClientSharedData.swift
@@ -11,6 +11,7 @@ import ForageSDK
 class ClientSharedData {
     static let shared = ClientSharedData()
     
+    var environment: EnvironmentTarget = .sandbox
     var paymentMethodReference: String = ""
     var merchantID: String = ""
     var bearerToken: String = ""

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentRequest.swift
@@ -11,7 +11,7 @@ struct CreatePaymentRequest {
     let amount: Double
     let fundingType: String
     let paymentMethodIdentifier: String
-    let merchantAccount: String
+    let merchantID: String
     let description: String
     let metadata: [String:String]
     let deliveryAddress: Address

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentResponse.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentResponse.swift
@@ -11,7 +11,7 @@ struct CreatePaymentResponse: Codable {
     let fundingType: FundingType
     let paymentMethodIdentifier: String
     let paymentIdentifier: String
-    let merchantAccount: String
+    let merchantID: String
     let amount: String
     let description: String
     
@@ -19,7 +19,7 @@ struct CreatePaymentResponse: Codable {
         case fundingType = "funding_type"
         case paymentMethodIdentifier = "payment_method"
         case paymentIdentifier = "ref"
-        case merchantAccount = "merchant"
+        case merchantID = "merchant"
         case amount
         case description
     }

--- a/Sample/SampleForageSDK/Foundation/Network/Model/ForageCaptureModel.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/ForageCaptureModel.swift
@@ -17,7 +17,7 @@ public enum ForageOrderStatus: String, Codable {
 
 public struct ForageCaptureModel: Codable {
     public let paymentIdentifier: String
-    public let merchantAccount: String
+    public let merchantID: String
     public let fundingType: String
     public let amount: String
     public let description: String
@@ -31,7 +31,7 @@ public struct ForageCaptureModel: Codable {
     
     private enum CodingKeys : String, CodingKey {
         case paymentIdentifier = "ref"
-        case merchantAccount = "merchant"
+        case merchantID = "merchant"
         case fundingType = "funding_type"
         case amount
         case description

--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -42,9 +42,9 @@ extension SampleAPI: ServiceProtocol {
             ]
 
             let httpHeaders: HTTPHeaders = [
-                "Merchant-Account": model.merchantAccount,
+                "Merchant-Account": model.merchantID,
                 "IDEMPOTENCY-KEY": UUID.init().uuidString,
-                "authorization": "Bearer \(ClientSharedData.shared.bearerToken)",
+                "authorization": "Bearer \(ClientSharedData.shared.sessionToken)",
                 "API-VERSION": "2023-05-15"
             ]
 

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -168,8 +168,6 @@ class CapturePaymentView: UIView {
         let inputFieldReference = isEbtSnap ? snapTextField : nonSnapTextField
         
         ForageSDK.shared.capturePayment(
-            bearerToken: ClientSharedData.shared.bearerToken,
-            merchantAccount: ClientSharedData.shared.merchantID,
             paymentReference: paymentReference,
             foragePinTextEdit: inputFieldReference) { result in
                 self.printResult(result: result)

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -198,8 +198,6 @@ class CardNumberView: UIView {
     
     @objc fileprivate func sendInfo(_ gesture: UIGestureRecognizer) {
         ForageSDK.shared.tokenizeEBTCard(
-            bearerToken: ClientSharedData.shared.bearerToken,
-            merchantAccount: ClientSharedData.shared.merchantID,
             customerID: ClientSharedData.shared.customerID,
             reusable: ClientSharedData.shared.isReusablePaymentMethod) { result in
                 self.printResult(result: result)

--- a/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CreatePayment/CreatePaymentView.swift
@@ -131,7 +131,7 @@ class CreatePaymentView: UIView {
         return label
     }()
     
-    private let merchantAccountLabel: UILabel = {
+    private let merchantIDLabel: UILabel = {
         let label = UILabel()
         label.text = ""
         label.textColor = .black
@@ -208,7 +208,7 @@ class CreatePaymentView: UIView {
             amount: paymentAmount,
             fundingType: isEbtSnap ? "ebt_snap" : "ebt_cash",
             paymentMethodIdentifier: ClientSharedData.shared.paymentMethodReference,
-            merchantAccount: ClientSharedData.shared.merchantID,
+            merchantID: ClientSharedData.shared.merchantID,
             description: "desc",
             metadata: [:],
             deliveryAddress: Address(
@@ -235,7 +235,7 @@ class CreatePaymentView: UIView {
                 self.fundingTypeLabel.text = "fundingType=\(response.fundingType.rawValue)"
                 self.paymentMethodIdentifierLabel.text = "paymentMethodIdentifier=\(response.paymentMethodIdentifier)"
                 self.paymentIdentifierLabel.text = "paymentIdentifier=\(response.paymentIdentifier)"
-                self.merchantAccountLabel.text = "merchantAccount=\(response.merchantAccount)"
+                self.merchantIDLabel.text = "merchantID=\(response.merchantID)"
                 self.amountLabel.text = "amount=\(response.amount)"
                 self.errorLabel.text = ""
                 ClientSharedData.shared.paymentReference[response.fundingType] = response.paymentIdentifier
@@ -245,7 +245,7 @@ class CreatePaymentView: UIView {
                 self.fundingTypeLabel.text = ""
                 self.paymentMethodIdentifierLabel.text = ""
                 self.paymentIdentifierLabel.text = ""
-                self.merchantAccountLabel.text = ""
+                self.merchantIDLabel.text = ""
                 self.amountLabel.text = ""
             }
             
@@ -264,7 +264,7 @@ class CreatePaymentView: UIView {
         contentView.addSubview(fundingTypeLabel)
         contentView.addSubview(paymentMethodIdentifierLabel)
         contentView.addSubview(paymentIdentifierLabel)
-        contentView.addSubview(merchantAccountLabel)
+        contentView.addSubview(merchantIDLabel)
         contentView.addSubview(amountLabel)
         contentView.addSubview(errorLabel)
         contentView.addSubview(nextButton)
@@ -360,7 +360,7 @@ class CreatePaymentView: UIView {
             padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
-        merchantAccountLabel.anchor(
+        merchantIDLabel.anchor(
             top: paymentIdentifierLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
@@ -370,7 +370,7 @@ class CreatePaymentView: UIView {
         )
         
         amountLabel.anchor(
-            top: merchantAccountLabel.safeAreaLayoutGuide.bottomAnchor,
+            top: merchantIDLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -156,8 +156,6 @@ class RequestBalanceView: UIView {
     
     @objc fileprivate func getBalanceInfo(_ gesture: UIGestureRecognizer) {
         ForageSDK.shared.checkBalance(
-            bearerToken: ClientSharedData.shared.bearerToken,
-            merchantAccount: ClientSharedData.shared.merchantID,
             paymentMethodReference: ClientSharedData.shared.paymentMethodReference,
             foragePinTextEdit: pinNumberTextField) { result in
                 self.printPINResult(result: result)

--- a/Sample/SampleForageSDK/ViewController.swift
+++ b/Sample/SampleForageSDK/ViewController.swift
@@ -32,6 +32,14 @@ class ViewController: UIViewController {
         ClientSharedData.shared.merchantID = merchantID
         ClientSharedData.shared.bearerToken = bearerToken
         
+        ForageSDK.setup(
+            ForageSDK.Config(
+                environment: ClientSharedData.shared.environment,
+                merchantAccount: merchantID,
+                bearerToken: bearerToken
+            )
+        )
+        
         let cardNumberViewController = CardNumberViewController()
         navigationController?.pushViewController(cardNumberViewController, animated: true)
     }

--- a/Sample/SampleForageSDK/ViewController.swift
+++ b/Sample/SampleForageSDK/ViewController.swift
@@ -12,7 +12,7 @@ class ViewController: UIViewController {
     
     // MARK: IBOutlets
     
-    @IBOutlet private weak var bearerTokenTextField: UITextField!
+    @IBOutlet private weak var sessionTokenTextField: UITextField!
     @IBOutlet private weak var merchantIdTextField: UITextField!
     
     // MARK: Lifecycle Methods
@@ -26,17 +26,17 @@ class ViewController: UIViewController {
     @IBAction func didTapOnStartSDK(_ sender: Any) {
         guard
             let merchantID = merchantIdTextField.text,
-            let bearerToken = bearerTokenTextField.text
+            let sessionToken = sessionTokenTextField.text
         else { return }
         
         ClientSharedData.shared.merchantID = merchantID
-        ClientSharedData.shared.bearerToken = bearerToken
+        ClientSharedData.shared.sessionToken = sessionToken
         
         ForageSDK.setup(
             ForageSDK.Config(
                 environment: ClientSharedData.shared.environment,
-                merchantAccount: merchantID,
-                bearerToken: bearerToken
+                merchantID: merchantID,
+                sessionToken: sessionToken
             )
         )
         

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -99,5 +99,8 @@ public class ForageSDK {
      */
     public class func setup(_ config: Config) {
         ForageSDK.config = config
+        ForageSDK.shared.environment = config.environment
+        ForageSDK.shared.merchantAccount = config.merchantAccount
+        ForageSDK.shared.bearerToken = config.bearerToken
     }
 }

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -41,6 +41,7 @@ public class ForageSDK {
             assertionFailure("ForageSDK missing Config setup")
             return
         }
+        
         self.environment = config.environment
         self.merchantID = config.merchantID
         self.sessionToken = config.sessionToken
@@ -100,7 +101,7 @@ public class ForageSDK {
     public class func setup(_ config: Config) {
         ForageSDK.config = config
         ForageSDK.shared.environment = config.environment
-        ForageSDK.shared.merchantAccount = config.merchantAccount
-        ForageSDK.shared.bearerToken = config.bearerToken
+        ForageSDK.shared.merchantID = config.merchantID
+        ForageSDK.shared.sessionToken = config.sessionToken
     }
 }

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -27,8 +27,8 @@ public class ForageSDK {
     internal var panNumber: String = ""
     internal var environment: EnvironmentTarget = .sandbox
     internal var logger: ForageLogger? = nil
-    internal var merchantAccount: String = ""
-    internal var bearerToken: String = ""
+    internal var merchantID: String = ""
+    internal var sessionToken: String = ""
     
     // Don't update! Only updated when releasing.
     public static let version = "3.0.8"
@@ -42,8 +42,8 @@ public class ForageSDK {
             return
         }
         self.environment = config.environment
-        self.merchantAccount = config.merchantAccount
-        self.bearerToken = config.bearerToken
+        self.merchantID = config.merchantID
+        self.sessionToken = config.sessionToken
         // ForageSDK.shared.environment is not set
         // until the end of this initialization
         // so we have to provide the environment from the config
@@ -55,7 +55,7 @@ public class ForageSDK {
         )
         self.logger = logger
         LDManager.shared.initialize(self.environment, logger: logger)
-    
+        
         VGSCollectLogger.shared.disableAllLoggers()
         let provider = Provider(logger: logger)
         self.service = LiveForageService(provider: provider, logger: logger)
@@ -66,33 +66,33 @@ public class ForageSDK {
      
      - Parameters:
         - environment: *EnvironmentTarget* enum to set environment.
-        - merchantAccount: The unique merchant ID that Forage provides during onboarding preceded by `mid/`, as in `mid/<Merchant ID>`
-        - bearerToken: The [session token](https://docs.joinforage.app/docs/authentication#session-tokens) that your backend generates to authenticate your app against the Forage Payments API. The token expires after 15 minutes.
+        - merchantID: The unique merchant ID that Forage provides during onboarding preceded by `mid/`, as in `mid/<Merchant ID>`
+        - sessionToken: The [session token](https://docs.joinforage.app/docs/authentication#session-tokens) that your backend generates to authenticate your app against the Forage Payments API. The token expires after 15 minutes.
      */
     public struct Config {
         let environment: EnvironmentTarget
-        let merchantAccount: String
-        let bearerToken: String
+        let merchantID: String
+        let sessionToken: String
 
-        public init(environment: EnvironmentTarget = .sandbox, merchantAccount: String, bearerToken: String) {
+        public init(environment: EnvironmentTarget = .sandbox, merchantID: String, sessionToken: String) {
             self.environment = environment
-            self.merchantAccount = merchantAccount
-            self.bearerToken = bearerToken
+            self.merchantID = merchantID
+            self.sessionToken = sessionToken
         }
     }
     
     /**
-     Setup ForageSDK using Config struct.
+     Setup ForageSDK using ``Config`` struct.
      
      - Parameters:
-       - config: *Config* struct object to set environment, merchant ID, and session token
+       - config: ``Config`` struct object to set environment, merchant ID, and session token
      
     ````
      ForageSDK.setup(
          ForageSDK.Config(
              environment: .sandbox,
-             merchantAccount: "mid/abcd123",
-             bearerToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
+             merchantID: "mid/abcd123",
+             sessionToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
          )
      )
     ````

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -27,6 +27,8 @@ public class ForageSDK {
     internal var panNumber: String = ""
     internal var environment: EnvironmentTarget = .sandbox
     internal var logger: ForageLogger? = nil
+    internal var merchantAccount: String = ""
+    internal var bearerToken: String = ""
     
     // Don't update! Only updated when releasing.
     public static let version = "3.0.8"
@@ -40,33 +42,42 @@ public class ForageSDK {
             return
         }
         self.environment = config.environment
+        self.merchantAccount = config.merchantAccount
+        self.bearerToken = config.bearerToken
         // ForageSDK.shared.environment is not set
         // until the end of this initialization
         // so we have to provide the environment from the config
         let logger = DatadogLogger(
             ForageLoggerConfig(
-                environment: config.environment,
+                environment: self.environment,
                 prefix: ""
             )
         )
         self.logger = logger
         LDManager.shared.initialize(self.environment, logger: logger)
+    
         VGSCollectLogger.shared.disableAllLoggers()
         let provider = Provider(logger: logger)
         self.service = LiveForageService(provider: provider, logger: logger)
     }
     
     /**
-     ``Config`` struct to set environment(``EnvironmentTarget``) on `ForageSDK` singleton
+     ``Config`` struct to set environment(``EnvironmentTarget``), merchant ID and session token on the ``ForageSDK`` singleton
      
      - Parameters:
         - environment: *EnvironmentTarget* enum to set environment.
+        - merchantAccount: The unique merchant ID that Forage provides during onboarding preceded by `mid/`, as in `mid/<Merchant ID>`
+        - bearerToken: The [session token](https://docs.joinforage.app/docs/authentication#session-tokens) that your backend generates to authenticate your app against the Forage Payments API. The token expires after 15 minutes.
      */
     public struct Config {
         let environment: EnvironmentTarget
+        let merchantAccount: String
+        let bearerToken: String
 
-        public init(environment: EnvironmentTarget = .sandbox) {
+        public init(environment: EnvironmentTarget = .sandbox, merchantAccount: String, bearerToken: String) {
             self.environment = environment
+            self.merchantAccount = merchantAccount
+            self.bearerToken = bearerToken
         }
     }
     
@@ -74,12 +85,16 @@ public class ForageSDK {
      Setup ForageSDK using Config struct.
      
      - Parameters:
-       - config: *Config* struct object to set environment.
+       - config: *Config* struct object to set environment, merchant ID, and session token
      
     ````
-      ForageSDK.setup(
-         ForageSDK.Config(environment: .sandbox)
-      )
+     ForageSDK.setup(
+         ForageSDK.Config(
+             environment: .sandbox,
+             merchantAccount: "mid/abcd123",
+             bearerToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
+         )
+     )
     ````
      */
     public class func setup(_ config: Config) {

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -92,7 +92,7 @@ public class ForageSDK {
      ForageSDK.setup(
          ForageSDK.Config(
              environment: .sandbox,
-             merchantID: "mid/abcd123",
+             merchantID: "1234567",
              sessionToken: "sandbox_eyJ0eXAiOiJKV1Qi..."
          )
      )

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -58,8 +58,8 @@ extension ForageSDK: ForageSDKService {
             .notice("Called ForageSDK.shared.tokenizeEBTCard", attributes: nil)
         
         let request = ForagePANRequestModel(
-            authorization: self.bearerToken,
-            merchantAccount: self.merchantAccount,
+            authorization: self.sessionToken,
+            merchantID: self.merchantID,
             panNumber: panNumber,
             type: CardType.EBT.rawValue,
             customerID: customerID,
@@ -80,21 +80,21 @@ extension ForageSDK: ForageSDKService {
                 ))
                 .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
                         
-            let bearerToken = self.bearerToken
-            let merchantAccount = self.merchantAccount
+            let sessionToken = self.sessionToken
+            let merchantID = self.merchantID
             
-            service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
+            service?.getXKey(sessionToken: sessionToken, merchantID: merchantID) { result in
                 switch result {
                 case .success(let model):
-                    self.service?.getPaymentMethod(bearerToken: bearerToken, merchantAccount: merchantAccount, paymentMethodRef: paymentMethodReference) { result in
+                    self.service?.getPaymentMethod(sessionToken: sessionToken, merchantID: merchantID, paymentMethodRef: paymentMethodReference) { result in
                         switch result {
                         case .success(let paymentMethod):
                             let request = ForageRequestModel(
-                                authorization: bearerToken,
+                                authorization: sessionToken,
                                 paymentMethodReference: paymentMethodReference,
                                 paymentReference: "",
                                 cardNumberToken: paymentMethod.card.token,
-                                merchantID: merchantAccount,
+                                merchantID: merchantID,
                                 xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                             )
                             self.service?.checkBalance(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)
@@ -120,25 +120,25 @@ extension ForageSDK: ForageSDKService {
                     paymentRef: paymentReference
                 ))
                 .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)
-                        
-            let bearerToken = self.bearerToken
-            let merchantAccount = self.merchantAccount
+
+            let sessionToken = self.sessionToken
+            let merchantID = self.merchantID
             
-            service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
+            service?.getXKey(sessionToken: sessionToken, merchantID: merchantID) { result in
                 switch result {
                 case .success(let model):
-                    self.service?.getPayment(bearerToken: bearerToken, merchantAccount: merchantAccount, paymentRef: paymentReference) { result in
+                    self.service?.getPayment(sessionToken: sessionToken, merchantID: merchantID, paymentRef: paymentReference) { result in
                         switch result {
                         case .success(let payment):
-                            self.service?.getPaymentMethod(bearerToken: bearerToken, merchantAccount: merchantAccount, paymentMethodRef: payment.paymentMethodRef) { result in
+                            self.service?.getPaymentMethod(sessionToken: sessionToken, merchantID: merchantID, paymentMethodRef: payment.paymentMethodRef) { result in
                                 switch result {
                                 case .success(let paymentMethod):
                                     let request = ForageRequestModel(
-                                        authorization: bearerToken,
+                                        authorization: sessionToken,
                                         paymentMethodReference: "",
                                         paymentReference: paymentReference,
                                         cardNumberToken: paymentMethod.card.token,
-                                        merchantID: merchantAccount,
+                                        merchantID: merchantID,
                                         xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                                     )
                                     self.service?.capturePayment(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -53,7 +53,7 @@ extension ForageSDK: ForageSDKService {
             .setPrefix("tokenizeEBTCard")
             .addContext(ForageLogContext(
                 customerID: customerID,
-                merchantRef: merchantAccount
+                merchantRef: merchantID
             ))
             .notice("Called ForageSDK.shared.tokenizeEBTCard", attributes: nil)
         
@@ -75,7 +75,7 @@ extension ForageSDK: ForageSDKService {
             _ = self.logger?
                 .setPrefix("checkBalance")
                 .addContext(ForageLogContext(
-                    merchantRef: merchantAccount,
+                    merchantRef: merchantID,
                     paymentMethodRef: paymentMethodReference
                 ))
                 .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
@@ -116,7 +116,7 @@ extension ForageSDK: ForageSDKService {
             _ = self.logger?
                 .setPrefix("capturePayment")
                 .addContext(ForageLogContext(
-                    merchantRef: merchantAccount,
+                    merchantRef: merchantID,
                     paymentRef: paymentReference
                 ))
                 .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -14,13 +14,9 @@ protocol ForageSDKService: AnyObject {
     /// Tokenize a given EBT Card
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: Merchant account identifier, `merchant id`.
     ///  - customerID: A unique ID for the end customer making the payment. We recommend that you hash this value.
     ///  - completion: Which will return the result. See more [here](https://docs.joinforage.app/reference/create-payment-method-1)
     func tokenizeEBTCard(
-        bearerToken: String,
-        merchantAccount: String,
         customerID: String,
         reusable: Bool?,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
@@ -28,14 +24,9 @@ protocol ForageSDKService: AnyObject {
     /// Check balance for a given EBT Card
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: Merchant account identifier, `merchant id`.
     ///  - paymentMethodReference: PaymentMethod's unique reference hash
-    ///  - cardNumberToken: The token field of the ``TokenizedPaymentMethod.card`` object
     ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/check-balance))
     func checkBalance(
-        bearerToken: String,
-        merchantAccount: String,
         paymentMethodReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void)
@@ -43,14 +34,9 @@ protocol ForageSDKService: AnyObject {
     /// Capture a payment for a given payment reference
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: Merchant account identifier, `merchant id`.
     ///  - paymentReference: The reference hash of the payment
-    ///  - cardNumberToken: The token field of the ``TokenizedPaymentMethod.card`` object
     ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/capture-payment))
     func capturePayment(
-        bearerToken: String,
-        merchantAccount: String,
         paymentReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void)
@@ -59,8 +45,6 @@ protocol ForageSDKService: AnyObject {
 extension ForageSDK: ForageSDKService {
     
     public func tokenizeEBTCard(
-        bearerToken: String,
-        merchantAccount: String,
         customerID: String,
         reusable: Bool? = true,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
@@ -74,8 +58,8 @@ extension ForageSDK: ForageSDKService {
             .notice("Called ForageSDK.shared.tokenizeEBTCard", attributes: nil)
         
         let request = ForagePANRequestModel(
-            authorization: bearerToken,
-            merchantAccount: merchantAccount,
+            authorization: self.bearerToken,
+            merchantAccount: self.merchantAccount,
             panNumber: panNumber,
             type: CardType.EBT.rawValue,
             customerID: customerID,
@@ -85,8 +69,6 @@ extension ForageSDK: ForageSDKService {
     }
     
     public func checkBalance(
-        bearerToken: String,
-        merchantAccount: String,
         paymentMethodReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
@@ -98,6 +80,9 @@ extension ForageSDK: ForageSDKService {
                 ))
                 .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
                         
+            let bearerToken = self.bearerToken
+            let merchantAccount = self.merchantAccount
+            
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
                 case .success(let model):
@@ -125,8 +110,6 @@ extension ForageSDK: ForageSDKService {
         }
     
     public func capturePayment(
-        bearerToken: String,
-        merchantAccount: String,
         paymentReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
@@ -138,6 +121,9 @@ extension ForageSDK: ForageSDKService {
                 ))
                 .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)
                         
+            let bearerToken = self.bearerToken
+            let merchantAccount = self.merchantAccount
+            
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
                 case .success(let model):

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -12,10 +12,10 @@ import Foundation
  */
 enum ForageAPI {
     case tokenizeNumber(request: ForagePANRequestModel)
-    case xKey(bearerToken: String, merchantAccount: String)
-    case message(request: MessageResponseModel, bearerToken: String, merchantID: String)
-    case getPaymentMethod(bearerToken: String, merchantAccount: String, paymentMethodRef: String)
-    case getPayment(bearerToken: String, merchantAccount: String, paymentRef: String)
+    case xKey(sessionToken: String, merchantID: String)
+    case message(request: MessageResponseModel, sessionToken: String, merchantID: String)
+    case getPaymentMethod(sessionToken: String, merchantID: String, paymentMethodRef: String)
+    case getPayment(sessionToken: String, merchantID: String, paymentRef: String)
 }
 
 extension ForageAPI: ServiceProtocol {
@@ -56,7 +56,7 @@ extension ForageAPI: ServiceProtocol {
             ]
 
             let httpHeaders: HTTPHeaders = [
-                "Merchant-Account": model.merchantAccount,
+                "Merchant-Account": model.merchantID,
                 "authorization": "Bearer \(model.authorization)",
                 "content-type": "application/json",
                 "accept": "application/json",
@@ -69,11 +69,11 @@ extension ForageAPI: ServiceProtocol {
                 additionalHeaders: httpHeaders
             )
 
-        case .xKey(bearerToken: let bearerToken, merchantAccount: let merchantAccount):
+        case .xKey(sessionToken: let sessionToken, merchantID: let merchantID):
             let httpHeaders: HTTPHeaders = [
-                "authorization": "Bearer \(bearerToken)",
+                "authorization": "Bearer \(sessionToken)",
                 "accept": "application/json",
-                "Merchant-Account": merchantAccount,
+                "Merchant-Account": merchantID,
             ]
 
             return .requestParametersAndHeaders(
@@ -82,10 +82,10 @@ extension ForageAPI: ServiceProtocol {
                 additionalHeaders: httpHeaders
             )
 
-        case .message(_, bearerToken: let bearerToken, merchantID: let merchantID):
+        case .message(_, sessionToken: let sessionToken, merchantID: let merchantID):
             let httpHeaders: HTTPHeaders = [
                 "Merchant-Account": merchantID,
-                "authorization": "Bearer \(bearerToken)",
+                "authorization": "Bearer \(sessionToken)",
                 "accept": "application/json",
                 "API-VERSION": "2023-02-01"
             ]
@@ -98,8 +98,8 @@ extension ForageAPI: ServiceProtocol {
 
         case .getPaymentMethod(request: let request):
             let httpHeaders: HTTPHeaders = [
-                "Merchant-Account": request.merchantAccount,
-                "authorization": "Bearer \(request.bearerToken)",
+                "Merchant-Account": request.merchantID,
+                "authorization": "Bearer \(request.sessionToken)",
                 "API-VERSION": "2023-05-15"
             ]
 
@@ -111,8 +111,8 @@ extension ForageAPI: ServiceProtocol {
 
         case .getPayment(request: let request):
             let httpHeaders: HTTPHeaders = [
-                "Merchant-Account": request.merchantAccount,
-                "authorization": "Bearer \(request.bearerToken)",
+                "Merchant-Account": request.merchantID,
+                "authorization": "Bearer \(request.sessionToken)",
                 "API-VERSION": "2023-05-15"
             ]
 

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -41,10 +41,10 @@ internal class LiveForageService: ForageService {
     /// Retrieve from ForageAPI the X-Key header to perform request.
     ///
     /// - Parameters:
-    ///  - bearerToken: Session authorization token.
+    ///  - sessionToken: Session authorization token.
     ///  - completion: Returns *ForageXKeyModel* object.
-    internal func getXKey(bearerToken: String, merchantAccount: String, completion: @escaping (Result<ForageXKeyModel, Error>) -> Void) {
-        do { try provider.execute(model: ForageXKeyModel.self, endpoint: ForageAPI.xKey(bearerToken: bearerToken, merchantAccount: merchantAccount), completion: completion) }
+    internal func getXKey(sessionToken: String, merchantID: String, completion: @escaping (Result<ForageXKeyModel, Error>) -> Void) {
+        do { try provider.execute(model: ForageXKeyModel.self, endpoint: ForageAPI.xKey(sessionToken: sessionToken, merchantID: merchantID), completion: completion) }
         catch { completion(.failure(error)) }
     }
     
@@ -81,8 +81,8 @@ internal class LiveForageService: ForageService {
                     switch pollingResult {
                     case .success:
                         self?.getPaymentMethod(
-                            bearerToken: request.authorization,
-                            merchantAccount: request.merchantID,
+                            sessionToken: request.authorization,
+                            merchantID: request.merchantID,
                             paymentMethodRef: request.paymentMethodReference,
                             completion: { paymentMethodResult in
                                 switch paymentMethodResult {
@@ -126,8 +126,8 @@ internal class LiveForageService: ForageService {
     /// - Parameters:
     ///  - request: Model element with data to perform request.
     ///  - completion: Returns balance object.
-    internal func getPaymentMethod(bearerToken: String, merchantAccount: String, paymentMethodRef: String, completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) {
-        do { try provider.execute(model: PaymentMethodModel.self, endpoint: ForageAPI.getPaymentMethod(bearerToken: bearerToken, merchantAccount: merchantAccount, paymentMethodRef: paymentMethodRef), completion: completion) }
+    internal func getPaymentMethod(sessionToken: String, merchantID: String, paymentMethodRef: String, completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) {
+        do { try provider.execute(model: PaymentMethodModel.self, endpoint: ForageAPI.getPaymentMethod(sessionToken: sessionToken, merchantID: merchantID, paymentMethodRef: paymentMethodRef), completion: completion) }
         catch { completion(.failure(error)) }
     }
     
@@ -161,8 +161,8 @@ internal class LiveForageService: ForageService {
                     switch pollingResult {
                     case .success:
                         self?.getPayment(
-                            bearerToken: request.authorization,
-                            merchantAccount: request.merchantID,
+                            sessionToken: request.authorization,
+                            merchantID: request.merchantID,
                             paymentRef: request.paymentReference,
                             completion: { [weak self] paymentResult in
                                 switch paymentResult {
@@ -192,8 +192,8 @@ internal class LiveForageService: ForageService {
     /// - Parameters:
     ///  - request: Model element with data to perform request.
     ///  - completion: Returns balance object.
-    internal func getPayment(bearerToken: String, merchantAccount: String, paymentRef: String, completion: @escaping (Result<PaymentModel, Error>) -> Void) {
-        do { try provider.execute(model: PaymentModel.self, endpoint: ForageAPI.getPayment(bearerToken: bearerToken, merchantAccount: merchantAccount, paymentRef: paymentRef), completion: completion) }
+    internal func getPayment(sessionToken: String, merchantID: String, paymentRef: String, completion: @escaping (Result<PaymentModel, Error>) -> Void) {
+        do { try provider.execute(model: PaymentModel.self, endpoint: ForageAPI.getPayment(sessionToken: sessionToken, merchantID: merchantID, paymentRef: paymentRef), completion: completion) }
         catch { completion(.failure(error)) }
     }
 }
@@ -251,7 +251,7 @@ extension LiveForageService: Polling {
         completion: @escaping (Result<MessageResponseModel, Error>) -> Void) -> Void
     {
         do {
-            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(request: message, bearerToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
+            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(request: message, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success(let data):

--- a/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForagePANRequestModel.swift
@@ -10,7 +10,7 @@ import Foundation
 /// `ForagePANRequestModel` used for compose request to tokenize Ebt Card
 internal struct ForagePANRequestModel: Codable {
     let authorization: String
-    let merchantAccount: String
+    let merchantID: String
     let panNumber: String
     let type: String
     let customerID: String

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
@@ -61,7 +61,7 @@ public struct Receipt: Codable {
 /// `PaymentModel` used to represent a tokenized EBT Card
 public struct PaymentModel: Codable {
     public let paymentRef: String
-    public let merchantAccount: String
+    public let merchantID: String
     public let fundingType: String
     public let amount: String
     public let description: String
@@ -82,7 +82,7 @@ public struct PaymentModel: Codable {
     
     private enum CodingKeys : String, CodingKey {
         case paymentRef = "ref"
-        case merchantAccount = "merchant"
+        case merchantID = "merchant"
         case fundingType = "funding_type"
         case amount
         case description

--- a/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
@@ -12,14 +12,14 @@ import VGSCollectSDK
  Interface for internal Forage SDK requests
  */
 internal protocol ForageService: AnyObject {
-    /// Provider provides the interface for perform url requests.
+    /// Provider provides the interface for performing HTTP requests.
     var provider: Provider { get }
     
     /// Retrieve X-key header for requests
     ///
     /// - Parameters:
     ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: The merchant FNS number.
+    ///  - merchantAccount: merchant ID.
     ///  - completion: Which will return the x-key object.
     func getXKey(
         bearerToken: String,
@@ -30,7 +30,7 @@ internal protocol ForageService: AnyObject {
     ///
     /// - Parameters:
     ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: The merchant FNS number.
+    ///  - merchantAccount: merchant ID.
     ///  - paymentMethodRef: The PaymentMethod ref.
     ///  - completion: Returns the PaymentMethod
     func getPaymentMethod(
@@ -43,7 +43,7 @@ internal protocol ForageService: AnyObject {
     ///
     /// - Parameters:
     ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: The merchant FNS number.
+    ///  - merchantAccount: merchant ID.
     ///  - paymentRef: The Payment ref.
     ///  - completion: Returns the Payment
     func getPayment(

--- a/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
@@ -18,37 +18,37 @@ internal protocol ForageService: AnyObject {
     /// Retrieve X-key header for requests
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: merchant ID.
+    ///  - sessionToken: Authorization token.
+    ///  - merchantID: merchant ID.
     ///  - completion: Which will return the x-key object.
     func getXKey(
-        bearerToken: String,
-        merchantAccount: String,
+        sessionToken: String,
+        merchantID: String,
         completion: @escaping (Result<ForageXKeyModel, Error>) -> Void) -> Void
     
     /// Perform a GET request for the PaymentMethod
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: merchant ID.
+    ///  - sessionToken: Authorization token.
+    ///  - merchantID: merchant ID.
     ///  - paymentMethodRef: The PaymentMethod ref.
     ///  - completion: Returns the PaymentMethod
     func getPaymentMethod(
-        bearerToken: String,
-        merchantAccount: String,
+        sessionToken: String,
+        merchantID: String,
         paymentMethodRef: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) -> Void
     
     /// Perform a GET request for the Payment
     ///
     /// - Parameters:
-    ///  - bearerToken: Authorization token.
-    ///  - merchantAccount: merchant ID.
+    ///  - sessionToken: Authorization token.
+    ///  - merchantID: merchant ID.
     ///  - paymentRef: The Payment ref.
     ///  - completion: Returns the Payment
     func getPayment(
-        bearerToken: String,
-        merchantAccount: String,
+        sessionToken: String,
+        merchantID: String,
         paymentRef: String,
         completion: @escaping (Result<PaymentModel, Error>) -> Void)
     

--- a/Tests/ForageSDKTests/CollectorTests.swift
+++ b/Tests/ForageSDKTests/CollectorTests.swift
@@ -14,7 +14,11 @@ import BasisTheoryElements
 class VaultCollectorTests: XCTestCase {
 
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(
+            environment: .sandbox,
+            merchantAccount: "merchantID123",
+            bearerToken: "authToken123"
+        ))
         ForageSDK.shared.service = nil
     }
     

--- a/Tests/ForageSDKTests/CollectorTests.swift
+++ b/Tests/ForageSDKTests/CollectorTests.swift
@@ -16,8 +16,8 @@ class VaultCollectorTests: XCTestCase {
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(
             environment: .sandbox,
-            merchantAccount: "merchantID123",
-            bearerToken: "authToken123"
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
         ))
         ForageSDK.shared.service = nil
     }

--- a/Tests/ForageSDKTests/FloatingTextFieldTests.swift
+++ b/Tests/ForageSDKTests/FloatingTextFieldTests.swift
@@ -12,7 +12,7 @@ final class FloatingTextFieldTests: XCTestCase {
     var floatingTextField: FloatingTextField!
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         ForageSDK.shared.environment = .sandbox
         ForageSDK.shared.service = nil
         ForageSDK.shared.panNumber = ""

--- a/Tests/ForageSDKTests/ForageElementDelegateTests.swift
+++ b/Tests/ForageSDKTests/ForageElementDelegateTests.swift
@@ -48,7 +48,7 @@ final class ForageElementDelegateTests: XCTestCase {
     }
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         ForageSDK.shared.service = nil
         observableState = nil
     }

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -12,10 +12,16 @@ final class ForagePANTextFieldTests: XCTestCase {
     var foragePANTextField: ForagePANTextField!
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+         ForageSDK.setup(ForageSDK.Config(
+            environment: .sandbox,
+            merchantAccount: "merchantID123",
+            bearerToken: "authToken123"
+        ))
         ForageSDK.shared.service = nil
         ForageSDK.shared.panNumber = ""
         foragePANTextField = ForagePANTextField()
+       
+        observableState = nil
     }
     
     override func tearDown() {

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -14,8 +14,8 @@ final class ForagePANTextFieldTests: XCTestCase {
     override func setUp() {
          ForageSDK.setup(ForageSDK.Config(
             environment: .sandbox,
-            merchantAccount: "merchantID123",
-            bearerToken: "authToken123"
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
         ))
         ForageSDK.shared.service = nil
         ForageSDK.shared.panNumber = ""

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -19,9 +19,7 @@ final class ForagePANTextFieldTests: XCTestCase {
         ))
         ForageSDK.shared.service = nil
         ForageSDK.shared.panNumber = ""
-        foragePANTextField = ForagePANTextField()
-       
-        observableState = nil
+        foragePANTextField = ForagePANTextField()       
     }
     
     override func tearDown() {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -14,7 +14,11 @@ final class ForagePINTextFieldTests: XCTestCase {
     var observableState: ObservableState?
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(
+            environment: .sandbox,
+            merchantAccount: "merchantID123",
+            bearerToken: "authToken123"
+        ))        
         observableState = nil
     }
     

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -16,8 +16,8 @@ final class ForagePINTextFieldTests: XCTestCase {
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(
             environment: .sandbox,
-            merchantAccount: "merchantID123",
-            bearerToken: "authToken123"
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
         ))        
         observableState = nil
     }

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -16,8 +16,8 @@ final class ForageServiceTests: XCTestCase {
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(
             environment: .sandbox,
-            merchantAccount: "merchantID123",
-            bearerToken: "authToken123"
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
         ))
         ForageSDK.shared.service = nil
         forageMocks = ForageMocks()
@@ -31,7 +31,7 @@ final class ForageServiceTests: XCTestCase {
         
         let foragePANRequestModel = ForagePANRequestModel(
             authorization: "authToken123",
-            merchantAccount: "merchantID123",
+            merchantID: "merchantID123",
             panNumber: "5076801234123412",
             type: "ebt",
             customerID: "test-ios-customer-id",
@@ -63,7 +63,7 @@ final class ForageServiceTests: XCTestCase {
         
         let foragePANRequestModel = ForagePANRequestModel(
             authorization: "authToken123",
-            merchantAccount: "merchantID123",
+            merchantID: "merchantID123",
             panNumber: "5076801234123412",
             type: "ebt",
             customerID: "test-ios-customer-id",
@@ -90,7 +90,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the X-Key header - should succeed")
-        service.getXKey(bearerToken: "auth1234", merchantAccount: "1234567") { result in
+        service.getXKey(sessionToken: "auth1234", merchantID: "1234567") { result in
             switch result {
             case .success(let model):
                 XCTAssertEqual(model.alias, "tok_sandbox_agCcwWZs8TMkkq89f8KHSx")
@@ -110,7 +110,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the X-Key header - result should be failure")
-        service.getXKey(bearerToken: "auth1234", merchantAccount: "1234567") { result in
+        service.getXKey(sessionToken: "auth1234", merchantID: "1234567") { result in
             switch result {
             case .success:
                 XCTFail("Expected failure")
@@ -129,7 +129,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the Payment Method - should succeed")
-        service.getPaymentMethod(bearerToken: "auth1234", merchantAccount: "1234567", paymentMethodRef: "ca29d3443f") { result in
+        service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
             switch result {
             case .success(let paymentMethod):
                 XCTAssertEqual(paymentMethod.paymentMethodIdentifier, "ca29d3443f")
@@ -153,7 +153,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the Payment Method - result should be failure")
-        service.getPaymentMethod(bearerToken: "auth1234", merchantAccount: "1234567", paymentMethodRef: "ca29d3443f") { result in
+        service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
             switch result {
             case .success:
                 XCTFail("Expected failure")
@@ -172,7 +172,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
-        service.getPayment(bearerToken: "auth1234", merchantAccount: "1234567", paymentRef: "11767381fd") { result in
+        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
             switch result {
             case .success(let payment):
                 XCTAssertEqual(payment.paymentMethodRef, "81dab02290")
@@ -195,7 +195,7 @@ final class ForageServiceTests: XCTestCase {
         let service = LiveForageService(provider: Provider(mockSession))
         
         let expectation = XCTestExpectation(description: "Get the Payment - result should be failure")
-        service.getPayment(bearerToken: "auth1234", merchantAccount: "1234567", paymentRef: "11767381fd") { result in
+        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
             switch result {
             case .success:
                 XCTFail("Expected failure")

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -14,7 +14,11 @@ final class ForageServiceTests: XCTestCase {
     var forageMocks: ForageMocks!
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(
+            environment: .sandbox,
+            merchantAccount: "merchantID123",
+            bearerToken: "authToken123"
+        ))
         ForageSDK.shared.service = nil
         forageMocks = ForageMocks()
     }

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -12,7 +12,7 @@ final class MaskedUITextFieldTests: XCTestCase {
     var maskedTextField: MaskedUITextField!
     
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         // .setup() currently doesn't allow us to update the environment
         ForageSDK.shared.environment = .sandbox
         ForageSDK.shared.service = nil

--- a/Tests/ForageSDKTests/ResponseMonitorTests.swift
+++ b/Tests/ForageSDKTests/ResponseMonitorTests.swift
@@ -43,7 +43,7 @@ class TestableResponseMonitor: ResponseMonitor {
 
 final class ResponseMonitorTests: XCTestCase {
     override func setUp() {
-        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         ForageSDK.shared.service = nil
     }
     


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Move `merchantAccount` and `bearerToken` from the submit methods to the `ForageSDK.Config`
- Call `ForageSDK.setup()` with the new `ForageSDK.Config` to update the environment, session token, merchant account, and/or bearer token

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

https://linear.app/joinforage/issue/FX-392/move-merchantaccount-bearertoken-to-foragesdksetup-in-forage-ios-sdk

Opted against using `@available` and gracefully deprecating the old method signatures (make the change reverse compatible), since only one client will have to make this small + trivial change on their end and we're currently making other breaking changes to the SDK anyway.

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ | ❌ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How

- Breaking change!
- [ ] Merge down this PR #75 
- [ ] Merge down PR #86
- [ ] Merge down PR #86 
- [ ] Merge down PR #87 
- [ ] Merge down PR #88 
- [ ] Communicate this change and the [migration guide](https://www.notion.so/joinforage/iOS-SDK-Migration-guide-v3-v4-86907ee4b4e34caba9633dc3774cca97) to the client when we release this version
- [ ] Update the [readme docs](https://docs.joinforage.app/docs/ios#starter-code)

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->


### Migration guide (v3 -> v4)

Can be [found in Notion](https://www.notion.so/joinforage/iOS-SDK-Migration-guide-v3-v4-86907ee4b4e34caba9633dc3774cca97)