### PR TITLE
[FX-415] Stop storing PAN in ForageSDK.shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ A component that securely accepts the PAN number. This field validates the PAN n
 private let panTextField: ForagePANTextField = {
     let tf = ForagePANTextField()
     tf.borderColor = .black
-    tf.accessibilityIdentifier = "tf_ebt_card_number"
     tf.placeholder = "EBT Card Number"
     return tf
 }()

--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ A component that securely accepts the PAN number. This field validates the PAN n
 ![Screen Shot 2022-10-31 at 10 19 27](https://user-images.githubusercontent.com/115553362/199017253-ee05dcf0-01c8-41dc-9662-9da525e573c9.png)
 
 ```swift
-private let panNumberTextField: ForagePANTextField = {
+private let panTextField: ForagePANTextField = {
     let tf = ForagePANTextField()
-    tf.placeholder = "PAN Number"
+    tf.borderColor = .black
+    tf.accessibilityIdentifier = "tf_ebt_card_number"
+    tf.placeholder = "EBT Card Number"
     return tf
 }()
 ```
@@ -103,7 +105,7 @@ private let panNumberTextField: ForagePANTextField = {
 ForagePANTextField uses a delegate `ForageElementDelegate` to communicate the updates to the client side.
 
 ```swift
-panNumberTextField.delegate = self
+panTextField.delegate = self
 ```
 
 ```swift
@@ -146,6 +148,7 @@ To send the PAN number, we can use ForageSDK to perform the request.
 // Signature
 
 func tokenizeEBTCard(
+    foragePanTextField: ForagePANTextField,
     customerID: String,
     reusable: Bool?,
     completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
@@ -156,6 +159,7 @@ func tokenizeEBTCard(
 // Usage
 
 ForageSDK.shared.tokenizeEBTCard(
+    foragePanTextField: panTextField,
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     customerID: UUID.init().uuidString,
@@ -173,8 +177,8 @@ A component the securely accepts an EBT PIN for balance requests and payment cap
 ```swift
 private let pinNumberTextField: ForagePINTextField = {
     let tf = ForagePINTextField()
-    tf.placeholder = "PIN Field"
-    tf.isSecureTextEntry = true
+    tf.borderRadius = 10
+    tf.backgroundColor = .lightGray
     tf.pinType = .balance
     return tf
 }()

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -198,6 +198,7 @@ class CardNumberView: UIView {
     
     @objc fileprivate func sendInfo(_ gesture: UIGestureRecognizer) {
         ForageSDK.shared.tokenizeEBTCard(
+            foragePanTextField: panNumberTextField,
             customerID: ClientSharedData.shared.customerID,
             reusable: ClientSharedData.shared.isReusablePaymentMethod) { result in
                 self.printResult(result: result)

--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -18,7 +18,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     }
     
     public func clearText() {
-        ForageSDK.shared.panNumber = ""
+        self.enhancedTextField.actualPAN = ""
     }
     
     /// BorderWidth for the text field
@@ -43,15 +43,15 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     }
     
     @IBInspectable public var isEmpty: Bool {
-        textField.isEmpty
+        enhancedTextField.isEmpty
     }
 
     @IBInspectable public var isValid: Bool {
-        textField.isValid
+        enhancedTextField.isValid
     }
 
     @IBInspectable public var isComplete: Bool {
-        textField.isComplete
+        enhancedTextField.isComplete
     }
     
     // MARK: Public Delegate
@@ -63,47 +63,47 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     
     /// Placeholder for the text field
     @IBInspectable public var placeholder: String? {
-        get { return textField.placeholder }
-        set { textField.placeholder = newValue }
+        get { return enhancedTextField.placeholder }
+        set { enhancedTextField.placeholder = newValue }
     }
     
     /// Text color for the text field
     /// `textColor` default value is `black`
     @IBInspectable public var textColor: UIColor? {
-        get { return textField.textColor }
-        set { textField.textColor = newValue }
+        get { return enhancedTextField.textColor }
+        set { enhancedTextField.textColor = newValue }
     }
     
     /// Size of the text for the text field
     /// `size` default value is `24`
     @IBInspectable public var size: Double = 24.0 {
-        didSet { textField.font = UIFont.systemFont(ofSize: size) }
+        didSet { enhancedTextField.font = UIFont.systemFont(ofSize: size) }
     }
     
     /// Tint color for the text field
     /// `tfTintColor` default value is `black`
     @IBInspectable public var tfTintColor: UIColor? {
-        get { return textField.tintColor }
-        set { textField.tintColor = newValue }
+        get { return enhancedTextField.tintColor }
+        set { enhancedTextField.tintColor = newValue }
     }
     
     /// Text alignment
     /// `textAlignment` default value is `natural`
     @IBInspectable public var textAlignment: NSTextAlignment = .natural {
-        didSet { textField.textAlignment = textAlignment }
+        didSet { enhancedTextField.textAlignment = textAlignment }
     }
     
     /// Allow user to clear text field
     /// `clearButtonMode` default value is `never`
     @IBInspectable public var clearButtonMode: UITextField.ViewMode = .never {
-        didSet { textField.clearButtonMode = clearButtonMode }
+        didSet { enhancedTextField.clearButtonMode = clearButtonMode }
     }
     
     /// Change UIFont
     /// `UITextField` text font
     @IBInspectable public var font: UIFont? {
-        get { return textField.font }
-        set { textField.font = newValue }
+        get { return enhancedTextField.font }
+        set { enhancedTextField.font = newValue }
     }
     
     override public var intrinsicContentSize: CGSize {
@@ -149,7 +149,8 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
         return ddLogger
     }()
     
-    private lazy var textField: MaskedUITextField = {
+    /// UITextField with masking and floating placeholder label functionality.
+    internal lazy var enhancedTextField: MaskedUITextField = {
         let tf = MaskedUITextField()
         tf.translatesAutoresizingMaskIntoConstraints = false
         tf.textColor = UIColor.black
@@ -199,12 +200,12 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
         
         root.addSubview(container)
         
-        textFieldContainer.addSubview(textField)
+        textFieldContainer.addSubview(enhancedTextField)
         imageViewContainer.addSubview(imageView)
         container.addArrangedSubview(textFieldContainer)
         container.addArrangedSubview(imageViewContainer)
         
-        textField.forageDelegate = self
+        enhancedTextField.forageDelegate = self
         
         root.anchor(
             top: self.topAnchor,
@@ -224,7 +225,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
             padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         )
         
-        textField.anchor(
+        enhancedTextField.anchor(
             top: textFieldContainer.topAnchor,
             leading: textFieldContainer.leadingAnchor,
             bottom: textFieldContainer.bottomAnchor,
@@ -252,6 +253,10 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {
         becomeFirstResponder()
+    }
+    
+    internal func getActualPAN() -> String {
+        return enhancedTextField.actualPAN
     }
 }
 
@@ -302,16 +307,16 @@ extension ForagePANTextField {
     
     /// Make `ForagePANTextField` focused.
     @discardableResult override public func becomeFirstResponder() -> Bool {
-        return textField.becomeFirstResponder()
+        return enhancedTextField.becomeFirstResponder()
     }
     
     /// Remove  focus from `ForagePANTextField`.
     @discardableResult override public func resignFirstResponder() -> Bool {
-        return textField.resignFirstResponder()
+        return enhancedTextField.resignFirstResponder()
     }
     
     /// Check if `ForagePANTextField` is focused.
     override public var isFirstResponder: Bool {
-        return textField.isFirstResponder
+        return enhancedTextField.isFirstResponder
     }
 }

--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -18,6 +18,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     }
     
     public func clearText() {
+        self.enhancedTextField.text = ""
         self.enhancedTextField.actualPAN = ""
     }
     

--- a/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/MaskedUITextField.swift
@@ -24,6 +24,8 @@ internal enum MaskPattern : String {
 
 internal class MaskedUITextField : FloatingTextField, ObservableState {
     // MARK: - Properties
+    internal var actualPAN: String = ""
+    
     private var wasBackspacePressed = false
     
     /// A delegate that informs the client about the state of the entered card number (validation, focus)
@@ -75,8 +77,7 @@ internal class MaskedUITextField : FloatingTextField, ObservableState {
         let maskPattern = determineMaskPattern(for: newUnmaskedText, stateIIN: matchedStateIIN)
         self.applyMask(newUnmaskedText, maskPattern: maskPattern)
         
-        // TODO: Stop sharing the PAN state and instead have each PAN hold it's own state
-        ForageSDK.shared.panNumber = newUnmaskedText
+        actualPAN = newUnmaskedText
         
         if text.count > 0 {
             self.addClearButton(isVisible: true)

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -34,6 +34,7 @@ public class ForageSDK {
         self.environment = Environment(sessionToken: config.sessionToken)
         self.merchantID = config.merchantID
         self.sessionToken = config.sessionToken
+        
         // ForageSDK.shared.environment is not set
         // until the end of this initialization
         // so we have to provide the environment from the config

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -14,7 +14,6 @@ public class ForageSDK {
     
     private static var config: Config?
     internal var service: ForageService?
-    internal var panNumber: String = ""
     internal var logger: ForageLogger? = nil
     internal var merchantID: String = ""
     internal var sessionToken: String = ""

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -14,9 +14,11 @@ protocol ForageSDKService: AnyObject {
     /// Tokenize a given EBT Card
     ///
     /// - Parameters:
+    ///  - foragePanTextField: A text field capturing the PAN (Primary Account Number) of the EBT card.
     ///  - customerID: A unique ID for the end customer making the payment. We recommend that you hash this value.
     ///  - completion: Which will return the result. See more [here](https://docs.joinforage.app/reference/create-payment-method-1)
     func tokenizeEBTCard(
+        foragePanTextField: ForagePANTextField,
         customerID: String,
         reusable: Bool?,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void)
@@ -45,6 +47,7 @@ protocol ForageSDKService: AnyObject {
 extension ForageSDK: ForageSDKService {
     
     public func tokenizeEBTCard(
+        foragePanTextField: ForagePANTextField,
         customerID: String,
         reusable: Bool? = true,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
@@ -60,7 +63,7 @@ extension ForageSDK: ForageSDKService {
         let request = ForagePANRequestModel(
             authorization: self.sessionToken,
             merchantID: self.merchantID,
-            panNumber: panNumber,
+            panNumber: foragePanTextField.getActualPAN(),
             type: CardType.EBT.rawValue,
             customerID: customerID,
             reusable: reusable ?? true

--- a/Tests/ForageSDKTests/FloatingTextFieldTests.swift
+++ b/Tests/ForageSDKTests/FloatingTextFieldTests.swift
@@ -15,7 +15,6 @@ final class FloatingTextFieldTests: XCTestCase {
         ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         ForageSDK.shared.environment = .sandbox
         ForageSDK.shared.service = nil
-        ForageSDK.shared.panNumber = ""
         floatingTextField = FloatingTextField()
     }
     

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -17,7 +17,6 @@ final class ForagePANTextFieldTests: XCTestCase {
             sessionToken: "authToken123"
         ))
         ForageSDK.shared.service = nil
-        ForageSDK.shared.panNumber = ""
         foragePANTextField = ForagePANTextField()       
     }
     

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -33,6 +33,32 @@ final class ForagePANTextFieldTests: XCTestCase {
         XCTAssertFalse(foragePANTextField.isComplete)
     }
     
+    func test_multiplePanElements_shouldHaveTheirOwnStates() {
+        let validTextField = ForagePANTextField()
+        let invalidTextField = ForagePANTextField()
+        
+        validTextField.enhancedTextField.text = "5077031234567890123"
+        invalidTextField.enhancedTextField.text = "1234123412341234"
+        
+        validTextField.enhancedTextField.textFieldDidChange()
+        invalidTextField.enhancedTextField.textFieldDidChange()
+
+        XCTAssertEqual(validTextField.enhancedTextField.actualPAN, "5077031234567890123")
+        XCTAssertEqual(invalidTextField.enhancedTextField.actualPAN, "1234123412341234")
+
+        XCTAssertEqual(validTextField.enhancedTextField.text, "507703 1234 5678 901 23")
+        XCTAssertEqual(invalidTextField.enhancedTextField.text, "1234 1234 1234 1234")
+
+        XCTAssertTrue(validTextField.isValid)
+        XCTAssertFalse(invalidTextField.isValid)
+        
+        XCTAssertTrue(validTextField.isComplete)
+        XCTAssertFalse(invalidTextField.isComplete)
+        
+        XCTAssertFalse(validTextField.isEmpty)
+        XCTAssertFalse(invalidTextField.isEmpty)
+    }
+    
     func test_textField_enterNumericString_shouldReturnTrue() {
         let changesAllowed = foragePANTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "1234")
         

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -16,7 +16,6 @@ final class MaskedUITextFieldTests: XCTestCase {
         // .setup() currently doesn't allow us to update the environment
         ForageSDK.shared.environment = .sandbox
         ForageSDK.shared.service = nil
-        ForageSDK.shared.panNumber = ""
         maskedTextField = MaskedUITextField()
     }
     
@@ -42,7 +41,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081234567890")
+        XCTAssertEqual(maskedTextField.actualPAN, "5077081234567890")
     }
     
     func testValidation_partiallyIdentifying16DigitCard_shouldBeValid() {
@@ -52,7 +51,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "50770812345678")
+        XCTAssertEqual(maskedTextField.actualPAN, "50770812345678")
     }
     
     func testValidation_identifyingIIN_shouldBeValid() {
@@ -62,7 +61,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "12345")
+        XCTAssertEqual(maskedTextField.actualPAN, "12345")
     }
     
     func testValidation_invalidIIN_shouldBeInvalid() {
@@ -72,7 +71,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertFalse(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "123412")
+        XCTAssertEqual(maskedTextField.actualPAN, "123412")
     }
     
     func testValidation_validCardWithExtraDigits_shouldBeInvalid() {
@@ -94,7 +93,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isFirstResponder)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, expectedPAN)
+        XCTAssertEqual(maskedTextField.actualPAN, expectedPAN)
     }
     
     // MARK: - Validation with special cards
@@ -107,7 +106,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertFalse(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "4444444444444454")
+        XCTAssertEqual(maskedTextField.actualPAN, "4444444444444454")
     }
     
     func testValidation_specialInsufficientFundsCard_shouldBeValid() {
@@ -117,7 +116,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "4444444444444451")
+        XCTAssertEqual(maskedTextField.actualPAN, "4444444444444451")
     }
     
     func testValidation_specialInvalidCardNum_shouldBeValid() {
@@ -127,7 +126,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5555555555555514")
+        XCTAssertEqual(maskedTextField.actualPAN, "5555555555555514")
     }
     
     func testValidation_specialExpiredCardNum_shouldBeValid() {
@@ -137,7 +136,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5555555555555554")
+        XCTAssertEqual(maskedTextField.actualPAN, "5555555555555554")
     }
     
     func testValidation_completeSpecial9999Card_shouldBeValid() {
@@ -147,7 +146,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "9999123411111111")
+        XCTAssertEqual(maskedTextField.actualPAN, "9999123411111111")
     }
     
     func testValidation_partialSpecial9999Card_shouldBeValidButIncomplete() {
@@ -157,7 +156,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertFalse(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "99991234")
+        XCTAssertEqual(maskedTextField.actualPAN, "99991234")
     }
     
     func testValidation_zeroEbtCashCard() {
@@ -167,7 +166,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertFalse(maskedTextField.isEmpty)
         XCTAssertTrue(maskedTextField.isValid)
         XCTAssertTrue(maskedTextField.isComplete)
-        XCTAssertEqual(ForageSDK.shared.panNumber, "6543212312341234")
+        XCTAssertEqual(maskedTextField.actualPAN, "6543212312341234")
     }
 
     
@@ -178,7 +177,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "5077 0812 3456 7890")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081234567890")
+        XCTAssertEqual(maskedTextField.actualPAN, "5077081234567890")
     }
     
     func testMasking_sixDigits_shouldApply16Mask() {
@@ -186,7 +185,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 56")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "123456")
+        XCTAssertEqual(maskedTextField.actualPAN, "123456")
     }
     
     func testMasking_lessThanSixDigits_shouldNotApplyMask() {
@@ -194,7 +193,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "12345")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "12345")
+        XCTAssertEqual(maskedTextField.actualPAN, "12345")
     }
     
     func testMasking_16DigitInProgress_shouldApply16Mask() {
@@ -202,7 +201,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "5077 081")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5077081")
+        XCTAssertEqual(maskedTextField.actualPAN, "5077081")
     }
     
     func testMasking_invalid16Digit_shouldApplyNoIINMatchMask() {
@@ -210,7 +209,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "1234567812345678")
+        XCTAssertEqual(maskedTextField.actualPAN, "1234567812345678")
     }
     
     func testMasking_invalid17Digit_shouldApplyNoIINMatchMask() {
@@ -218,7 +217,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 1")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "12345678123456781")
+        XCTAssertEqual(maskedTextField.actualPAN, "12345678123456781")
     }
     
     func testMasking_invalid18Digit_shouldApplyNoIINMatchMask() {
@@ -226,7 +225,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 12")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "123456781234567812")
+        XCTAssertEqual(maskedTextField.actualPAN, "123456781234567812")
     }
     
     func testMasking_invalid19Digit_shouldApplyNoIINMatchMask() {
@@ -234,7 +233,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "1234 5678 1234 5678 123")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "1234567812345678123")
+        XCTAssertEqual(maskedTextField.actualPAN, "1234567812345678123")
     }
     
     func testMasking_valid18Digit_shouldApply18Mask() {
@@ -242,7 +241,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "600890 1234 56789 01 2")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "600890123456789012")
+        XCTAssertEqual(maskedTextField.actualPAN, "600890123456789012")
     }
     
     func testMasking_valid19Digit_shouldApply19Mask() {
@@ -250,7 +249,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "507703 1234 5678 901 23")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "5077031234567890123")
+        XCTAssertEqual(maskedTextField.actualPAN, "5077031234567890123")
     }
     
     func testMasking_validSpecialCard_shouldApplyNoIINMatchMask() {
@@ -258,7 +257,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         maskedTextField.textFieldDidChange()
         
         XCTAssertEqual(maskedTextField.text, "9999 1234 1234 1234 123")
-        XCTAssertEqual(ForageSDK.shared.panNumber, "9999123412341234123")
+        XCTAssertEqual(maskedTextField.actualPAN, "9999123412341234123")
     }
     
     // MARK: Masking with backspace
@@ -275,7 +274,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         
         XCTAssertEqual(maskedTextField.text, expectedPAN)
         XCTAssertEqual(precedingChar, "2")
-        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+        XCTAssertEqual(maskedTextField.actualPAN, removeWhitespace(from: expectedPAN))
     }
     
     func testMasking_backspaceChangeIIN_shouldChangeMask() {
@@ -291,7 +290,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         // Now uses New Hampshire 16-digit mask
         XCTAssertEqual(maskedTextField.text, "5077 0100 0000 0000")
         XCTAssertEqual(precedingChar, " ")
-        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+        XCTAssertEqual(maskedTextField.actualPAN, removeWhitespace(from: expectedPAN))
     }
     
     func testMasking_backspaceChangeIntermediateDigit_shouldShiftPAN() {
@@ -311,7 +310,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertEqual(precedingChar, "9")
         // did remove the "2" character and shift the PAN
         XCTAssertEqual(maskedTextField.text, expectedPAN)
-        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+        XCTAssertEqual(maskedTextField.actualPAN, removeWhitespace(from: expectedPAN))
     }
     
     func testMasking_backspaceOnGap_shouldOnlyMoveCursor() {
@@ -330,7 +329,7 @@ final class MaskedUITextFieldTests: XCTestCase {
         XCTAssertEqual(precedingChar, "3")
         // did not change display text, only moved the cursor
         XCTAssertEqual(maskedTextField.text, expectedPAN)
-        XCTAssertEqual(ForageSDK.shared.panNumber, removeWhitespace(from: expectedPAN))
+        XCTAssertEqual(maskedTextField.actualPAN, removeWhitespace(from: expectedPAN))
     }
     
     func test_clearButton() {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Stop saving PAN in a static shared variable
- Allow developer to pass in a `ForagePINTextField` to the SDK

🎥 Screen recording: https://joinforage.slack.com/archives/C031SJGSZV0/p1693358544532169

Co-author: @dleis612

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

Linear ticket: https://linear.app/joinforage/issue/FX-415/ios-do-not-store-pannumber-in-foragesdkshared

- Allow client to display and use more than one PAN element
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

Displayed and submitted multiple PAN elements in the sample app, as seen in the [screen recording](https://joinforage.slack.com/archives/C031SJGSZV0/p1693358544532169).

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How

⚠️ Breaking change!

- Should be released with the rest of the PRs in the stack (#60 and #75)
- Supersedes Danny's previous PR: https://github.com/teamforage/forage-ios-sdk/pull/69

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
