### PR TITLE
[POP-92] Code coverage fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ fastlane/test_output
 
 # Code Coverage
 cobertura.xml
+
+# macOS
+.DS_Store

--- a/.slather.yml
+++ b/.slather.yml
@@ -2,5 +2,7 @@ coverage_service: cobertura_xml
 xcodeproj: Sample/SampleForageSDK.xcodeproj
 scheme: ForageSDK
 ignore:
+  - ../Library/*
+  - ../../Library/*
   - ../../../Library/*
   - Tests/*


### PR DESCRIPTION
## What
Minor quality of life improvements.

- Add `.DS_Store` to `.gitignore`
- Add additional `Library` paths 

## Why
We want to make sure to ignore `Library` locally when generating coverage reports even if it's on a slightly different relative path. Within GitHub, it's 3 layers above the project dir. My local machine is 2, and it's possible some devs have 1 if they're cloning their project straight to their home. 

I noticed `.DS_Store` files were being staged while I was updating this, so I added it to `.gitignore`. 
