### PR TITLE
[FX-511] Refactor from textEdit -> textField

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A component that securely accepts the PAN number. This field validates the PAN n
 ![Screen Shot 2022-10-31 at 10 19 27](https://user-images.githubusercontent.com/115553362/199017253-ee05dcf0-01c8-41dc-9662-9da525e573c9.png)
 
 ```swift
-private let panTextField: ForagePANTextField = {
+private let foragePanTextField: ForagePANTextField = {
     let tf = ForagePANTextField()
     tf.borderColor = .black
     tf.placeholder = "EBT Card Number"
@@ -104,7 +104,7 @@ private let panTextField: ForagePANTextField = {
 ForagePANTextField uses a delegate `ForageElementDelegate` to communicate the updates to the client side.
 
 ```swift
-panTextField.delegate = self
+foragePanTextField.delegate = self
 ```
 
 ```swift
@@ -158,7 +158,7 @@ func tokenizeEBTCard(
 // Usage
 
 ForageSDK.shared.tokenizeEBTCard(
-    foragePanTextField: panTextField,
+    foragePanTextField: foragePanTextField,
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     customerID: UUID.init().uuidString,
@@ -174,7 +174,7 @@ A component the securely accepts an EBT PIN for balance requests and payment cap
 ![Screen Shot 2022-10-31 at 10 21 32](https://user-images.githubusercontent.com/115553362/199017609-33b2094c-339c-4117-8124-00b5ce130dac.png)
 
 ```swift
-private let pinNumberTextField: ForagePINTextField = {
+private let foragePinTextField: ForagePINTextField = {
     let tf = ForagePINTextField()
     tf.borderRadius = 10
     tf.backgroundColor = .lightGray
@@ -196,7 +196,7 @@ public enum PinType: String {
 ForagePINTextField uses a delegate `ForageElementDelegate` to communicate the updates to the client side.
 
 ```swift
-pinNumberTextField.delegate = self
+foragePinTextField.delegate = self
 ```
 
 ```swift
@@ -240,7 +240,7 @@ To send the PIN number, we can use the ForageSDK to perform the request.
 
 func checkBalance(
     paymentMethodReference: String,
-    foragePinTextEdit: ForagePINTextField,
+    foragePinTextField: ForagePINTextField,
     completion: @escaping (Result<BalanceModel, Error>) -> Void
 )
 ```
@@ -250,7 +250,7 @@ func checkBalance(
 
 ForageSDK.shared.checkBalance(
     paymentMethodReference: paymentMethodReference,
-    foragePinTextEdit: pinNumberTextField) { result in
+    foragePinTextField: ebtPinTextField) { result in
         // handle callback here
     }
 ```
@@ -262,7 +262,7 @@ ForageSDK.shared.checkBalance(
 
 func capturePayment(
     paymentReference: String,
-    foragePinTextEdit: ForagePINTextField,
+    foragePinTextField: ForagePINTextField,
     completion: @escaping (Result<PaymentModel, Error>) -> Void
 )
 ```
@@ -272,7 +272,7 @@ func capturePayment(
 
 ForageSDK.shared.capturePayment(
     paymentReference: paymentReference,
-    foragePinTextEdit: pinNumberTextField) { result in
+    foragePinTextField: foragePinTextField) { result in
         // handle callback here
     }
 ```

--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ func checkBalance(
 // Usage
 
 ForageSDK.shared.checkBalance(
+    foragePinTextField: foragePinTextField,
     paymentMethodReference: paymentMethodReference,
-    foragePinTextField: ebtPinTextField) { result in
+   ) { result in
         // handle callback here
     }
 ```
@@ -261,8 +262,8 @@ ForageSDK.shared.checkBalance(
 // Signature
 
 func capturePayment(
-    paymentReference: String,
     foragePinTextField: ForagePINTextField,
+    paymentReference: String,
     completion: @escaping (Result<PaymentModel, Error>) -> Void
 )
 ```

--- a/README.md
+++ b/README.md
@@ -162,9 +162,10 @@ ForageSDK.shared.tokenizeEBTCard(
     // NOTE: The following line is for testing purposes only and should not be used in production.
     // Please replace this line with a real hashed customer ID value.
     customerID: UUID.init().uuidString,
-    reusable: true) { result in
-        // handle callback here
-    }
+    reusable: true
+) { result in
+    // Handle result and error here
+}
 ```
 
 ### ForagePINTextField
@@ -250,10 +251,10 @@ func checkBalance(
 
 ForageSDK.shared.checkBalance(
     foragePinTextField: foragePinTextField,
-    paymentMethodReference: paymentMethodReference,
-   ) { result in
-        // handle callback here
-    }
+    paymentMethodReference: paymentMethodReference
+) { result in
+    // Handle result and error here
+}
 ```
 
 ### Capture payment
@@ -273,9 +274,10 @@ func capturePayment(
 
 ForageSDK.shared.capturePayment(
     foragePinTextField: foragePinTextField,
-    paymentReference: paymentReference) { result in
-        // handle callback here
-    }
+    paymentReference: paymentReference
+) { result in
+    // Handle result and error here
+}
 ```
 
 ## Demo Application

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ To send the PIN number, we can use the ForageSDK to perform the request.
 // Signature
 
 func checkBalance(
-    paymentMethodReference: String,
     foragePinTextField: ForagePINTextField,
+    paymentMethodReference: String,
     completion: @escaping (Result<BalanceModel, Error>) -> Void
 )
 ```
@@ -271,8 +271,8 @@ func capturePayment(
 // Usage
 
 ForageSDK.shared.capturePayment(
-    paymentReference: paymentReference,
-    foragePinTextField: foragePinTextField) { result in
+    foragePinTextField: foragePinTextField,
+    paymentReference: paymentReference) { result in
         // handle callback here
     }
 ```

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -169,7 +169,7 @@ class CapturePaymentView: UIView {
         
         ForageSDK.shared.capturePayment(
             paymentReference: paymentReference,
-            foragePinTextEdit: inputFieldReference) { result in
+            foragePinTextField: inputFieldReference) { result in
                 self.printResult(result: result)
             }
     }

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -168,8 +168,8 @@ class CapturePaymentView: UIView {
         let inputFieldReference = isEbtSnap ? snapTextField : nonSnapTextField
         
         ForageSDK.shared.capturePayment(
-            paymentReference: paymentReference,
-            foragePinTextField: inputFieldReference) { result in
+            foragePinTextField: inputFieldReference,
+            paymentReference: paymentReference) { result in
                 self.printResult(result: result)
             }
     }

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -156,8 +156,8 @@ class RequestBalanceView: UIView {
     
     @objc fileprivate func getBalanceInfo(_ gesture: UIGestureRecognizer) {
         ForageSDK.shared.checkBalance(
-            paymentMethodReference: ClientSharedData.shared.paymentMethodReference,
-            foragePinTextField: foragePinTextField) { result in
+            foragePinTextField: foragePinTextField,
+            paymentMethodReference: ClientSharedData.shared.paymentMethodReference) { result in
                 self.printPINResult(result: result)
             }
     }

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -38,7 +38,7 @@ class RequestBalanceView: UIView {
         return label
     }()
     
-    public let pinNumberTextField: ForagePINTextField = {
+    public let foragePinTextField: ForagePINTextField = {
         let tf = ForagePINTextField()
         tf.placeholder = "PIN Field"
         tf.pinType = .balance
@@ -157,7 +157,7 @@ class RequestBalanceView: UIView {
     @objc fileprivate func getBalanceInfo(_ gesture: UIGestureRecognizer) {
         ForageSDK.shared.checkBalance(
             paymentMethodReference: ClientSharedData.shared.paymentMethodReference,
-            foragePinTextEdit: pinNumberTextField) { result in
+            foragePinTextField: foragePinTextField) { result in
                 self.printPINResult(result: result)
             }
     }
@@ -169,7 +169,7 @@ class RequestBalanceView: UIView {
     // MARK: Public Methods
     
     public func render() {
-        pinNumberTextField.delegate = self
+        foragePinTextField.delegate = self
         setupView()
         setupConstraints()
     }
@@ -199,7 +199,7 @@ class RequestBalanceView: UIView {
     private func setupView() {
         self.addSubview(contentView)
         contentView.addSubview(titleLabel)
-        contentView.addSubview(pinNumberTextField)
+        contentView.addSubview(foragePinTextField)
         contentView.addSubview(isFirstResponderLabel)
         contentView.addSubview(isEmptyLabel)
         contentView.addSubview(isValidLabel)
@@ -234,7 +234,7 @@ class RequestBalanceView: UIView {
             padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
-        pinNumberTextField.anchor(
+        foragePinTextField.anchor(
             top: titleLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
@@ -245,7 +245,7 @@ class RequestBalanceView: UIView {
         )
         
         isFirstResponderLabel.anchor(
-            top: pinNumberTextField.safeAreaLayoutGuide.bottomAnchor,
+            top: foragePinTextField.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceViewController.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceViewController.swift
@@ -20,7 +20,7 @@ class RequestBalanceViewController: BaseViewCodeViewController<RequestBalanceVie
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.customView.pinNumberTextField.becomeFirstResponder()
+        self.customView.foragePinTextField.becomeFirstResponder()
     }
 }
 

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -16,7 +16,7 @@ protocol ForageSDKService: AnyObject {
     /// - Parameters:
     ///  - foragePanTextField: A text field capturing the PAN (Primary Account Number) of the EBT card.
     ///  - customerID: A unique ID for the end customer making the payment. We recommend that you hash this value.
-    ///  - completion: Which will return the result. See more [here](https://docs.joinforage.app/reference/create-payment-method-1)
+    ///  - completion: The closure returns a `Result` containing either a `PaymentMethodModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/create-payment-method)
     func tokenizeEBTCard(
         foragePanTextField: ForagePANTextField,
         customerID: String,
@@ -26,21 +26,23 @@ protocol ForageSDKService: AnyObject {
     /// Check balance for a given EBT Card
     ///
     /// - Parameters:
+    ///  - foragePinTextField: A specialized text field for securely capturing the PIN to check the balance of the EBT card.
     ///  - paymentMethodReference: PaymentMethod's unique reference hash
-    ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/check-balance))
+    ///  - completion: The closure returns a `Result` containing either a `BalanceModel` or an `Error`.
     func checkBalance(
-        paymentMethodReference: String,
         foragePinTextField: ForagePINTextField,
+        paymentMethodReference: String,
         completion: @escaping (Result<BalanceModel, Error>) -> Void)
     
     /// Capture a payment for a given payment reference
     ///
     /// - Parameters:
-    ///  - paymentReference: The reference hash of the payment
-    ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/capture-payment))
+    ///  - foragePinTextField: A specialized text field  for securely capturing the PIN to capture the EBT payment.
+    ///  - paymentReference: The reference hash of the Payment
+    ///  - completion: The closure returns a `Result` containing either a `PaymentModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/capture-payment))
     func capturePayment(
-        paymentReference: String,
         foragePinTextField: ForagePINTextField,
+        paymentReference: String,
         completion: @escaping (Result<PaymentModel, Error>) -> Void)
 }
 
@@ -72,8 +74,8 @@ extension ForageSDK: ForageSDKService {
     }
     
     public func checkBalance(
-        paymentMethodReference: String,
         foragePinTextField: ForagePINTextField,
+        paymentMethodReference: String,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
             _ = self.logger?
                 .setPrefix("checkBalance")
@@ -113,8 +115,8 @@ extension ForageSDK: ForageSDKService {
         }
     
     public func capturePayment(
-        paymentReference: String,
         foragePinTextField: ForagePINTextField,
+        paymentReference: String,
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
             _ = self.logger?
                 .setPrefix("capturePayment")

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -30,7 +30,7 @@ protocol ForageSDKService: AnyObject {
     ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/check-balance))
     func checkBalance(
         paymentMethodReference: String,
-        foragePinTextEdit: ForagePINTextField,
+        foragePinTextField: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void)
     
     /// Capture a payment for a given payment reference
@@ -40,7 +40,7 @@ protocol ForageSDKService: AnyObject {
     ///  - completion: Which will return the result. (See more [here](https://docs.joinforage.app/reference/capture-payment))
     func capturePayment(
         paymentReference: String,
-        foragePinTextEdit: ForagePINTextField,
+        foragePinTextField: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void)
 }
 
@@ -73,7 +73,7 @@ extension ForageSDK: ForageSDKService {
     
     public func checkBalance(
         paymentMethodReference: String,
-        foragePinTextEdit: ForagePINTextField,
+        foragePinTextField: ForagePINTextField,
         completion: @escaping (Result<BalanceModel, Error>) -> Void) {
             _ = self.logger?
                 .setPrefix("checkBalance")
@@ -100,7 +100,7 @@ extension ForageSDK: ForageSDKService {
                                 merchantID: merchantID,
                                 xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                             )
-                            self.service?.checkBalance(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)
+                            self.service?.checkBalance(pinCollector: foragePinTextField.collector!, request: request, completion: completion)
                             
                         case .failure(let error):
                             completion(.failure(error))
@@ -114,7 +114,7 @@ extension ForageSDK: ForageSDKService {
     
     public func capturePayment(
         paymentReference: String,
-        foragePinTextEdit: ForagePINTextField,
+        foragePinTextField: ForagePINTextField,
         completion: @escaping (Result<PaymentModel, Error>) -> Void) {
             _ = self.logger?
                 .setPrefix("capturePayment")
@@ -144,7 +144,7 @@ extension ForageSDK: ForageSDKService {
                                         merchantID: merchantID,
                                         xKey: ["vgsXKey": model.alias, "btXKey": model.bt_alias]
                                     )
-                                    self.service?.capturePayment(pinCollector: foragePinTextEdit.collector!, request: request, completion: completion)
+                                    self.service?.capturePayment(pinCollector: foragePinTextField.collector!, request: request, completion: completion)
                                 case .failure(let error):
                                     completion(.failure(error))
                                 }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -39,7 +39,7 @@ protocol ForageSDKService: AnyObject {
     /// - Parameters:
     ///  - foragePinTextField: A specialized text field  for securely capturing the PIN to capture the EBT payment.
     ///  - paymentReference: The reference hash of the Payment
-    ///  - completion: The closure returns a `Result` containing either a `PaymentModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/capture-payment))
+    ///  - completion: The closure returns a `Result` containing either a `PaymentModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/capture-payment)
     func capturePayment(
         foragePinTextField: ForagePINTextField,
         paymentReference: String,


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Make naming more consistent
- Make parameter position more consistent with `tokenizeEBTCard` and other SDKs (object first, then rest of params)
- Refresh comments (had broken links and missing info
- Update README
<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-511/ios-foragepintextedit-should-be-renamed-to-foragepintextfield

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Should be released with the [rest of the PRs in this stack](https://github.com/teamforage/forage-ios-sdk/pull/87#issuecomment-1699370908)