### PR TITLE
[FX-398] iOS support dynamically updating the mask of ebt card

### DIFF
--- a/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
@@ -92,6 +92,12 @@ internal class MaskedUITextField : UITextField, ObservableState {
             forageDelegate?.textFieldDidChange(self) // notify client about latest validation status.
         }
         
+        if isSpecialCard(newUnmaskedText) {
+            isValid = true
+            isComplete = newUnmaskedText.count >= 16 && newUnmaskedText.count <= 19
+            return
+        }
+        
         // Prior to seeing 6 digits, the PAN is considered valid but incomplete.
         if newUnmaskedText.count < 6 {
             isValid = true
@@ -198,5 +204,28 @@ internal class MaskedUITextField : UITextField, ObservableState {
             }
         }
         return result
+    }
+    
+    /// Determines whether to disable validation for specific card numbers used to trigger exceptions.
+    ///
+    /// - Parameter newUnmaskedText: The unmasked card number to be checked.
+    /// - Returns: `true` if validation should be disabled for the given card number, `false` otherwise.
+    private func isSpecialCard(_ newUnmaskedText: String) -> Bool {
+        // Special error cards that fail at PIN entry for capture
+        if newUnmaskedText.hasPrefix("44444444444444") {
+            return true
+        }
+        
+        // Special error cards that fail at PIN entry for balance check
+        if newUnmaskedText.hasPrefix("55555555555555") {
+            return true
+        }
+        
+        // Special cards that pass validation checks without causing any errors
+        if newUnmaskedText.hasPrefix("9999") {
+            return true
+        }
+        
+        return false
     }
 }

--- a/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
@@ -1,0 +1,202 @@
+//
+//  MaskedUITextField.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-08-14.
+//
+
+import UIKit
+import Foundation
+
+extension String {
+    subscript(safe index: Int) -> Character? {
+        return index < count && index >= 0 ? self[self.index(startIndex, offsetBy: index)] : nil
+    }
+}
+
+internal enum MaskPattern : String {
+    case unset = "###################"
+    case sixteenDigits = "#### #### #### ####"
+    case eighteenDigits = "###### #### ##### ## #"
+    case nineteenDigits = "###### #### #### ### ##"
+}
+
+internal class MaskedUITextField : UITextField, ObservableState {
+    // MARK: - Properties
+    private var wasBackspacePressed = false
+    
+    /// A delegate that informs the client about the state of the entered card number (validation, focus)
+    public weak var forageDelegate: ForageElementDelegate? {
+        didSet {
+            delegate = forageDelegate as? UITextFieldDelegate
+        }
+    }
+    
+    @IBInspectable private(set) public var isEmpty = true
+    // TODO: default to isValid = true on initialization
+    @IBInspectable private(set) public var isValid = false
+    @IBInspectable private(set) public var isComplete = false
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    private func setup() {
+        autocorrectionType = .no
+        addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+    }
+    
+    // MARK: - Text Field Actions
+    override func deleteBackward() {
+        wasBackspacePressed = true
+        super.deleteBackward()
+    }
+    
+    @objc func textFieldDidChange() {
+        defer { wasBackspacePressed = false }
+        
+        guard let text = text else { return }
+        
+        // the UITextFieldDelegate ensures the user can enter only numeric inputs
+        var newUnmaskedText = text.replacingOccurrences(of: " ", with: "")
+        let matchedStateIIN = ForagePANValidations.checkPANLength(newUnmaskedText)
+        
+        newUnmaskedText = trimTrailingDigits(newUnmaskedText, stateIIN: matchedStateIIN)
+        
+        validateText(newUnmaskedText, stateIIN: matchedStateIIN)
+        
+        let maskPattern = determineMaskPattern(for: newUnmaskedText, stateIIN: matchedStateIIN)
+        self.applyMask(newUnmaskedText, maskPattern: maskPattern)
+        
+        // TODO: Stop sharing the PAN state and instead have each PAN hold it's own state
+        ForageSDK.shared.panNumber = newUnmaskedText
+    }
+    
+    // MARK: - Text Handling
+    private func trimTrailingDigits(_ newUnmaskedText: String, stateIIN: StateIIN?) -> String {
+        let maxPanLength = min(newUnmaskedText.count, stateIIN?.panLength ?? 16)
+        
+        return String(newUnmaskedText.prefix(maxPanLength))
+    }
+    
+    private func validateText(_ newUnmaskedText: String, stateIIN: StateIIN?) {
+        defer {
+            isEmpty = newUnmaskedText.isEmpty
+            forageDelegate?.textFieldDidChange(self) // notify client about latest validation status.
+        }
+        
+        // Prior to seeing 6 digits, the PAN is considered valid but incomplete.
+        if newUnmaskedText.count < 6 {
+            isValid = true
+            isComplete = false
+            return
+        }
+        
+        if let stateIIN = stateIIN {
+            isValid = true
+            isComplete = newUnmaskedText.count == stateIIN.panLength
+            return
+        }
+        
+        // If 6 or more digits are included and the first 6 digits don't map to a known state
+        isValid = false
+        isComplete = false
+    }
+    
+    private func determineMaskPattern(for newUnmaskedText: String, stateIIN: StateIIN?) -> MaskPattern {
+        if newUnmaskedText.count < 6 {
+            return MaskPattern.unset
+        }
+        if let stateIIN = stateIIN {
+            switch stateIIN.panLength {
+            case 16:
+                return MaskPattern.sixteenDigits
+            case 18:
+                return MaskPattern.eighteenDigits
+            default:
+                return MaskPattern.nineteenDigits
+            }
+        }
+        return MaskPattern.sixteenDigits
+    }
+    
+    private func applyMask(_ newUnmaskedText: String, maskPattern: MaskPattern) {
+        // Find the current cursor position
+        var cursorOffset = offset(from: beginningOfDocument, to: selectedTextRange!.start)
+        let maskedText = getMaskedText(newUnmaskedText, maskPattern: maskPattern)
+        let isCursorAtEndOfText = cursorOffset - maskedText.count >= 0
+        
+        // when the mask gets set at 6 digits
+        if newUnmaskedText.count == 6 && cursorOffset - maskedText.count == -1 {
+            // move the cursor forward
+            cursorOffset += 1
+        }
+        
+        if wasBackspacePressed && isCursorAtEndOfText {
+            self.text = maskedText
+            return
+        }
+        
+        // Apply the masked text to the text field with a new character, we use " " string as "any" character
+        let maskedTextWithNewChar = getMaskedText(newUnmaskedText + " ", maskPattern: maskPattern)
+        self.text = maskedText
+        
+        // Calculate the new cursor position
+        if !isCursorAtEndOfText
+            && !wasBackspacePressed
+            && isNextCharacterGap(offset: cursorOffset, maskPattern: maskPattern) {
+            // move cursor an additional step forward
+            cursorOffset += 1
+        }
+        // Check if a whitespace (or other non-placeholder character) was added during the masking
+        if isCursorAtEndOfText && maskedTextWithNewChar.count > maskedText.count + 1 {
+            // move cursor an additional step forward
+            cursorOffset += 1
+        }
+        
+        self.setNewCursorPosition(cursorOffset)
+    }
+    
+    private func wasBackspacePressedOnGap(offset cursorOffset: NSInteger, maskPattern: MaskPattern) -> Bool {
+        return wasBackspacePressed && cursorOffset > 0 && maskPattern.rawValue[safe: cursorOffset] == " "
+    }
+    
+    private func isNextCharacterGap(offset cursorOffset: NSInteger, maskPattern: MaskPattern) -> Bool {
+        return cursorOffset > 0 && maskPattern.rawValue[safe: cursorOffset - 1] == " "
+    }
+    
+    private func getNextChar(_ maskPattern: MaskPattern, cursorOffset: Int) -> Character? {
+        return maskPattern.rawValue[safe: cursorOffset]
+    }
+    
+    private func setNewCursorPosition(_ newPositionOffset: NSInteger) {
+        if let newPosition = position(from: beginningOfDocument, offset: newPositionOffset) {
+            selectedTextRange = textRange(from: newPosition, to: newPosition)
+        }
+    }
+    
+    private func getMaskedText(_ newUnmaskedText: String, maskPattern: MaskPattern) -> String {
+        var result = ""
+        var insertionIndex = newUnmaskedText.startIndex
+        
+        for char in maskPattern.rawValue {
+            if insertionIndex >= newUnmaskedText.endIndex {
+                break
+            }
+            if char == "#" {
+                result.append(newUnmaskedText[insertionIndex])
+                insertionIndex = newUnmaskedText.index(after: insertionIndex)
+            } else {
+                result.append(char)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
@@ -33,8 +33,7 @@ internal class MaskedUITextField : UITextField, ObservableState {
     }
     
     @IBInspectable private(set) public var isEmpty = true
-    // TODO: default to isValid = true on initialization
-    @IBInspectable private(set) public var isValid = false
+    @IBInspectable private(set) public var isValid = true
     @IBInspectable private(set) public var isComplete = false
     
     // MARK: - Initialization
@@ -92,7 +91,8 @@ internal class MaskedUITextField : UITextField, ObservableState {
             forageDelegate?.textFieldDidChange(self) // notify client about latest validation status.
         }
         
-        if isSpecialCard(newUnmaskedText) {
+        let isProdEnvironment = ForageSDK.shared.environment == EnvironmentTarget.prod
+        if !isProdEnvironment && isSpecialCard(newUnmaskedText) {
             isValid = true
             isComplete = newUnmaskedText.count >= 16 && newUnmaskedText.count <= 19
             return
@@ -223,6 +223,10 @@ internal class MaskedUITextField : UITextField, ObservableState {
         
         // Special cards that pass validation checks without causing any errors
         if newUnmaskedText.hasPrefix("9999") {
+            return true
+        }
+        
+        if newUnmaskedText.hasPrefix("654321") {
             return true
         }
         

--- a/Tests/ForageSDKTests/ForageElementDelegateTests.swift
+++ b/Tests/ForageSDKTests/ForageElementDelegateTests.swift
@@ -1,0 +1,114 @@
+//
+//  ForageElementDelegateTests.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-08-15.
+//
+
+import XCTest
+@testable import ForageSDK
+
+final class ForageElementDelegateTests: XCTestCase {
+    var observableState: ObservableState?
+    class mockState: ObservableState {
+        var _isFirstResponder = false
+        var isFirstResponder: Bool {
+            get {
+                return _isFirstResponder
+            }
+        }
+        
+        var _isEmpty = false
+        var isEmpty: Bool {
+            get {
+                return _isEmpty
+            }
+        }
+        
+        var _isValid = false
+        var isValid: Bool {
+            get {
+                return _isValid
+            }
+        }
+        
+        var _isComplete = false
+        var isComplete: Bool {
+            get {
+                return _isComplete
+            }
+        }
+        
+        init(isFirstResponder: Bool, isEmpty: Bool, isValid: Bool, isComplete: Bool) {
+            self._isFirstResponder = isFirstResponder
+            self._isEmpty = isEmpty
+            self._isValid = isValid
+            self._isComplete = isComplete
+        }
+    }
+    
+    override func setUp() {
+        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.shared.service = nil
+        observableState = nil
+    }
+    
+    func test_forageElementDelegate_focusDidChange() {
+        let foragePanTextField = ForagePANTextField()
+        
+        let expectedIsFirstResponder = true
+        let expectedIsEmpty = false
+        let expectedIsValid = true
+        let expectedIsComplete = false
+        
+        foragePanTextField.delegate = self
+        foragePanTextField.delegate?.focusDidChange(
+            mockState(
+                isFirstResponder: expectedIsFirstResponder,
+                isEmpty: expectedIsEmpty,
+                isValid: expectedIsValid,
+                isComplete: expectedIsComplete
+            )
+        )
+        
+        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
+        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
+        XCTAssertEqual(expectedIsValid, observableState?.isValid)
+        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
+    }
+    
+    func test_forageElementDelegate_textFieldDidChange() {
+        let foragePanTextField = ForagePANTextField()
+        
+        let expectedIsFirstResponder = false
+        let expectedIsEmpty = true
+        let expectedIsValid = false
+        let expectedIsComplete = true
+        
+        foragePanTextField.delegate = self
+        foragePanTextField.delegate?.textFieldDidChange(
+            mockState(
+                isFirstResponder: expectedIsFirstResponder,
+                isEmpty: expectedIsEmpty,
+                isValid: expectedIsValid,
+                isComplete: expectedIsComplete
+            )
+        )
+        
+        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
+        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
+        XCTAssertEqual(expectedIsValid, observableState?.isValid)
+        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
+    }
+}
+
+
+extension ForageElementDelegateTests : ForageElementDelegate {
+    func focusDidChange(_ state: ObservableState) {
+        observableState = state
+    }
+    
+    func textFieldDidChange(_ state: ObservableState) {
+        observableState = state
+    }
+}

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -1,190 +1,58 @@
 //
 //  ForagePANTextFieldTests.swift
-//  ForageSDK
+//  
 //
-//  Created by Symphony on 28/11/22.
+//  Created by Danilo Joksimovic on 2023-08-15.
 //
 
 import XCTest
 @testable import ForageSDK
 
 final class ForagePANTextFieldTests: XCTestCase {
-    
-    var observableState: ObservableState?
-    
-    class mockState: ObservableState {
-        var _isFirstResponder = false
-        var isFirstResponder: Bool {
-            get {
-                return _isFirstResponder
-            }
-        }
-        
-        var _isEmpty = false
-        var isEmpty: Bool {
-            get {
-                return _isEmpty
-            }
-        }
-        
-        var _isValid = false
-        var isValid: Bool {
-            get {
-                return _isValid
-            }
-        }
-        
-        var _isComplete = false
-        var isComplete: Bool {
-            get {
-                return _isComplete
-            }
-        }
-        
-        init(isFirstResponder: Bool, isEmpty: Bool, isValid: Bool, isComplete: Bool) {
-            self._isFirstResponder = isFirstResponder
-            self._isEmpty = isEmpty
-            self._isValid = isValid
-            self._isComplete = isComplete
-        }
-    }
+    var foragePANTextField: ForagePANTextField!
     
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
-        observableState = nil
+        ForageSDK.shared.service = nil
+        ForageSDK.shared.panNumber = ""
+        foragePANTextField = ForagePANTextField()
     }
     
-    
-    
-    func test_givenValidCard_shouldReturnValid() {
-        let foragePanTextField = ForagePANTextField()
-        foragePanTextField.delegate = self
-        
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "5076801234123412")
-        
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertTrue(foragePanTextField.isValid)
-        XCTAssertTrue(foragePanTextField.isComplete)
+    override func tearDown() {
+        foragePANTextField = nil
     }
     
-    func test_givenValidCard_withMoreDigits_shouldReturnInvalid() {
-        let foragePanTextField = ForagePANTextField()
-        foragePanTextField.delegate = self
-        
-        // Add a valid card
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "5076801234123412")
-        
-        // Check for valid state
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertTrue(foragePanTextField.isValid)
-        XCTAssertTrue(foragePanTextField.isComplete)
-        
-        // Try to exceed the max length of this valid card
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "50768012341234123")
-        
-        // Check that we didn't let the card go past max length and that we are still valid
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertTrue(foragePanTextField.isValid)
-        XCTAssertTrue(foragePanTextField.isComplete)
+    // MARK: - Initialization Tests
+    
+    // TODO: default to isValid = true on initialization
+    func test_initialization_shouldBeEmptyAndInvalid() {
+        XCTAssertNotNil(foragePANTextField)
+        XCTAssertTrue(foragePANTextField.isEmpty)
+        XCTAssertFalse(foragePANTextField.isValid)
+        XCTAssertFalse(foragePANTextField.isComplete)
     }
     
-    func test_givenTooFewDigits_shouldBeValid() {
-        let foragePanTextField = ForagePANTextField()
-        foragePanTextField.delegate = self
+    func test_textField_enterNumericString_shouldReturnTrue() {
+        let changesAllowed = foragePANTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "1234")
         
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "12341")
-        
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertTrue(foragePanTextField.isValid)
-        XCTAssertFalse(foragePanTextField.isComplete)
-        
+        XCTAssertTrue(changesAllowed)
     }
     
-    func test_givenInvalidCard_shouldReturnInvalid() {
-        let foragePanTextField = ForagePANTextField()
-        foragePanTextField.delegate = self
+    func test_textField_pressBackspace_shouldReturnTrue() {
+        let changesAllowed = foragePANTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "")
         
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "123412")
-        
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertFalse(foragePanTextField.isValid)
-        XCTAssertFalse(foragePanTextField.isComplete)
-        
+        XCTAssertTrue(changesAllowed)
     }
     
-    func test_givenInvalidCard_shouldReturnIdentifying() {
-        let foragePanTextField = ForagePANTextField()
-        foragePanTextField.delegate = self
+    func test_textField_nonNumericStr_shouldReturnFalse() {
+        let changesAllowed = foragePANTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "abcdef")
         
-        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "50768012341234")
-        
-        XCTAssertFalse(foragePanTextField.isEmpty)
-        XCTAssertFalse(foragePanTextField.isFirstResponder)
-        XCTAssertTrue(foragePanTextField.isValid)
-        XCTAssertFalse(foragePanTextField.isComplete)
-        
+        XCTAssertFalse(changesAllowed)
     }
     
-    func test_forageElementDelegate_focusDidChange() {
-        let foragePanTextField = ForagePANTextField()
+    func test_textField_pressSpace_shouldReturnFalse() {
+        let changesAllowed = foragePANTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: " ")
         
-        let expectedIsFirstResponder = true
-        let expectedIsEmpty = false
-        let expectedIsValid = true
-        let expectedIsComplete = false
-        
-        foragePanTextField.delegate = self
-        foragePanTextField.delegate?.focusDidChange(
-            mockState(
-                isFirstResponder: expectedIsFirstResponder,
-                isEmpty: expectedIsEmpty,
-                isValid: expectedIsValid,
-                isComplete: expectedIsComplete
-            )
-        )
-        
-        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
-        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
-        XCTAssertEqual(expectedIsValid, observableState?.isValid)
-        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
-    }
-    
-    func test_forageElementDelegate_textFieldDidChange() {
-        let foragePanTextField = ForagePANTextField()
-        
-        let expectedIsFirstResponder = false
-        let expectedIsEmpty = true
-        let expectedIsValid = false
-        let expectedIsComplete = true
-        
-        foragePanTextField.delegate = self
-        foragePanTextField.delegate?.textFieldDidChange(
-            mockState(
-                isFirstResponder: expectedIsFirstResponder,
-                isEmpty: expectedIsEmpty,
-                isValid: expectedIsValid,
-                isComplete: expectedIsComplete
-            )
-        )
-        
-        XCTAssertEqual(expectedIsFirstResponder, observableState?.isFirstResponder)
-        XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
-        XCTAssertEqual(expectedIsValid, observableState?.isValid)
-        XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
-    }
-}
-
-extension ForagePANTextFieldTests: ForageElementDelegate {
-    func focusDidChange(_ state: ObservableState) {
-        observableState = state
-    }
-    
-    func textFieldDidChange(_ state: ObservableState) {
-        observableState = state
+        XCTAssertFalse(changesAllowed)
     }
 }

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -24,11 +24,10 @@ final class ForagePANTextFieldTests: XCTestCase {
     
     // MARK: - Initialization Tests
     
-    // TODO: default to isValid = true on initialization
-    func test_initialization_shouldBeEmptyAndInvalid() {
+    func test_initialization_shouldBeEmptyAndValid() {
         XCTAssertNotNil(foragePANTextField)
         XCTAssertTrue(foragePANTextField.isEmpty)
-        XCTAssertFalse(foragePANTextField.isValid)
+        XCTAssertTrue(foragePANTextField.isValid)
         XCTAssertFalse(foragePANTextField.isComplete)
     }
     

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -20,15 +20,15 @@ final class MaskedUITextFieldTests: XCTestCase {
     
     override func tearDown() {
         maskedTextField = nil
+        ForageSDK.shared.environment = .sandbox
     }
     
     // MARK: - Initialization Tests
     
-    // TODO: default to isValid = true on initialization
-    func test_initialization_shouldBeEmptyAndInvalid() {
+    func test_initialization_shouldBeEmptyAndValid() {
         XCTAssertNotNil(maskedTextField)
         XCTAssertTrue(maskedTextField.isEmpty)
-        XCTAssertFalse(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
     }
     
@@ -54,7 +54,17 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertEqual(ForageSDK.shared.panNumber, "50770812345678")
     }
     
-    func testValidation_invalidCard_shouldBeInvalid() {
+    func testValidation_identifyingIIN_shouldBeValid() {
+        maskedTextField.text = "12345"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "12345")
+    }
+    
+    func testValidation_invalidIIN_shouldBeInvalid() {
         maskedTextField.text = "123412"
         maskedTextField.textFieldDidChange()
         
@@ -87,6 +97,17 @@ final class MaskedUITextFieldTests: XCTestCase {
     }
     
     // MARK: - Validation with special cards
+    
+    func testValidation_specialButProd_shouldBeInvalidAndIncomplete() {
+        ForageSDK.shared.environment = .prod
+        maskedTextField.text = "4444444444444454"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertFalse(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "4444444444444454")
+    }
     
     func testValidation_specialInsufficientFundsCard_shouldBeValid() {
         maskedTextField.text = "4444444444444451"
@@ -136,6 +157,16 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
         XCTAssertEqual(ForageSDK.shared.panNumber, "99991234")
+    }
+    
+    func testValidation_zeroEbtCashCard() {
+        maskedTextField.text = "6543 2123 1234 1234"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "6543212312341234")
     }
 
     

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -1,0 +1,242 @@
+//
+//  MaskedUITextFieldTests.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-08-14.
+//
+
+import XCTest
+@testable import ForageSDK
+
+final class MaskedUITextFieldTests: XCTestCase {
+    var maskedTextField: MaskedUITextField!
+    
+    override func setUp() {
+        ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        ForageSDK.shared.service = nil
+        ForageSDK.shared.panNumber = ""
+        maskedTextField = MaskedUITextField()
+    }
+    
+    override func tearDown() {
+        maskedTextField = nil
+    }
+    
+    // MARK: - Initialization Tests
+    
+    // TODO: default to isValid = true on initialization
+    func test_initialization_shouldBeEmptyAndInvalid() {
+        XCTAssertNotNil(maskedTextField)
+        XCTAssertTrue(maskedTextField.isEmpty)
+        XCTAssertFalse(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+    }
+    
+    // MARK: - Validation Tests
+    
+    func testValidation_valid16DigitCard_shouldBeValid() {
+        maskedTextField.text = "50770812 3456 7890"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081234567890")
+    }
+    
+    func testValidation_partiallyIdentifying16DigitCard_shouldBeValid() {
+        maskedTextField.text = "50770812 3456 78"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "50770812345678")
+    }
+    
+    func testValidation_invalidCard_shouldBeInvalid() {
+        maskedTextField.text = "123412"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertFalse(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "123412")
+    }
+    
+    func testValidation_validCardWithExtraDigits_shouldReturnInvalid() {
+        let expectedPAN = "5077081234567890"
+        maskedTextField.text = expectedPAN
+        maskedTextField.textFieldDidChange()
+        
+        // Check for valid state
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertFalse(maskedTextField.isFirstResponder)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        
+        // Try to exceed the max length of this valid card
+        maskedTextField.text = "50770812345678901"
+        
+        // Check that we didn't let the card go past max length and that we are still valid
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertFalse(maskedTextField.isFirstResponder)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, expectedPAN)
+    }
+    
+    // MARK: Masking
+    
+    func testMasking_valid16DigitCard_shouldApply16Mask() {
+        maskedTextField.text = "50770812 3456 7890"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "5077 0812 3456 7890")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081234567890")
+    }
+    
+    func testMasking_sixDigits_shouldApply16Mask() {
+        maskedTextField.text = "123456"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "1234 56")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "123456")
+    }
+    
+    func testMasking_lessThanSixDigits_shouldNotApplyMask() {
+        maskedTextField.text = "12345"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "12345")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "12345")
+    }
+    
+    func testMasking_16DigitInProgress_shouldApply16Mask() {
+        maskedTextField.text = "507708 1"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "5077 081")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081")
+    }
+    
+    func testMasking_invalid16Digit_shouldApply16Mask() {
+        maskedTextField.text = "1234567812345678"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "1234567812345678")
+    }
+    
+    func testMasking_valid18Digit_shouldApply18Mask() {
+        maskedTextField.text = "600890123456789012"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "600890 1234 56789 01 2")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "600890123456789012")
+    }
+    
+    func testMasking_valid19Digit_shouldApply19Mask() {
+        maskedTextField.text = "5077031234567890123"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "507703 1234 5678 901 23")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5077031234567890123")
+    }
+    
+    // MARK: Masking with backspace
+    
+    func testMasking_backspaceAtEnd_shouldRemoveLastChar() {
+        maskedTextField.text = "5077031111111111121"
+        maskedTextField.textFieldDidChange()
+        
+        // move cursor to end of text
+        moveCursor(by: maskedTextField.text?.count ?? 19)
+        pressBackspace()
+        let precedingChar = getPrecedingChar()
+        let expectedPAN = "507703 1111 1111 111 2"
+        
+        XCTAssertEqual(maskedTextField.text, expectedPAN)
+        XCTAssertEqual(precedingChar, "2")
+        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+    }
+    
+    func testMasking_backspaceChangeIIN_shouldChangeMask() {
+        maskedTextField.text = "5077031000000000000"
+        maskedTextField.textFieldDidChange()
+        
+        // move cursor to end of IIN
+        moveCursor(by: 6)
+        self.pressBackspace()
+        let precedingChar = getPrecedingChar()
+        let expectedPAN = "5077 0100 0000 0000"
+        
+        // Now uses New Hampshire 16-digit mask
+        XCTAssertEqual(maskedTextField.text, "5077 0100 0000 0000")
+        XCTAssertEqual(precedingChar, " ")
+        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+    }
+    
+    func testMasking_backspaceChangeIntermediateDigit_shouldShiftPAN() {
+        maskedTextField.text = "50770392111111111111"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "507703 9211 1111 111 11")
+        
+        // move cursor to right of first "2" char
+        moveCursor(by: 9)
+        self.pressBackspace()
+        let precedingChar = getPrecedingChar()
+        
+        let expectedPAN = "507703 9111 1111 111 1"
+        
+        // did cursor move back to char preceding "2" character
+        XCTAssertEqual(precedingChar, "9")
+        // did remove the "2" character and shift the PAN
+        XCTAssertEqual(maskedTextField.text, expectedPAN)
+        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+    }
+    
+    func testMasking_backspaceOnGap_shouldOnlyMoveCursor() {
+        maskedTextField.text = "50770311111111111111"
+        maskedTextField.textFieldDidChange()
+        
+        let expectedPAN = "507703 1111 1111 111 11"
+        XCTAssertEqual(maskedTextField.text, expectedPAN)
+        
+        // move cursor to the immediate right of first gap (" ") char
+        moveCursor(by: 7)
+        self.pressBackspace()
+        let precedingChar = getPrecedingChar()
+        
+        // did cursor move back to char preceding the gap (" ") character
+        XCTAssertEqual(precedingChar, "3")
+        // did not change display text, only moved the cursor
+        XCTAssertEqual(maskedTextField.text, expectedPAN)
+        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+    }
+    
+    func moveCursor(by offset: Int) {
+        var cursorOffset = maskedTextField.offset(from: maskedTextField.beginningOfDocument, to: maskedTextField.selectedTextRange!.start)
+        cursorOffset += offset
+        
+        if let newPosition = maskedTextField.position(from: maskedTextField.beginningOfDocument, offset: cursorOffset) {
+            maskedTextField.selectedTextRange = maskedTextField.textRange(from: newPosition, to: newPosition)
+        }
+    }
+    
+    func removeWhitespace(from text: String) -> String {
+        return text.replacingOccurrences(of: " ", with: "")
+    }
+    
+    func pressBackspace() {
+        maskedTextField.deleteBackward()
+        maskedTextField.textFieldDidChange()
+    }
+    
+    private func getPrecedingChar() -> Character {
+        let newCursorOffset = maskedTextField.offset(from: maskedTextField.beginningOfDocument, to: maskedTextField.selectedTextRange!.start)
+        let previousIndex = maskedTextField.text!.index(maskedTextField.text!.startIndex, offsetBy: newCursorOffset - 1)
+        return maskedTextField.text![previousIndex]
+    }
+}

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -64,7 +64,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertEqual(ForageSDK.shared.panNumber, "123412")
     }
     
-    func testValidation_validCardWithExtraDigits_shouldReturnInvalid() {
+    func testValidation_validCardWithExtraDigits_shouldBeInvalid() {
         let expectedPAN = "5077081234567890"
         maskedTextField.text = expectedPAN
         maskedTextField.textFieldDidChange()
@@ -85,6 +85,59 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertTrue(maskedTextField.isComplete)
         XCTAssertEqual(ForageSDK.shared.panNumber, expectedPAN)
     }
+    
+    // MARK: - Validation with special cards
+    
+    func testValidation_specialInsufficientFundsCard_shouldBeValid() {
+        maskedTextField.text = "4444444444444451"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "4444444444444451")
+    }
+    
+    func testValidation_specialInvalidCardNum_shouldBeValid() {
+        maskedTextField.text = "5555555555555514"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5555555555555514")
+    }
+    
+    func testValidation_specialExpiredCardNum_shouldBeValid() {
+        maskedTextField.text = "5555555555555554"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "5555555555555554")
+    }
+    
+    func testValidation_completeSpecial9999Card_shouldBeValid() {
+        maskedTextField.text = "9999 1234 1111 1111"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertTrue(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "9999123411111111")
+    }
+    
+    func testValidation_partialSpecial9999Card_shouldBeValidButIncomplete() {
+        maskedTextField.text = "9999 1234"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertFalse(maskedTextField.isEmpty)
+        XCTAssertTrue(maskedTextField.isValid)
+        XCTAssertFalse(maskedTextField.isComplete)
+        XCTAssertEqual(ForageSDK.shared.panNumber, "99991234")
+    }
+
     
     // MARK: Masking
     

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -13,6 +13,8 @@ final class MaskedUITextFieldTests: XCTestCase {
     
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
+        // .setup() currently doesn't allow us to update the environment
+        ForageSDK.shared.environment = .sandbox
         ForageSDK.shared.service = nil
         ForageSDK.shared.panNumber = ""
         maskedTextField = MaskedUITextField()
@@ -20,7 +22,6 @@ final class MaskedUITextFieldTests: XCTestCase {
     
     override func tearDown() {
         maskedTextField = nil
-        ForageSDK.shared.environment = .sandbox
     }
     
     // MARK: - Initialization Tests
@@ -162,7 +163,7 @@ final class MaskedUITextFieldTests: XCTestCase {
     func testValidation_zeroEbtCashCard() {
         maskedTextField.text = "6543 2123 1234 1234"
         maskedTextField.textFieldDidChange()
-        
+
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)


### PR DESCRIPTION
## What

Apply dynamic masking to the PAN based on expected card length.

Screen recording: https://joinforage.slack.com/archives/C031SJGSZV0/p1692122220569439

## Test Plan
Unit tests to validate the adjusted mask.

## How

can be released as-is. A later PR will make isValid default to true on empty state.
