### PR TITLE
[FX-514] Update Basis theory to v2.8.0

### DIFF
--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.source_files = ["Sources/ForageSDK/**/*.swift", "DatadogPrivate-Objc/**/*.{h,m}"]
   spec.dependency 'VGSCollectSDK', '~> 1.11.2'
   spec.dependency 'LaunchDarkly', '~> 8.0.1'
-  spec.dependency 'BasisTheoryElements', '~> 2.7.0'
+  spec.dependency 'BasisTheoryElements', '~> 2.8.0'
   spec.resource_bundles = {
     'ForageIcon' => ['Sources/Resources/*']
   }

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(
             name: "BasisTheoryElements",
             url: "https://github.com/Basis-Theory/basistheory-ios",
-            from: "2.7.0"
+            from: "2.8.0"
         ),
     ],
     targets: [


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Update Basis Theory package to v2.8.0
- Which consequently removes [Datadog](https://github.com/DataDog/dd-sdk-ios/) as a dependency from our dependency tree.

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-514/update-basis-theory-ios-to-v280

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is