### PR TITLE
[FX-400] Lower minimum iOS version to 13

### DIFF
--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/teamforage/forage-ios-sdk"
   spec.license      = { :type => "MIT", :file => "LICENSE" }
   spec.author       = { "Rob Gormisky" => "rob@joinforage.com" }
-  spec.platform     = :ios, "14.0"
+  spec.platform     = :ios, "13.0"
   spec.source       = { :git => "https://github.com/teamforage/forage-ios-sdk.git", :tag => "2.0.2" }
   spec.source_files = "Sources/ForageSDK/**/*.swift"
   spec.dependency 'VGSCollectSDK', '~> 1.11.2'
   spec.dependency 'LaunchDarkly', '~> 8.0.1'
-  spec.dependency 'BasisTheoryElements', '~> 2.2.0'
+  spec.dependency 'BasisTheoryElements', '~> 2.5.0'
   spec.resource_bundles = {
     'ForageIcon' => ['Sources/Resources/*']
   }

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ForageSDK",
     platforms: [
-            .iOS(.v14),
+            .iOS(.v13),
         ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -30,7 +30,7 @@ let package = Package(
         .package(
             name: "BasisTheoryElements",
             url: "https://github.com/Basis-Theory/basistheory-ios",
-            from: "2.2.0"
+            from: "2.5.0"
         ),
     ],
     targets: [


### PR DESCRIPTION
## What
Lower the minimum iOS version from 14 to 13 so we don't break GoPuff.

## Test Plan
Unit tests and qa-tests pass locally.
