### PR TITLE
[FX-512] Add ForageSDK.swift unit tests

### DIFF
--- a/Tests/ForageSDKTests/CollectorTests.swift
+++ b/Tests/ForageSDKTests/CollectorTests.swift
@@ -18,7 +18,6 @@ class VaultCollectorTests: XCTestCase {
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
-        ForageSDK.shared.service = nil
     }
     
     func testVGSCollectWrapper_SetCustomHeaders_HeaderKey() {

--- a/Tests/ForageSDKTests/FloatingTextFieldTests.swift
+++ b/Tests/ForageSDKTests/FloatingTextFieldTests.swift
@@ -14,7 +14,6 @@ final class FloatingTextFieldTests: XCTestCase {
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         ForageSDK.shared.environment = .sandbox
-        ForageSDK.shared.service = nil
         floatingTextField = FloatingTextField()
     }
     

--- a/Tests/ForageSDKTests/ForageElementDelegateTests.swift
+++ b/Tests/ForageSDKTests/ForageElementDelegateTests.swift
@@ -49,7 +49,6 @@ final class ForageElementDelegateTests: XCTestCase {
     
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
-        ForageSDK.shared.service = nil
         observableState = nil
     }
     

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -16,7 +16,6 @@ final class ForagePANTextFieldTests: XCTestCase {
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
-        ForageSDK.shared.service = nil
         foragePANTextField = ForagePANTextField()       
     }
     

--- a/Tests/ForageSDKTests/ForageSDKTests.swift
+++ b/Tests/ForageSDKTests/ForageSDKTests.swift
@@ -1,0 +1,66 @@
+//
+//  ForageSDKTests.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-08-30.
+//
+
+import XCTest
+
+@testable import ForageSDK
+
+final class ForageSDKTests: XCTestCase {
+    override func setUp() {
+        // need to call
+        ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
+    }
+    
+    func testInit_shouldInitializeLogger() {
+        ForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
+        ))
+        
+        XCTAssertNotNil(ForageSDK.shared.logger)
+    }
+    
+    func testInit_shouldInitLiveForageService() {
+        ForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
+        ))
+        
+        XCTAssertNotNil(ForageSDK.shared.service)
+    }
+    
+    func testSetup_calledOnce_shouldSetConfig() {
+        ForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "staging_authToken123"
+        ))
+        
+        XCTAssertEqual(ForageSDK.shared.environment.rawValue, "staging")
+        XCTAssertEqual(ForageSDK.shared.merchantID, "merchantID123")
+        XCTAssertEqual(ForageSDK.shared.sessionToken, "staging_authToken123")
+    }
+    
+    func testSetup_calledTwice_shouldUpdateConfig() {
+        ForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "staging_authToken123"
+        ))
+        
+        XCTAssertEqual(ForageSDK.shared.environment.rawValue, "staging")
+        XCTAssertEqual(ForageSDK.shared.merchantID, "merchantID123")
+        XCTAssertEqual(ForageSDK.shared.sessionToken, "staging_authToken123")
+        
+        ForageSDK.setup(ForageSDK.Config(
+            merchantID: "newMerchantID456",
+            sessionToken: "sandbox_newToken123"
+        ))
+        
+        XCTAssertEqual(ForageSDK.shared.environment.rawValue, "sandbox")
+        XCTAssertEqual(ForageSDK.shared.merchantID, "newMerchantID456")
+        XCTAssertEqual(ForageSDK.shared.sessionToken, "sandbox_newToken123")
+    }
+}

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -18,7 +18,6 @@ final class ForageServiceTests: XCTestCase {
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
-        ForageSDK.shared.service = nil
         forageMocks = ForageMocks()
     }
     

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -15,7 +15,6 @@ final class MaskedUITextFieldTests: XCTestCase {
         ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
         // .setup() currently doesn't allow us to update the environment
         ForageSDK.shared.environment = .sandbox
-        ForageSDK.shared.service = nil
         maskedTextField = MaskedUITextField()
     }
     

--- a/Tests/ForageSDKTests/ResponseMonitorTests.swift
+++ b/Tests/ForageSDKTests/ResponseMonitorTests.swift
@@ -44,7 +44,6 @@ class TestableResponseMonitor: ResponseMonitor {
 final class ResponseMonitorTests: XCTestCase {
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(merchantID: "merchant123", sessionToken: "sandbox_auth123"))
-        ForageSDK.shared.service = nil
     }
     
     func testInit_shouldSetLogKind() {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Add unit tests for `ForageSDK.swift`
- Remove `ForageSDK.shared.service = nil` statements [FX-416](https://linear.app/joinforage/issue/FX-416/ios-remove-foragesdksharedservice-=-nil-statements-from-tests)

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

- helps ensure the rest of the changes in this PR stack work and reduce the risk of regressions
- helps ensure logger is initialized, which is not covered by our E2E tests.
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is, with the rest of the PRs in this stack.
