### PR TITLE
[FX-486] PAN uses num pad, PINs use phone pad

### DIFF
--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -147,7 +147,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
         tf.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         tf.borderStyle = .roundedRect
         tf.autocorrectionType = .no
-        tf.keyboardType = UIKeyboardType.phonePad
+        tf.keyboardType = UIKeyboardType.numberPad
         tf.accessibilityIdentifier = "tf_forage_ebt_text_field"
         tf.isAccessibilityElement = true
         return tf

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -58,7 +58,7 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         rules.add(rule: VGSValidationRulePattern(pattern: "^[0-9]+$", error: VGSValidationErrorType.pattern.rawValue))
         let configuration = VGSConfiguration(collector: (collector as! VGSCollectWrapper).vgsCollect, fieldName: "pin")
         configuration.type = .none
-        configuration.keyboardType = .numberPad
+        configuration.keyboardType = .phonePad
         configuration.maxInputLength = 4
         configuration.validationRules = rules
         textField.configuration = configuration


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

PAN (no letters)
<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/75358151-1305-43af-9a9b-f59a95845136" width="300px">

PIN inputs use telephone pad (with letters)
<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/f1fdbcc7-a0e5-444d-88f1-6aba66703282" width="300px">

**Remark: when I tested this on iOS 14.0.1 against an iPhone 8., the phone pad still appeared for the PAN field – but this feature seems to work on newer iPhones (tested with iPhone 14 using iOS 16.2)**

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

Better UX/CX

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅  iOS QA Tests passed locally
- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is
