### PR TITLE
[FX-509] Remove sentry from iOS SDK

### DIFF
--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |spec|
   spec.dependency 'VGSCollectSDK', '~> 1.11.2'
   spec.dependency 'LaunchDarkly', '~> 8.0.1'
   spec.dependency 'BasisTheoryElements', '~> 2.7.0'
-  spec.dependency 'Sentry', '~> 8.8.0'
   spec.resource_bundles = {
     'ForageIcon' => ['Sources/Resources/*']
   }

--- a/Package.swift
+++ b/Package.swift
@@ -32,11 +32,6 @@ let package = Package(
             url: "https://github.com/Basis-Theory/basistheory-ios",
             from: "2.7.0"
         ),
-        .package(
-            name: "Sentry",
-            url: "https://github.com/getsentry/sentry-cocoa",
-            from: "8.8.0"
-        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -47,7 +42,6 @@ let package = Package(
                 "VGSCollectSDK",
                 "LaunchDarkly",
                 "BasisTheoryElements",
-                "Sentry",
                 "DatadogPrivateFork"
             ],
             path: "Sources",

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import VGSCollectSDK
-import Sentry
 /**
  Environment base URL
  */
@@ -53,18 +52,6 @@ public class ForageSDK {
         self.logger = logger
         LDManager.shared.initialize(self.environment, logger: logger)
         VGSCollectLogger.shared.disableAllLoggers()
-                
-        if !isUnitTesting() {
-            SentrySDK.start { options in
-                options.dsn = "https://8fcdd8dc94aa892ed8fd4cdb20db90ee@o921422.ingest.sentry.io/4505665631813632"
-                options.debug = false
-                options.environment = String(describing: self.environment)
-                let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
-                options.failedRequestStatusCodes = [ httpStatusCodeRange ]
-                options.tracesSampleRate = 1.0
-                options.enableTracing = true
-            }
-        }
         let provider = Provider(logger: logger)
         self.service = LiveForageService(provider: provider, logger: logger)
     }


### PR DESCRIPTION
## What
Remove sentry from iOS SDK to avoid crashing GoPuff app
