### PR TITLE
[FX-415] iOS do not store pannumber in foragesdkshared

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ func tokenizeEBTCard(
     bearerToken: String,
     merchantAccount: String,
     customerID: String,
+    foragePanTextEdit: ForagePANTextField,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
 )
 ```

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -159,7 +159,8 @@ class CardNumberView: UIView {
         ForageSDK.shared.tokenizeEBTCard(
             bearerToken: ClientSharedData.shared.bearerToken,
             merchantAccount: ClientSharedData.shared.merchantID,
-            customerID: ClientSharedData.shared.customerID) { result in
+            customerID: ClientSharedData.shared.customerID,
+            foragePanTextEdit: panNumberTextField) { result in
                 self.printResult(result: result)
             }
     }

--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -18,7 +18,9 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement {
     }
     
     public func clearText() {
-        ForageSDK.shared.panNumber = ""
+        self.actualPan = ""
+        self.maskedPan = ""
+        self.textField.text = ""
     }
     
     /// BorderWidth for the text field
@@ -43,7 +45,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement {
     }
     
     @IBInspectable public var isEmpty: Bool {
-        get { return ForageSDK.shared.panNumber.isEmpty }
+        get { return self.actualPan.isEmpty }
     }
     
     private var _isValid: Bool = true
@@ -248,8 +250,8 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement {
         becomeFirstResponder()
     }
     
-    internal var actualText: String = ""
-    internal var maskedText: String = ""
+    internal var actualPan: String = ""
+    internal var maskedPan: String = ""
 }
 
 // MARK: - UITextFieldDelegate
@@ -325,7 +327,7 @@ extension ForagePANTextField: UITextFieldDelegate {
     }
     
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        var newString = (maskedText as NSString).replacingCharacters(in: range, with: string) // Apply new text
+        var newString = (maskedPan as NSString).replacingCharacters(in: range, with: string) // Apply new text
 
         // Remove all whitespaces
         newString = newString.replacingOccurrences(of: " ", with: "").filter("0123456789".contains)
@@ -338,8 +340,8 @@ extension ForagePANTextField: UITextFieldDelegate {
         // If the string is less than 6 digits, apply no mask.
         // Prior to seeing 6 digits, the PAN is considered valid but incomplete.
         if newString.count < 6 {
-            self.actualText = newString
-            self.maskedText = newString
+            self.actualPan = newString
+            self.maskedPan = newString
             textField.text = newString
             _isValid = true
             _isComplete = false
@@ -373,13 +375,11 @@ extension ForagePANTextField: UITextFieldDelegate {
         }
         
         // Store the string's actual value for submitting later
-        // TODO: Stop sharing the PAN state and instead have each PAN hold it's own state
-        ForageSDK.shared.panNumber = newString
-        self.actualText = newString
+        self.actualPan = newString
         // Get the masked version of the string
         newString = formatText(text: newString, maskToApply: maskToApply)
         // Store the visual string for reference on next input
-        self.maskedText = newString
+        self.maskedPan = newString
         // And show the masked string to the user
         textField.text = newString
         return false

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -25,7 +25,6 @@ public class ForageSDK {
     
     private static var config: Config?
     internal var service: ForageService?
-    internal var panNumber: String = ""
     internal var environment: EnvironmentTarget = .sandbox
     
     public static let shared = ForageSDK()

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -27,7 +27,7 @@ public class ForageSDK {
     internal var service: ForageService?
     internal var environment: EnvironmentTarget = .sandbox
     
-    public static let shared = ForageSDK()
+    public static var shared = ForageSDK()
     
     // MARK: Init
     
@@ -71,5 +71,6 @@ public class ForageSDK {
      */
     public class func setup(_ config: Config) {
         ForageSDK.config = config
+        ForageSDK.shared = ForageSDK()
     }
 }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -23,6 +23,7 @@ protocol ForageSDKService: AnyObject {
         bearerToken: String,
         merchantAccount: String,
         customerID: String,
+        foragePanTextEdit: ForagePANTextField,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
     
     /// Check balance for a given EBT Card
@@ -62,12 +63,13 @@ extension ForageSDK: ForageSDKService {
         bearerToken: String,
         merchantAccount: String,
         customerID: String,
+        foragePanTextEdit: ForagePANTextField,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
         let request = ForagePANRequestModel(
             authorization: bearerToken,
             merchantAccount: merchantAccount,
-            panNumber: panNumber,
+            panNumber: foragePanTextEdit.actualPan,
             type: CardType.EBT.rawValue,
             reusable: true,
             customerID: customerID

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -185,6 +185,16 @@ final class ForagePANTextFieldTests: XCTestCase {
         XCTAssertEqual(numLessThan6Digits, foragePanTextField.actualText)
     }
     
+    func test_maskAppliedAt6Digits() {
+        let foragePanTextField = ForagePANTextField()
+        let sixDigitNum = "123456"
+        let sixDigitNumWithMask = "1234 56"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: sixDigitNum)
+
+        XCTAssertEqual(sixDigitNumWithMask, foragePanTextField.maskedText)
+        XCTAssertEqual(sixDigitNum, foragePanTextField.actualText)
+    }
+    
     func test_16DigitMaskAppliedInvalidNum() {
         let foragePanTextField = ForagePANTextField()
         let invalidNum = "1234567890123456789"

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -181,8 +181,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let numLessThan6Digits = "12345"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: numLessThan6Digits)
 
-        XCTAssertEqual(numLessThan6Digits, foragePanTextField.maskedText)
-        XCTAssertEqual(numLessThan6Digits, foragePanTextField.actualText)
+        XCTAssertEqual(numLessThan6Digits, foragePanTextField.maskedPan)
+        XCTAssertEqual(numLessThan6Digits, foragePanTextField.actualPan)
     }
     
     func test_maskAppliedAt6Digits() {
@@ -191,8 +191,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let sixDigitNumWithMask = "1234 56"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: sixDigitNum)
 
-        XCTAssertEqual(sixDigitNumWithMask, foragePanTextField.maskedText)
-        XCTAssertEqual(sixDigitNum, foragePanTextField.actualText)
+        XCTAssertEqual(sixDigitNumWithMask, foragePanTextField.maskedPan)
+        XCTAssertEqual(sixDigitNum, foragePanTextField.actualPan)
     }
     
     func test_16DigitMaskAppliedInvalidNum() {
@@ -201,8 +201,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let invalidNumWithMask = "1234 5678 9012 3456 789"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: invalidNum)
 
-        XCTAssertEqual(invalidNumWithMask, foragePanTextField.maskedText)
-        XCTAssertEqual(invalidNum, foragePanTextField.actualText)
+        XCTAssertEqual(invalidNumWithMask, foragePanTextField.maskedPan)
+        XCTAssertEqual(invalidNum, foragePanTextField.actualPan)
     }
     
     func test_16DigitMaskAppliedValidNum() {
@@ -211,8 +211,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let validNumWithMask = "5076 8012 3456 7890"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
 
-        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
-        XCTAssertEqual(validNum, foragePanTextField.actualText)
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedPan)
+        XCTAssertEqual(validNum, foragePanTextField.actualPan)
     }
     
     func test_18DigitMaskAppliedValidNum() {
@@ -221,8 +221,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let validNumWithMask = "600890 1234 56789 01 2"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
 
-        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
-        XCTAssertEqual(validNum, foragePanTextField.actualText)
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedPan)
+        XCTAssertEqual(validNum, foragePanTextField.actualPan)
     }
     
     func test_19DigitMaskAppliedValidNum() {
@@ -231,8 +231,8 @@ final class ForagePANTextFieldTests: XCTestCase {
         let validNumWithMask = "507703 1234 5678 901 23"
         _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
 
-        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
-        XCTAssertEqual(validNum, foragePanTextField.actualText)
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedPan)
+        XCTAssertEqual(validNum, foragePanTextField.actualPan)
     }
 }
 

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -54,8 +54,6 @@ final class ForagePANTextFieldTests: XCTestCase {
         observableState = nil
     }
     
-    
-    
     func test_givenValidCard_shouldReturnValid() {
         let foragePanTextField = ForagePANTextField()
         foragePanTextField.delegate = self
@@ -176,6 +174,55 @@ final class ForagePANTextFieldTests: XCTestCase {
         XCTAssertEqual(expectedIsEmpty, observableState?.isEmpty)
         XCTAssertEqual(expectedIsValid, observableState?.isValid)
         XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
+    }
+    
+    func test_maskNotAppliedLessThan6Digits() {
+        let foragePanTextField = ForagePANTextField()
+        let numLessThan6Digits = "12345"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: numLessThan6Digits)
+
+        XCTAssertEqual(numLessThan6Digits, foragePanTextField.maskedText)
+        XCTAssertEqual(numLessThan6Digits, foragePanTextField.actualText)
+    }
+    
+    func test_16DigitMaskAppliedInvalidNum() {
+        let foragePanTextField = ForagePANTextField()
+        let invalidNum = "1234567890123456789"
+        let invalidNumWithMask = "1234 5678 9012 3456 789"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: invalidNum)
+
+        XCTAssertEqual(invalidNumWithMask, foragePanTextField.maskedText)
+        XCTAssertEqual(invalidNum, foragePanTextField.actualText)
+    }
+    
+    func test_16DigitMaskAppliedValidNum() {
+        let foragePanTextField = ForagePANTextField()
+        let validNum = "5076801234567890"
+        let validNumWithMask = "5076 8012 3456 7890"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
+
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
+        XCTAssertEqual(validNum, foragePanTextField.actualText)
+    }
+    
+    func test_18DigitMaskAppliedValidNum() {
+        let foragePanTextField = ForagePANTextField()
+        let validNum = "600890123456789012"
+        let validNumWithMask = "600890 1234 56789 01 2"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
+
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
+        XCTAssertEqual(validNum, foragePanTextField.actualText)
+    }
+    
+    func test_19DigitMaskAppliedValidNum() {
+        let foragePanTextField = ForagePANTextField()
+        let validNum = "5077031234567890123"
+        let validNumWithMask = "507703 1234 5678 901 23"
+        _ = foragePanTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: validNum)
+
+        XCTAssertEqual(validNumWithMask, foragePanTextField.maskedText)
+        XCTAssertEqual(validNum, foragePanTextField.actualText)
     }
 }
 


### PR DESCRIPTION
## What
Move the PAN value from shared storage to being owned by the individual PAN element itself.

## Test Plan
Adjust unit tests.
