### PR TITLE
[FX-464] Allow up to 19 digits for invalid + special cards

### DIFF
--- a/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
@@ -19,6 +19,7 @@ internal enum MaskPattern : String {
     case sixteenDigits = "#### #### #### ####"
     case eighteenDigits = "###### #### ##### ## #"
     case nineteenDigits = "###### #### #### ### ##"
+    case noIINmatch = "#### #### #### #### ###"
 }
 
 internal class MaskedUITextField : UITextField, ObservableState {
@@ -80,7 +81,7 @@ internal class MaskedUITextField : UITextField, ObservableState {
     
     // MARK: - Text Handling
     private func trimTrailingDigits(_ newUnmaskedText: String, stateIIN: StateIIN?) -> String {
-        let maxPanLength = min(newUnmaskedText.count, stateIIN?.panLength ?? 16)
+        let maxPanLength = min(newUnmaskedText.count, stateIIN?.panLength ?? 19)
         
         return String(newUnmaskedText.prefix(maxPanLength))
     }
@@ -130,7 +131,7 @@ internal class MaskedUITextField : UITextField, ObservableState {
                 return MaskPattern.nineteenDigits
             }
         }
-        return MaskPattern.sixteenDigits
+        return MaskPattern.noIINmatch
     }
     
     private func applyMask(_ newUnmaskedText: String, maskPattern: MaskPattern) {

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -205,12 +205,36 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertEqual(ForageSDK.shared.panNumber, "5077081")
     }
     
-    func testMasking_invalid16Digit_shouldApply16Mask() {
+    func testMasking_invalid16Digit_shouldApplyNoIINMatchMask() {
         maskedTextField.text = "1234567812345678"
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678")
         XCTAssertEqual(ForageSDK.shared.panNumber, "1234567812345678")
+    }
+    
+    func testMasking_invalid17Digit_shouldApplyNoIINMatchMask() {
+        maskedTextField.text = "12345678123456781"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 1")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "12345678123456781")
+    }
+    
+    func testMasking_invalid18Digit_shouldApplyNoIINMatchMask() {
+        maskedTextField.text = "123456781234567812"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 12")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "123456781234567812")
+    }
+    
+    func testMasking_invalid19Digit_shouldApplyNoIINMatchMask() {
+        maskedTextField.text = "1234567812345678123"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 123")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "1234567812345678123")
     }
     
     func testMasking_valid18Digit_shouldApply18Mask() {
@@ -227,6 +251,14 @@ final class MaskedUITextFieldTests: XCTestCase {
         
         XCTAssertEqual(maskedTextField.text, "507703 1234 5678 901 23")
         XCTAssertEqual(ForageSDK.shared.panNumber, "5077031234567890123")
+    }
+    
+    func testMasking_validSpecialCard_shouldApplyNoIINMatchMask() {
+        maskedTextField.text = "9999123412341234123"
+        maskedTextField.textFieldDidChange()
+        
+        XCTAssertEqual(maskedTextField.text, "9999 1234 1234 1234 123")
+        XCTAssertEqual(ForageSDK.shared.panNumber, "9999123412341234123")
     }
     
     // MARK: Masking with backspace


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Support mask for invalid and special cards (e.g. starts with 9999) when the entered PAN is greater than 16 digits
  - use 4 x 4 groups of chars and place the excess digits in the last char group (ex: XXXX XXXX XXXX XXXX XXX)

Screen recording: https://joinforage.slack.com/archives/C031SJGSZV0/p1692738518786379

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

Client wants to enter more than 16 digits during testing

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- Added unit tests

- ✅  iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is
