### PR TITLE
[FX-426] Disable and clear PIN field on submit

### DIFF
--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -240,12 +240,12 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         textField.clearText()
     }
     
-    public func enable() {
+    internal func enable() {
         self.textColor = .black
         self.isUserInteractionEnabled = true
     }
     
-    public func disable() {
+    internal func disable() {
         self.textColor = .lightGray
         self.isUserInteractionEnabled = false
     }

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -239,6 +239,21 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     public func clearText() {
         textField.clearText()
     }
+    
+    public func enable() {
+        self.textColor = .black
+        self.isUserInteractionEnabled = true
+    }
+    
+    public func disable() {
+        self.textColor = .lightGray
+        self.isUserInteractionEnabled = false
+    }
+    
+    internal func handleSubmissionCompletion() {
+        self.clearText()
+        self.enable()
+    }
 }
 
 extension ForagePINTextField: VaultWrapperDelegate {

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -82,6 +82,8 @@ extension ForageSDK: ForageSDKService {
         paymentMethodReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
+            foragePinTextEdit.disable()
+            
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
                 case .success(let model):
@@ -96,13 +98,18 @@ extension ForageSDK: ForageSDKService {
                                 merchantID: merchantAccount,
                                 xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                             )
-                            self.service?.checkBalance(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)
+                            self.service?.checkBalance(pinCollector: foragePinTextEdit.collector!, request: request) { result in
+                                foragePinTextEdit.handleSubmissionCompletion()
+                                completion(result)
+                            }
                             
                         case .failure(let error):
+                            foragePinTextEdit.handleSubmissionCompletion()
                             completion(.failure(error))
                         }
                     }
                 case .failure(let error):
+                    foragePinTextEdit.handleSubmissionCompletion()
                     completion(.failure(error))
                 }
             }
@@ -114,6 +121,8 @@ extension ForageSDK: ForageSDKService {
         paymentReference: String,
         foragePinTextEdit: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
+            foragePinTextEdit.disable()
+
             service?.getXKey(bearerToken: bearerToken, merchantAccount: merchantAccount) { result in
                 switch result {
                 case .success(let model):
@@ -131,16 +140,22 @@ extension ForageSDK: ForageSDKService {
                                         merchantID: merchantAccount,
                                         xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                                     )
-                                    self.service?.capturePayment(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)
+                                    self.service?.capturePayment(pinCollector: foragePinTextEdit.collector!, request: request) { result in
+                                        foragePinTextEdit.handleSubmissionCompletion()
+                                        completion(result)
+                                    }
                                 case .failure(let error):
+                                    foragePinTextEdit.handleSubmissionCompletion()
                                     completion(.failure(error))
                                 }
                             }
                         case .failure(let error):
+                            foragePinTextEdit.handleSubmissionCompletion()
                             completion(.failure(error))
                         }
                     }
                 case .failure(let error):
+                    foragePinTextEdit.handleSubmissionCompletion()
                     completion(.failure(error))
                 }
             }

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -102,6 +102,39 @@ final class ForagePINTextFieldTests: XCTestCase {
         XCTAssertEqual(expectedIsValid, observableState?.isValid)
         XCTAssertEqual(expectedIsComplete, observableState?.isComplete)
     }
+    
+    func test_disable() {
+        let foragePinTextField = ForagePINTextField()
+        foragePinTextField.disable()
+        
+        XCTAssertEqual(foragePinTextField.isUserInteractionEnabled, false)
+        XCTAssertEqual(foragePinTextField.textColor, .lightGray)
+    }
+    
+    func test_enable() {
+        let foragePinTextField = ForagePINTextField()
+        foragePinTextField.enable()
+        
+        XCTAssertEqual(foragePinTextField.isUserInteractionEnabled, true)
+        XCTAssertEqual(foragePinTextField.textColor, .black)
+    }
+    
+    class TestForagePINTextField: ForagePINTextField {
+        var didCallClearText = false
+        
+        override public func clearText() {
+            didCallClearText = true
+        }
+    }
+    
+    func test_handleSubmissionCompletion_shouldEnableAndClearText() {
+        let foragePinTextField = TestForagePINTextField(frame: CGRect())
+        foragePinTextField.handleSubmissionCompletion()
+        
+        XCTAssertEqual(foragePinTextField.textColor, .black)
+        XCTAssertEqual(foragePinTextField.isUserInteractionEnabled, true)
+        XCTAssertTrue(foragePinTextField.didCallClearText, "clearText method should be called")
+    }
 }
 
 extension ForagePINTextFieldTests: ForageElementDelegate {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->
- Add internal `PINTextFeild.enable` and `PINTextFeild.disable` methods 
- Clear text after polling response is received or if there's another failure (e.g. getting encryption key)
- Disable PIN text field on submit (visually + functionally) 
- Enable PIN text field after submission is complete


Screen recording: https://joinforage.slack.com/archives/C031SJGSZV0/p1692230961730419

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->
https://linear.app/joinforage/issue/FX-426/clear-pin-text-on-submit-in-ios-sdk

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

Added unit tests

- ✅  iOS QA Tests passed locally
- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is. 