### PR TITLE
[FX-500] Add sdk_version to logs

### DIFF
--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -13,6 +13,7 @@ internal struct ForageLogContext {
     var paymentRef: String? = nil
     var paymentMethodRef: String? = nil
     var vaultType: VaultType? = nil
+    var sdkVersion: String = ForageSDK.version
 }
 
 internal struct ForageLoggerConfig {
@@ -134,7 +135,8 @@ internal class DatadogLogger : ForageLogger {
             ("merchant_ref", newContext.merchantRef),
             ("payment_method_ref", newContext.paymentMethodRef),
             ("payment_ref", newContext.paymentRef),
-            ("vault_type", newContext.vaultType?.rawValue)
+            ("vault_type", newContext.vaultType?.rawValue),
+            ("sdk_version", newContext.sdkVersion)
         ]
         
         for (key, value) in attributeMappings {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

Add `sdk_version` to Datadog log context/attributes

- [DD logs with `@sdk_version:3.0.7`](https://app.datadoghq.com/logs?query=service%3Aios-sdk%20env%3Astaging%20%40sdk_version%3A3.0.7&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1693251094263&to_ts=1693253039313&live=false)

<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/5938f3e9-6fd5-4e9a-83c9-453dd1221671" width="300px">
<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

Help us with monitoring, troubleshooting and tracking which version the client is using

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is
