### PR TITLE
[FX-494] Make LDManager safer

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -10,4 +10,6 @@ ignore:
   - "**/Vendor/DatadogLogs/*"
   - "DatadogPrivate-Objc/*"
   - "**/DatadogPrivate-Objc/*"
+  - "Sources/ForageSDK/Foundation/Telemetry/NoopLogger.swift"
+  - "**/Sources/ForageSDK/Foundation/Telemetry/NoopLogger.swift"
   - Tests/*

--- a/Sources/ForageSDK/Foundation/Network/LDManager.swift
+++ b/Sources/ForageSDK/Foundation/Network/LDManager.swift
@@ -77,7 +77,7 @@ internal class LDManager {
     ///   - logger: An optional `ForageLogger` for logging purposes.
     ///   - startLdClient: A closure to start the LaunchDarkly client. Defaults to `LDClient.start`.
     internal func initialize(
-        _ environment: EnvironmentTarget,
+        _ environment: Environment,
         logger: ForageLogger? = nil,
         startLdClient: (LDConfig, LDContext?, (() -> Void)?) -> Void = LDClient.start
     ) {
@@ -139,7 +139,7 @@ internal class LDManager {
         return vaultType ?? .vgsVaultType
     }
 
-    private func createLDConfig(for environment: EnvironmentTarget) -> LDConfig {
+    private func createLDConfig(for environment: Environment) -> LDConfig {
         return LDConfig(mobileKey: getLDMobileKey(environment).rawValue)
     }
     

--- a/Sources/ForageSDK/Foundation/Network/LDManager.swift
+++ b/Sources/ForageSDK/Foundation/Network/LDManager.swift
@@ -55,14 +55,27 @@ private enum ContextKind: String {
     case service = "service"
 }
 
+/// `LDManager` is responsible for managing interactions with the LaunchDarkly service.
+///
+/// - Note: This class is a singleton and should be accessed via `LDManager.shared`.
 internal class LDManager {
+    // MARK: - Properties
+    
     static let shared = LDManager()
     private var logger: ForageLogger?
     
     internal private(set) var vaultType: VaultType?
     
+    // MARK: - Initialization
+    
     private init() {}
     
+    /// Initializes the LaunchDarkly client with a given environment and optional logger.
+    ///
+    /// - Parameters:
+    ///   - environment: The `EnvironmentTarget` to be used for initialization.
+    ///   - logger: An optional `ForageLogger` for logging purposes.
+    ///   - startLdClient: A closure to start the LaunchDarkly client. Defaults to `LDClient.start`.
     internal func initialize(
         _ environment: EnvironmentTarget,
         logger: ForageLogger? = nil,
@@ -82,6 +95,14 @@ internal class LDManager {
         })
     }
     
+    /// Determines the type of vault to be used based on the "vault-primary-traffic-percentage" feature flag.
+    ///
+    /// - Parameters:
+    ///   - ldClient: An optional `LDClientProtocol` object used to fetch feature flags. Defaults to `getDefaultLDClient()`.
+    ///   - genRandomDouble: A closure that returns a random double between 0 and 100. Defaults to `generateRandomDouble`.
+    ///   - fromCache: A Boolean flag indicating whether to return the cached vault type if available. Defaults to `true`.
+    ///
+    /// - Returns: The determined `VaultType`.
     internal func getVaultType(
         ldClient: LDClientProtocol? = getDefaultLDClient(),
         genRandomDouble: () -> Double = generateRandomDouble,

--- a/Sources/ForageSDK/Foundation/Network/LDManager.swift
+++ b/Sources/ForageSDK/Foundation/Network/LDManager.swift
@@ -96,6 +96,7 @@ internal class LDManager {
     }
     
     /// Determines the type of vault to be used based on the "vault-primary-traffic-percentage" feature flag.
+    /// Defaults to VGS if something goes wrong (ex: LDClient not initialized, LaunchDarkly is down).
     ///
     /// - Parameters:
     ///   - ldClient: An optional `LDClientProtocol` object used to fetch feature flags. Defaults to `getDefaultLDClient()`.

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -139,6 +139,7 @@ internal class DatadogLogger : ForageLogger {
         self.logger?.critical(self.getMessageWithPrefix(message), error: error, attributes: attributes)
     }
     
+    @discardableResult
     internal func addContext(_ newContext: ForageLogContext) -> ForageLogger {
         self.config?.context = newContext
         let attributeMappings: [(key: String, value: Encodable?)] = [
@@ -158,11 +159,13 @@ internal class DatadogLogger : ForageLogger {
         return self
     }
     
+    @discardableResult
     internal func setLogKind(_ logKind: ForageLogKind) -> ForageLogger {
         self.logger?.addTag(withKey: "log_kind", value: logKind.rawValue)
         return self
     }
     
+    @discardableResult
     internal func setPrefix(_ newPrefix: String) -> ForageLogger {
         self.config?.prefix = newPrefix
         return self

--- a/Sources/ForageSDK/Foundation/Telemetry/NoopLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/NoopLogger.swift
@@ -1,0 +1,47 @@
+//
+//  NoopLogger.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-09-01.
+//
+
+import Foundation
+
+/// Silent logger that doesn't do anything!
+internal class NoopLogger: ForageLogger {
+    required init(_ config: ForageLoggerConfig? = ForageLoggerConfig(environment: .sandbox)) {
+        // noop
+    }
+    
+    func addContext(_ newContext: ForageLogContext) -> ForageLogger {
+        return self
+    }
+    
+    func setLogKind(_ logKind: ForageLogKind) -> ForageLogger {
+        return self
+    }
+    
+    func setPrefix(_ prefix: String) -> ForageLogger {
+        return self
+    }
+    
+    func notice(_ message: String, attributes: [String : Encodable]?) {
+        // noop
+    }
+    
+    func info(_ message: String, attributes: [String : Encodable]?) {
+        // noop
+    }
+    
+    func warn(_ message: String, error: Error?, attributes: [String : Encodable]?) {
+        // noop
+    }
+    
+    func error(_ message: String, error: Error?, attributes: [String : Encodable]?) {
+        // noop
+    }
+    
+    func critical(_ message: String, error: Error?, attributes: [String : Encodable]?) {
+        // noop
+    }
+}

--- a/Tests/ForageSDKTests/LDManagerTests.swift
+++ b/Tests/ForageSDKTests/LDManagerTests.swift
@@ -1,0 +1,136 @@
+//
+//  LDManagerTests.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-09-01.
+//
+
+import XCTest
+
+@testable import ForageSDK
+@testable import LaunchDarkly
+
+class MockLogger : NoopLogger {
+    var lastInfoMsg: String = ""
+    var lastErrorMsg: String = ""
+
+    required init(_ config: ForageLoggerConfig? = nil) {
+        super.init(config)
+    }
+    
+    override func info(_ message: String, attributes: [String : Encodable]?) {
+        lastInfoMsg = message
+    }
+    
+    override func error(_ message: String, error: Error?, attributes: [String : Encodable]?) {
+        lastErrorMsg = message
+    }
+}
+
+class MockLDClient : LDClientProtocol {
+    var vaultPercentage: Double
+    
+    init(vaultPercentage: Double) {
+        self.vaultPercentage = vaultPercentage
+    }
+    
+    init(vaultType: VaultType) {
+        self.vaultPercentage = vaultType == VaultType.vgsVaultType ? 0 : 100
+        print("Setting vault percentage to: \(self.vaultPercentage)")
+    }
+    
+    func doubleVariationWrapper(forKey key: String, defaultValue: Double) -> Double {
+        print("Evalutate fake vault percentage \(vaultPercentage)!")
+        return vaultPercentage
+    }
+}
+
+final class LDManagerTests: XCTestCase {
+    // MARK: Test LDManager.getVaultType
+    
+    func testGetVaultType_WhenLDClientIsNil_ShouldReturnVGSVaultType() {
+        let result = LDManager.shared.getVaultType(ldClient: nil, fromCache: false)
+        XCTAssertEqual(result, VaultType.vgsVaultType)
+    }
+    
+    func testGetVaultType_WhenVaultTypeIsAlreadySet_ShouldReturnCachedValue() {
+        print("Testing \(self.name)...")
+        let mockLDClient = MockLDClient(vaultType: VaultType.btVaultType)
+        let firstVaultType = LDManager.shared.getVaultType(ldClient: mockLDClient, fromCache: false)
+        
+        let vgsMockLdClient = MockLDClient(vaultType: VaultType.vgsVaultType)
+        let secondVaultType = LDManager.shared.getVaultType(
+            ldClient: vgsMockLdClient,
+            fromCache: true
+        )
+        
+        XCTAssertEqual(firstVaultType, VaultType.btVaultType)
+        // should still be Basis Theory
+        XCTAssertEqual(secondVaultType, VaultType.btVaultType)
+    }
+    
+    func testGetVaultType_VariationGreaterThanRandom_ShouldReturnBTVaultType() {
+        print("Testing \(self.name)...")
+        
+        let mockLDClient = MockLDClient(vaultPercentage: 2)
+        let mockRandomGenerator = { return 1.00 }
+        
+        print("Moss: \(mockRandomGenerator() < 2)")
+        
+        let result = LDManager.shared.getVaultType(
+            ldClient: mockLDClient,
+            genRandomDouble: mockRandomGenerator,
+            fromCache: false
+        )
+        XCTAssertEqual(result, VaultType.btVaultType)
+    }
+    
+    func testGetVaultType_VariationLessThanRandom_ShouldReturnVGSVaultType() {
+        let mockLDClient = MockLDClient(vaultPercentage: 2)
+        let mockRandomGenerator = { return 3.00 }
+        
+        let result = LDManager.shared.getVaultType(
+            ldClient: mockLDClient,
+            genRandomDouble: mockRandomGenerator,
+            fromCache: false
+        )
+        XCTAssertEqual(result, VaultType.vgsVaultType)
+    }
+    
+    // Test when ldClient.variation() returns a value equal to the random percent
+    // Assuming you can mock or control the random number generation
+    func testGetVaultType_VariationEqualToRandom_ShouldReturnVGSVaultType() {
+        let mockLDClient = MockLDClient(vaultPercentage: 50)
+        let mockRandomGenerator = { return 50.00 }
+        
+        let result = LDManager.shared.getVaultType(
+            ldClient: mockLDClient,
+            genRandomDouble: mockRandomGenerator,
+            fromCache: false
+        )
+        XCTAssertEqual(result, VaultType.vgsVaultType)
+    }
+    
+    // MARK: Test LDManager.Initialize
+    
+    func testInitialize_StartsLDClient() {
+        let expectation = XCTestExpectation(description: "Completion should be called")
+        let mockLogger = MockLogger()
+        
+        let mockStartLdClient = { (config: LDConfig, context: LDContext?, completion: (() -> Void)?) in
+            // sandbox key:
+            XCTAssertEqual(config.mobileKey, "mob-22024b85-05b7-4e24-b290-a071310dfc3d")
+            XCTAssertNotNil(context)
+            completion?()
+            
+            XCTAssertEqual(mockLogger.lastInfoMsg, "Initialized LaunchDarkly client")
+            
+            expectation.fulfill()
+        }
+        
+        let manager = LDManager.shared
+        manager.initialize(.sandbox, logger: mockLogger, startLdClient: mockStartLdClient)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/Tests/ForageSDKTests/LDManagerTests.swift
+++ b/Tests/ForageSDKTests/LDManagerTests.swift
@@ -36,11 +36,9 @@ class MockLDClient : LDClientProtocol {
     
     init(vaultType: VaultType) {
         self.vaultPercentage = vaultType == VaultType.vgsVaultType ? 0 : 100
-        print("Setting vault percentage to: \(self.vaultPercentage)")
     }
     
     func doubleVariationWrapper(forKey key: String, defaultValue: Double) -> Double {
-        print("Evalutate fake vault percentage \(vaultPercentage)!")
         return vaultPercentage
     }
 }
@@ -54,7 +52,6 @@ final class LDManagerTests: XCTestCase {
     }
     
     func testGetVaultType_WhenVaultTypeIsAlreadySet_ShouldReturnCachedValue() {
-        print("Testing \(self.name)...")
         let mockLDClient = MockLDClient(vaultType: VaultType.btVaultType)
         let firstVaultType = LDManager.shared.getVaultType(ldClient: mockLDClient, fromCache: false)
         
@@ -69,14 +66,10 @@ final class LDManagerTests: XCTestCase {
         XCTAssertEqual(secondVaultType, VaultType.btVaultType)
     }
     
-    func testGetVaultType_VariationGreaterThanRandom_ShouldReturnBTVaultType() {
-        print("Testing \(self.name)...")
-        
+    func testGetVaultType_VariationGreaterThanRandom_ShouldReturnBTVaultType() {        
         let mockLDClient = MockLDClient(vaultPercentage: 2)
         let mockRandomGenerator = { return 1.00 }
-        
-        print("Moss: \(mockRandomGenerator() < 2)")
-        
+                
         let result = LDManager.shared.getVaultType(
             ldClient: mockLDClient,
             genRandomDouble: mockRandomGenerator,


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Remove use of [force unwrapping the LDCient, which can lead to crashes](https://www.hackingwithswift.com/sixty/10/4/force-unwrapping)
  - instead, we fallback to VGS and allow the show to go on.
- Add unit tests for LDManager
- Do a bit of refactoring to allow for testing via dependency injection and for better readability
- Add logs to catch LaunchDarkly related errors
<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- Crashproofing the iOS SDK
- Reliability
- Getting to > 80% unit test coverage

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- [x] TODO: run QA tests against environment where LD says vaultType = BasisTheory
   - [x] Check Datadog for any status:error logs.
- [x] TODO: verify that mobile key matches prod mobile key before GoPuff goes live.

- ✅ iOS QA Tests passed locally
- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is in the next release