### PR TITLE
[SYM-110] Enable border radius and background color customization

### DIFF
--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -48,6 +48,12 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         set { textField.borderColor = newValue }
     }
     
+    /// BorderRadius for the text field
+    @IBInspectable public var borderRadius: CGFloat {
+        get { return textField.borderRadius }
+        set { textField.borderRadius = newValue }
+    }
+    
     /// Padding for the text field
     @IBInspectable public var padding: UIEdgeInsets {
         get { return textField.padding }
@@ -65,6 +71,12 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     @IBInspectable public var textColor: UIColor? {
         get { return textField.textColor }
         set { textField.textColor = newValue }
+    }
+    
+    /// BackgroundColor for the text field
+    @IBInspectable public override var backgroundColor: UIColor? {
+        get { return textField.backgroundColor }
+        set { textField.backgroundColor = newValue }
     }
     
     /// Size of the text for the text field
@@ -139,7 +151,9 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         tf?.textColor = UIColor.black
         tf?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         tf?.borderWidth = 0.25
+        tf?.borderRadius = 4
         tf?.borderColor = UIColor.lightGray
+        tf?.backgroundColor = UIColor.white
         tf?.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         collector = tf?.collector
         

--- a/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
@@ -29,6 +29,8 @@ internal protocol InternalAppearance {
     var tfTintColor: UIColor? { get set }
     var borderWidth: CGFloat { get set }
     var borderColor: UIColor? { get set }
+    var borderRadius: CGFloat { get set }
+    var backgroundColor: UIColor? { get set }
     var font: UIFont? { get set }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -131,6 +131,15 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         }
     }
     
+    var borderRadius: CGFloat {
+        get {
+            return textField.layer.cornerRadius
+        }
+        set {
+            textField.layer.cornerRadius = newValue
+        }
+    }
+    
     var padding = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0) {
             didSet { setMainPaddings() }
     }
@@ -144,6 +153,18 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         }
         set {
             textField.layer.borderColor = newValue?.cgColor
+        }
+    }
+    
+    override var backgroundColor: UIColor? {
+        get {
+            guard let cgcolor = textField.layer.backgroundColor else {
+                return nil
+            }
+            return UIColor(cgColor: cgcolor)
+        }
+        set {
+            textField.layer.backgroundColor = newValue?.cgColor
         }
     }
     

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -91,6 +91,15 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         }
     }
     
+    var borderRadius: CGFloat {
+        get {
+            return textField.cornerRadius
+        }
+        set {
+            textField.cornerRadius = newValue
+        }
+    }
+    
     var padding: UIEdgeInsets {
         get {
             return textField.padding
@@ -106,6 +115,15 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         }
         set {
             textField.borderColor = newValue
+        }
+    }
+    
+    override var backgroundColor: UIColor? {
+        get {
+            return textField.backgroundColor
+        }
+        set {
+            textField.backgroundColor = newValue
         }
     }
     

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -120,31 +120,41 @@ final class ForagePINTextFieldTests: XCTestCase {
     }
     
     func test_backgroundColor() {
-        // Test VgsPinTextField background color
+        // Test ForagePINTextField background color
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.backgroundColor = .lightGray
         XCTAssertEqual(foragePinTextField.backgroundColor, .lightGray)
         
-        // Test BtPinTextField background color
-        let bTPinTextField = BasisTheoryTextFieldWrapper()
-        bTPinTextField.backgroundColor = .lightGray
-        XCTAssertEqual(bTPinTextField.backgroundColor, .lightGray)
+        // Test VGSTextFieldWrapper background color
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.backgroundColor = .lightGray
+        XCTAssertEqual(vgsTextFieldWrapper.backgroundColor, .lightGray)
         
-        // Test BtPinTextField background color = nil
-        bTPinTextField.backgroundColor = nil
-        XCTAssertEqual(bTPinTextField.backgroundColor, nil)
+        // Test BasisTheoryTextFieldWrapper background color
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.backgroundColor = .lightGray
+        XCTAssertEqual(btTextFieldWrapper.backgroundColor, .lightGray)
+        
+        // Test BasisTheoryTextFieldWrapper background color = nil
+        btTextFieldWrapper.backgroundColor = nil
+        XCTAssertEqual(btTextFieldWrapper.backgroundColor, nil)
     }
     
     func test_cornerRadius() {
-        // Test VgsPinTextField border radius
+        // Test ForagePINTextField border radius
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.borderRadius = 10
         XCTAssertEqual(foragePinTextField.borderRadius, 10)
         
-        // Test BtPinTextField border radius
-        let bTPinTextField = BasisTheoryTextFieldWrapper()
-        bTPinTextField.borderRadius = 10
-        XCTAssertEqual(bTPinTextField.borderRadius, 10)
+        // Test VGSTextFieldWrapper border radius
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.borderRadius = 10
+        XCTAssertEqual(vgsTextFieldWrapper.borderRadius, 10)
+        
+        // Test BasisTheoryTextFieldWrapper border radius
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.borderRadius = 10
+        XCTAssertEqual(btTextFieldWrapper.borderRadius, 10)
     }
     
     class TestForagePINTextField: ForagePINTextField {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -119,6 +119,20 @@ final class ForagePINTextFieldTests: XCTestCase {
         XCTAssertEqual(foragePinTextField.textColor, .black)
     }
     
+    func test_backgroundColor() {
+        let foragePinTextField = ForagePINTextField()
+        foragePinTextField.backgroundColor = .lightGray
+        
+        XCTAssertEqual(foragePinTextField.backgroundColor, .lightGray)
+    }
+    
+    func test_cornerRadius() {
+        let foragePinTextField = ForagePINTextField()
+        foragePinTextField.borderRadius = 10
+        
+        XCTAssertEqual(foragePinTextField.borderRadius, 10)
+    }
+    
     class TestForagePINTextField: ForagePINTextField {
         var didCallClearText = false
         

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -120,17 +120,31 @@ final class ForagePINTextFieldTests: XCTestCase {
     }
     
     func test_backgroundColor() {
+        // Test VgsPinTextField background color
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.backgroundColor = .lightGray
-        
         XCTAssertEqual(foragePinTextField.backgroundColor, .lightGray)
+        
+        // Test BtPinTextField background color
+        let bTPinTextField = BasisTheoryTextFieldWrapper()
+        bTPinTextField.backgroundColor = .lightGray
+        XCTAssertEqual(bTPinTextField.backgroundColor, .lightGray)
+        
+        // Test BtPinTextField background color = nil
+        bTPinTextField.backgroundColor = nil
+        XCTAssertEqual(bTPinTextField.backgroundColor, nil)
     }
     
     func test_cornerRadius() {
+        // Test VgsPinTextField border radius
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.borderRadius = 10
-        
         XCTAssertEqual(foragePinTextField.borderRadius, 10)
+        
+        // Test BtPinTextField border radius
+        let bTPinTextField = BasisTheoryTextFieldWrapper()
+        bTPinTextField.borderRadius = 10
+        XCTAssertEqual(bTPinTextField.borderRadius, 10)
     }
     
     class TestForagePINTextField: ForagePINTextField {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -119,7 +119,7 @@ final class ForagePINTextFieldTests: XCTestCase {
         XCTAssertEqual(foragePinTextField.textColor, .black)
     }
     
-    func test_backgroundColor() {
+    func test_BackgroundColor() {
         // Test ForagePINTextField background color
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.backgroundColor = .lightGray
@@ -140,7 +140,7 @@ final class ForagePINTextFieldTests: XCTestCase {
         XCTAssertEqual(btTextFieldWrapper.backgroundColor, nil)
     }
     
-    func test_cornerRadius() {
+    func test_CornerRadius() {
         // Test ForagePINTextField border radius
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.borderRadius = 10


### PR DESCRIPTION
## What

- Enable customization of styling of PIN input border radius and background color.

## Example
 Default TextField

<img width="340" alt="Screenshot 2023-08-24 at 11 02 53" src="https://github.com/teamforage/forage-ios-sdk/assets/136574617/38be8d0e-e3db-496a-a830-60de316991b0">

 Custom TextField

<img width="339" alt="Screenshot 2023-08-24 at 11 00 59" src="https://github.com/teamforage/forage-ios-sdk/assets/136574617/90d407db-7674-435d-a9f6-c5dcb3472c01">


## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally
