### PR TITLE
[FX-469] Set the PIN field to be centered text

### DIFF
--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -76,6 +76,7 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.keyboardType = UIKeyboardType.phonePad
         textField.isSecureTextEntry = true
+        textField.textAlignment = .center
         
         let regexDigit = try! NSRegularExpression(pattern: "\\d")
         

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -63,6 +63,7 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         configuration.validationRules = rules
         textField.configuration = configuration
         textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.textAlignment = .center
 
         textField.anchor(
             top: self.topAnchor,


### PR DESCRIPTION
## What
Set the PIN field to be centered text.

VGS:
<img width="381" alt="Screenshot 2023-08-21 at 4 58 54 PM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/238dd561-eeb6-42c9-975b-6b3aa5f9abfa">

BT:
<img width="365" alt="Screenshot 2023-08-21 at 5 00 38 PM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/df352a0f-9f6e-47c8-8b52-f26a872cae1f">

