### PR TITLE
[SYM-109] Enable customization of styling of PIN input width and height

### DIFF
--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -240,8 +240,7 @@ class CapturePaymentView: UIView {
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
             centerXAnchor: contentView.centerXAnchor,
-            padding: UIEdgeInsets(top: 24, left: 24, bottom: 12, right: 24),
-            size: .init(width: 0, height: 60)
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 12, right: 24)
         )
         
         captureSnapPaymentButton.anchor(
@@ -260,8 +259,7 @@ class CapturePaymentView: UIView {
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
             centerXAnchor: contentView.centerXAnchor,
-            padding: UIEdgeInsets(top: 24, left: 24, bottom: 12, right: 24),
-            size: .init(width: 0, height: 60)
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 12, right: 24)
         )
         
         captureNonSnapPaymentButton.anchor(

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -242,8 +242,7 @@ class RequestBalanceView: UIView {
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
             centerXAnchor: contentView.centerXAnchor,
-            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24),
-            size: .init(width: 0, height: 60)
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
         )
         
         isFirstResponderLabel.anchor(

--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -106,6 +106,16 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
         set { textField.font = newValue }
     }
     
+    /// ElementHeight for the text field
+    private var _elementHeight: CGFloat = 0
+    @IBInspectable public var elementHeight: CGFloat {
+        get { return _elementHeight }
+        set {
+            _elementHeight = newValue
+            self.changeElementHeight(value: _elementHeight)
+        }
+    }
+    
     override public var intrinsicContentSize: CGSize {
         return CGSize(width: frame.width, height: 83)
     }
@@ -252,6 +262,11 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {
         becomeFirstResponder()
+    }
+    
+    private func changeElementHeight(value: CGFloat) {
+        container.distribution = .equalCentering
+        container.heightAnchor.constraint(equalToConstant: value).isActive = true
     }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -105,6 +105,34 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         set { textField.font = newValue }
     }
     
+    /// InputWidth for the text field
+    @IBInspectable public var inputWidth: CGFloat {
+        get { return textField.inputWidth }
+        set {
+            container.alignment = .center
+            textField.inputWidth = newValue
+        }
+    }
+    
+    /// InputHeight for the text field
+    @IBInspectable public var inputHeight: CGFloat {
+        get { return textField.inputHeight }
+        set {
+            container.alignment = .center
+            textField.inputHeight = newValue
+        }
+    }
+    
+    /// ElementHeight for the text field
+    private var _elementHeight: CGFloat = 0
+    @IBInspectable public var elementHeight: CGFloat {
+        get { return _elementHeight }
+        set {
+            _elementHeight = newValue
+            self.changeElementHeight(value: _elementHeight)
+        }
+    }
+    
     // MARK: Private components
     
     private lazy var root: UIView = {
@@ -163,7 +191,9 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         tf?.borderRadius = 4
         tf?.borderColor = UIColor.lightGray
         tf?.backgroundColor = UIColor.white
-        tf?.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
+        tf?.inputWidth = 342
+        tf?.inputHeight = 36
+        tf?.padding = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         collector = tf?.collector
         
         return tf ?? VGSTextFieldWrapper()
@@ -262,6 +292,11 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
 
     public func clearText() {
         textField.clearText()
+    }
+    
+    private func changeElementHeight(value: CGFloat) {
+        container.distribution = .equalCentering
+        container.heightAnchor.constraint(equalToConstant: value).isActive = true
     }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -9,9 +9,16 @@ import UIKit
 import VGSCollectSDK
 
 public class ForagePINTextField: UIView, Identifiable, ForageElement {
-    public func setPlaceholderText(_ text: String) {
-        
-    }
+    
+    // MARK: - Properties
+    
+    public var pinType: PinType = .balance
+    internal var collector: VaultCollector?
+    
+    /// Delegate that updates client's side about state of the entered pin
+    public weak var delegate: ForageElementDelegate?
+    
+    // MARK: - Exposed properties
     
     @IBInspectable public var isEmpty: Bool {
         get { return textField.isEmpty }
@@ -24,17 +31,6 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     @IBInspectable public var isComplete: Bool {
         get { return textField.isComplete }
     }
-    
-    // MARK: Public Delegate
-    
-    /// Delegate that updates client's side about state of the entered pin
-    public weak var delegate: ForageElementDelegate?
-    
-    // MARK: Public Properties
-    
-    public var pinType: PinType = .balance
-    
-    internal var collector: VaultCollector?
     
     /// BorderWidth for the text field
     @IBInspectable public var borderWidth: CGFloat {
@@ -105,7 +101,8 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         set { textField.font = newValue }
     }
     
-    /// InputWidth for the text field
+    /// Width of the input field within the ForagePINTextField.
+    /// - SeeAlso: `inputHeight` to customize the height of the input field within the ForagePINTextField.
     @IBInspectable public var inputWidth: CGFloat {
         get { return textField.inputWidth }
         set {
@@ -114,7 +111,8 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         }
     }
     
-    /// InputHeight for the text field
+    /// Height of the input field within the ForagePINTextField.
+    /// - SeeAlso: `elementHeight` to customize the height of the entire ForagePINTextField.
     @IBInspectable public var inputHeight: CGFloat {
         get { return textField.inputHeight }
         set {
@@ -123,7 +121,8 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         }
     }
     
-    /// ElementHeight for the text field
+    /// Height of the entire ForagePINTextField element.
+    /// - SeeAlso: `inputHeight` to customize the height of the input field within the ForagePINTextField.
     private var _elementHeight: CGFloat = 0
     @IBInspectable public var elementHeight: CGFloat {
         get { return _elementHeight }
@@ -133,7 +132,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         }
     }
     
-    // MARK: Private components
+    // MARK: - Private components
     
     private lazy var root: UIView = {
         let view = UIView()
@@ -176,7 +175,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         let vaultType = LDManager.shared.getVaultType()
         
         var tf: VaultWrapper?
-        
+
         if (vaultType == VaultType.vgsVaultType) {
             tf = VGSTextFieldWrapper()
         } else if (vaultType == VaultType.btVaultType) {
@@ -184,18 +183,15 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         } else {
             tf = VGSTextFieldWrapper()
         }
-        
+
         tf?.textColor = UIColor.black
         tf?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         tf?.borderWidth = 0.25
         tf?.borderRadius = 4
         tf?.borderColor = UIColor.lightGray
         tf?.backgroundColor = UIColor.white
-        tf?.inputWidth = 342
-        tf?.inputHeight = 36
-        tf?.padding = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         collector = tf?.collector
-        
+
         return tf ?? VGSTextFieldWrapper()
     }()
     
@@ -212,7 +208,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         return imgView
     }()
     
-    // MARK: Lifecycle methods
+    // MARK: - Lifecycle methods
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -228,7 +224,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         super.awakeFromNib()
     }
     
-    // MARK: Private Methods
+    // MARK: - Private Methods
     
     private func commonInit() {
         addSubview(root)
@@ -289,16 +285,22 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     @objc fileprivate func requestFocus(_ gesture: UIGestureRecognizer) {
         becomeFirstResponder()
     }
-
-    public func clearText() {
-        textField.clearText()
-    }
     
     private func changeElementHeight(value: CGFloat) {
         container.distribution = .equalCentering
         container.heightAnchor.constraint(equalToConstant: value).isActive = true
     }
+    
+    // MARK: - Public API
+    
+    public func clearText() {
+        textField.clearText()
+    }
+    
+    public func setPlaceholderText(_ text: String) {}
 }
+
+// MARK: - VaultWrapperDelegate
 
 extension ForagePINTextField: VaultWrapperDelegate {
     internal func textFieldDidChange(_ textField: VaultWrapper) {
@@ -311,6 +313,7 @@ extension ForagePINTextField: VaultWrapperDelegate {
 }
 
 // MARK: - UIResponder methods
+
 extension ForagePINTextField {
     /// Make `ForagePINTextField` focused.
     @discardableResult override public func becomeFirstResponder() -> Bool {

--- a/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
@@ -31,6 +31,8 @@ internal protocol InternalAppearance {
     var borderColor: UIColor? { get set }
     var borderRadius: CGFloat { get set }
     var backgroundColor: UIColor? { get set }
+    var inputWidth: CGFloat { get set }
+    var inputHeight: CGFloat { get set }
     var font: UIFont? { get set }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -10,15 +10,16 @@ import BasisTheoryElements
 import Combine
 
 class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
-    /**
-     BT Event Types
-     */
+
+    // BT Event Types
     private enum BTEventType: String {
         case TEXT_CHANGE = "textChange"
         case MASK_CHANGE = "maskChange"
         case BLUR = "blur"
         case FOCUS = "focus"
     }
+    
+    // MARK: - Properties
     
     private var _isEmpty: Bool = true
     @IBInspectable public var isEmpty: Bool {
@@ -35,32 +36,38 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         get { return _isComplete }
     }
     
-    func clearText() {
-        textField.text = ""
-    }
-    
-    var collector: VaultCollector
-    
-    var delegate: VaultWrapperDelegate?
-    
-    var placeholder: String?
-    
-    var tfTintColor: UIColor?
-    
-    var inputWidthConstraint: NSLayoutConstraint?
-    var inputHeightConstraint: NSLayoutConstraint?
-    
+    private let textField: TextElementUITextField
+    private var inputWidthConstraint: NSLayoutConstraint?
+    private var inputHeightConstraint: NSLayoutConstraint?
     private var cancellables = Set<AnyCancellable>()
     
-    var verticalConstraint: [NSLayoutConstraint]?
-    var horizontalConstraints: [NSLayoutConstraint]?
+    var delegate: VaultWrapperDelegate?
+    var collector: VaultCollector
+    var placeholder: String?
+    var tfTintColor: UIColor?
+    var padding = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     
-    private let textField: TextElementUITextField
+    var widthConstraint: CGFloat? {
+        didSet {
+            if let widthConstraint = widthConstraint {
+                inputWidthConstraint?.constant = widthConstraint
+            }
+        }
+    }
+
+    var heightConstraint: CGFloat? {
+        didSet {
+            if let heightConstraint = heightConstraint {
+                inputHeightConstraint?.constant = heightConstraint
+            }
+        }
+    }
+    
+    // MARK: - Initialization
     
     override init(frame: CGRect) {
         textField = TextElementUITextField()
         collector = CollectorFactory.createBasisTheory(environment: ForageSDK.shared.environment, textElement: textField)
-        
         super.init(frame: frame)
         
         commonInit()
@@ -80,12 +87,16 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         textField.keyboardType = UIKeyboardType.phonePad
         textField.isSecureTextEntry = true
         textField.textAlignment = .center
+        textField.anchor(
+            top: self.topAnchor,
+            leading: self.leadingAnchor,
+            bottom: self.bottomAnchor,
+            trailing: self.trailingAnchor,
+            centerXAnchor: nil,
+            padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        )
         
-        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: inputHeight)
-        inputHeightConstraint?.isActive = true
-        
-        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: inputWidth)
-        inputWidthConstraint?.isActive = true
+        setupWidthHeightConstraints()
         
         let regexDigit = try! NSRegularExpression(pattern: "\\d")
         
@@ -127,30 +138,34 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         }.store(in: &cancellables)
     }
     
+    // MARK: - Private API
+    
+    private func setupWidthHeightConstraints() {
+        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: 342)
+        inputWidthConstraint?.isActive = true
+        
+        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: 36)
+        inputHeightConstraint?.isActive = true
+    }
+    
+    // MARK: - Public API
+    
     func setPlaceholderText(_ text: String) {
         textField.placeholder = text
     }
     
+    func clearText() {
+        textField.text = ""
+    }
+    
     var borderWidth: CGFloat {
-        get {
-            return textField.layer.borderWidth
-        }
-        set {
-            textField.layer.borderWidth = newValue
-        }
+        get { return textField.layer.borderWidth }
+        set { textField.layer.borderWidth = newValue }
     }
     
     var borderRadius: CGFloat {
-        get {
-            return textField.layer.cornerRadius
-        }
-        set {
-            textField.layer.cornerRadius = newValue
-        }
-    }
-    
-    var padding = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0) {
-            didSet { setMainPaddings() }
+        get { return textField.layer.cornerRadius }
+        set { textField.layer.cornerRadius = newValue }
     }
     
     var borderColor: UIColor? {
@@ -160,9 +175,7 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
             }
             return UIColor(cgColor: cgcolor)
         }
-        set {
-            textField.layer.borderColor = newValue?.cgColor
-        }
+        set { textField.layer.borderColor = newValue?.cgColor }
     }
     
     override var backgroundColor: UIColor? {
@@ -172,39 +185,7 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
             }
             return UIColor(cgColor: cgcolor)
         }
-        set {
-            textField.layer.backgroundColor = newValue?.cgColor
-        }
-    }
-    
-    func setPlaceholder(_ text: String) {
-        textField.placeholder = text
-    }
-    
-    func setMainPaddings() {
-        if let verticalConstraint = verticalConstraint {
-            NSLayoutConstraint.deactivate(verticalConstraint)
-        }
-        
-        if let horizontalConstraints = horizontalConstraints {
-            NSLayoutConstraint.deactivate(horizontalConstraints)
-        }
-        
-        let views = ["view": self, "textField": textField]
-        
-        horizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-\(padding.left)-[textField]-\(padding.right)-|",
-                                                               options: .alignAllCenterY,
-                                                               metrics: nil,
-                                                               views: views)
-        NSLayoutConstraint.activate(horizontalConstraints ?? [])
-        
-        verticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-\(padding.top)-[textField]-\(padding.bottom)-|",
-                                                                options: .alignAllCenterX,
-                                                                metrics: nil,
-                                                                views: views)
-        NSLayoutConstraint.activate(verticalConstraint ?? [])
-        
-        self.layoutIfNeeded()
+        set { textField.layer.backgroundColor = newValue?.cgColor }
     }
     
     var textColor: UIColor? {
@@ -223,21 +204,17 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     }
     
     var inputWidth: CGFloat {
-        get { return inputWidthConstraint?.constant ?? 0 }
-        set {
-            inputWidthConstraint?.constant = newValue
-            inputWidthConstraint?.isActive = true
-        }
+        get { return widthConstraint ?? 342 }
+        set { widthConstraint = newValue }
     }
- 
+
     var inputHeight: CGFloat {
-        get { return inputHeightConstraint?.constant ?? 0 }
-        set {
-            inputHeightConstraint?.constant = newValue
-            inputHeightConstraint?.isActive = true
-        }
+        get { return heightConstraint ?? 36 }
+        set { heightConstraint = newValue }
     }
 }
+
+// MARK: - UIResponder methods
 
 extension BasisTheoryTextFieldWrapper {
     /// Make `ForagePINTextField` focused.

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -47,6 +47,9 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     
     var tfTintColor: UIColor?
     
+    var inputWidthConstraint: NSLayoutConstraint?
+    var inputHeightConstraint: NSLayoutConstraint?
+    
     private var cancellables = Set<AnyCancellable>()
     
     var verticalConstraint: [NSLayoutConstraint]?
@@ -77,6 +80,12 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         textField.keyboardType = UIKeyboardType.phonePad
         textField.isSecureTextEntry = true
         textField.textAlignment = .center
+        
+        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: inputHeight)
+        inputHeightConstraint?.isActive = true
+        
+        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: inputWidth)
+        inputWidthConstraint?.isActive = true
         
         let regexDigit = try! NSRegularExpression(pattern: "\\d")
         
@@ -211,6 +220,22 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     var textAlignment: NSTextAlignment {
         get { return textField.textAlignment }
         set { textField.textAlignment = newValue }
+    }
+    
+    var inputWidth: CGFloat {
+        get { return inputWidthConstraint?.constant ?? 0 }
+        set {
+            inputWidthConstraint?.constant = newValue
+            inputWidthConstraint?.isActive = true
+        }
+    }
+ 
+    var inputHeight: CGFloat {
+        get { return inputHeightConstraint?.constant ?? 0 }
+        set {
+            inputHeightConstraint?.constant = newValue
+            inputHeightConstraint?.isActive = true
+        }
     }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -34,6 +34,9 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     
     var tfTintColor: UIColor?
     
+    var inputWidthConstraint: NSLayoutConstraint?
+    var inputHeightConstraint: NSLayoutConstraint?
+    
     private let textField: VGSTextField
     
     override init(frame: CGRect) {
@@ -73,6 +76,13 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
             centerXAnchor: nil,
             padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         )
+        
+        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: inputHeight)
+        inputHeightConstraint?.isActive = true
+        
+        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: inputWidth)
+        inputWidthConstraint?.isActive = true
+        
         textField.isSecureTextEntry = true
         
         textField.delegate = self
@@ -144,6 +154,22 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     var textAlignment: NSTextAlignment {
         get { return textField.textAlignment }
         set { textField.textAlignment = newValue }
+    }
+    
+    var inputWidth: CGFloat {
+        get { return inputWidthConstraint?.constant ?? 0 }
+        set {
+            inputWidthConstraint?.constant = newValue
+            inputWidthConstraint?.isActive = true
+        }
+    }
+ 
+    var inputHeight: CGFloat {
+        get { return inputHeightConstraint?.constant ?? 0 }
+        set {
+            inputHeightConstraint?.constant = newValue
+            inputHeightConstraint?.isActive = true
+        }
     }
 }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -115,10 +115,6 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         textField.cleanText()
     }
     
-    func setPlaceholder(_ text: String) {
-        textField.placeholder = text
-    }
-    
     var borderWidth: CGFloat {
         get { return textField.borderWidth }
         set { textField.borderWidth = newValue }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -10,6 +10,8 @@ import VGSCollectSDK
 
 class VGSTextFieldWrapper: UIView, VaultWrapper {
     
+    // MARK: - Properties
+    
     @IBInspectable public var isEmpty: Bool {
         get { return textField.state.isEmpty }
     }
@@ -22,22 +24,32 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         get { return textField.state.inputLength == 4 }
     }
     
-    func clearText() {
-        textField.cleanText()
-    }
-    
-    var collector: VaultCollector
+    private let textField: VGSTextField
+    private var inputWidthConstraint: NSLayoutConstraint?
+    private var inputHeightConstraint: NSLayoutConstraint?
     
     var delegate: VaultWrapperDelegate?
-    
+    var collector: VaultCollector
     var placeholder: String?
-    
     var tfTintColor: UIColor?
     
-    var inputWidthConstraint: NSLayoutConstraint?
-    var inputHeightConstraint: NSLayoutConstraint?
+    var widthConstraint: CGFloat? {
+        didSet {
+            if let widthConstraint = widthConstraint {
+                inputWidthConstraint?.constant = widthConstraint
+            }
+        }
+    }
     
-    private let textField: VGSTextField
+    var heightConstraint: CGFloat? {
+        didSet {
+            if let heightConstraint = heightConstraint {
+                inputHeightConstraint?.constant = heightConstraint
+            }
+        }
+    }
+    
+    // MARK: - Initialization
     
     override init(frame: CGRect) {
         textField = VGSTextField()
@@ -57,6 +69,7 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     
     private func commonInit() {
         addSubview(textField)
+        
         var rules = VGSValidationRuleSet()
         rules.add(rule: VGSValidationRulePattern(pattern: "^[0-9]+$", error: VGSValidationErrorType.pattern.rawValue))
         let configuration = VGSConfiguration(collector: (collector as! VGSCollectWrapper).vgsCollect, fieldName: "pin")
@@ -67,7 +80,6 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         textField.configuration = configuration
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.textAlignment = .center
-
         textField.anchor(
             top: self.topAnchor,
             leading: self.leadingAnchor,
@@ -77,68 +89,59 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
             padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         )
         
-        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: inputHeight)
-        inputHeightConstraint?.isActive = true
-        
-        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: inputWidth)
-        inputWidthConstraint?.isActive = true
+        setupWidthHeightConstraints()
         
         textField.isSecureTextEntry = true
-        
         textField.delegate = self
     }
+    
+    // MARK: - Private API
+    
+    private func setupWidthHeightConstraints() {
+        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: 342)
+        inputWidthConstraint?.isActive = true
+        
+        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: 36)
+        inputHeightConstraint?.isActive = true
+    }
+    
+    // MARK: - Public API
     
     func setPlaceholderText(_ text: String) {
         textField.placeholder = text
     }
     
-    var borderWidth: CGFloat {
-        get {
-            return textField.borderWidth
-        }
-        set {
-            textField.borderWidth = newValue
-        }
-    }
-    
-    var borderRadius: CGFloat {
-        get {
-            return textField.cornerRadius
-        }
-        set {
-            textField.cornerRadius = newValue
-        }
-    }
-    
-    var padding: UIEdgeInsets {
-        get {
-            return textField.padding
-        }
-        set {
-            textField.padding = newValue
-        }
-    }
-    
-    var borderColor: UIColor? {
-        get {
-            return textField.borderColor
-        }
-        set {
-            textField.borderColor = newValue
-        }
-    }
-    
-    override var backgroundColor: UIColor? {
-        get {
-            return textField.backgroundColor
-        }
-        set {
-            textField.backgroundColor = newValue
-        }
+    func clearText() {
+        textField.cleanText()
     }
     
     func setPlaceholder(_ text: String) {
         textField.placeholder = text
+    }
+    
+    var borderWidth: CGFloat {
+        get { return textField.borderWidth }
+        set { textField.borderWidth = newValue }
+    }
+    
+    var borderRadius: CGFloat {
+        get { return textField.cornerRadius }
+        set { textField.cornerRadius = newValue }
+    }
+    
+    var padding: UIEdgeInsets {
+        get { return textField.padding }
+        set { textField.padding = newValue }
+    }
+    
+    var borderColor: UIColor? {
+        get { return textField.borderColor }
+        set { textField.borderColor = newValue }
+    }
+    
+    override var backgroundColor: UIColor? {
+        get { return textField.backgroundColor }
+        set { textField.backgroundColor = newValue }
     }
 
     var textColor: UIColor? {
@@ -157,21 +160,17 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     }
     
     var inputWidth: CGFloat {
-        get { return inputWidthConstraint?.constant ?? 0 }
-        set {
-            inputWidthConstraint?.constant = newValue
-            inputWidthConstraint?.isActive = true
-        }
+        get { return widthConstraint ?? 342 }
+        set { widthConstraint = newValue }
     }
- 
+
     var inputHeight: CGFloat {
-        get { return inputHeightConstraint?.constant ?? 0 }
-        set {
-            inputHeightConstraint?.constant = newValue
-            inputHeightConstraint?.isActive = true
-        }
+        get { return heightConstraint ?? 36 }
+        set { heightConstraint = newValue }
     }
 }
+
+// MARK: - VGSTextFieldDelegate
 
 extension VGSTextFieldWrapper: VGSTextFieldDelegate {
     @objc func vgsTextFieldDidChange(_ textField: VGSTextField) {
@@ -193,6 +192,8 @@ extension VGSTextFieldWrapper: VGSTextFieldDelegate {
         delegate?.firstResponderDidChange(self)
     }
 }
+
+// MARK: - UIResponder methods
 
 extension VGSTextFieldWrapper {
     /// Make `ForagePINTextField` focused.

--- a/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
+++ b/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
@@ -29,6 +29,7 @@ public protocol Appearance {
     var tfTintColor: UIColor? { get set }
     var borderWidth: CGFloat { get set }
     var borderColor: UIColor? { get set }
+    var elementHeight: CGFloat { get set }
 }
 
 /// The visual characteristics that require input-specific customization.

--- a/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePANTextFieldTests.swift
@@ -54,4 +54,84 @@ final class ForagePANTextFieldTests: XCTestCase {
         
         XCTAssertFalse(changesAllowed)
     }
+    
+    func test_elementHeight() {
+        let newHeight = 100.0
+        foragePANTextField.elementHeight = newHeight
+        
+        let height = foragePANTextField.elementHeight
+        XCTAssertEqual(newHeight, height)
+    }
+    
+    func test_font() {
+        let newFont = UIFont.systemFont(ofSize: 14, weight: .regular)
+        foragePANTextField.font = newFont
+        
+        let font = foragePANTextField.font
+        XCTAssertEqual(newFont, font)
+    }
+    
+    func test_tintColor() {
+        let tintColor = UIColor.red
+        foragePANTextField.tfTintColor = tintColor
+        
+        let tint = foragePANTextField.tfTintColor
+        XCTAssertEqual(tintColor, tint)
+    }
+    
+    func test_textAlignment() {
+        let alignment = NSTextAlignment.center
+        foragePANTextField.textAlignment = alignment
+        
+        let textAlignment = foragePANTextField.textAlignment
+        XCTAssertEqual(alignment, textAlignment)
+    }
+    
+    func test_textColor() {
+        let color = UIColor.red
+        foragePANTextField.textColor = color
+        
+        let textColor = foragePANTextField.textColor
+        XCTAssertEqual(color, textColor)
+    }
+    
+    func test_placeholder() {
+        let placeholder = "Test placeholder"
+        foragePANTextField.placeholder = placeholder
+        
+        let textPlaceholder = foragePANTextField.placeholder
+        XCTAssertEqual(textPlaceholder, placeholder)
+    }
+    
+    func test_clearButton() {
+        let mode =  UITextField.ViewMode.always
+        foragePANTextField.clearButtonMode = mode
+        
+        let clearButton = foragePANTextField.clearButtonMode
+        XCTAssertEqual(clearButton, mode)
+    }
+    
+    func test_padding() {
+        let padding = UIEdgeInsets(top: 2.0, left: 2.0, bottom: 2.0, right: 2.0)
+        foragePANTextField.padding = padding
+        
+        let textPadding = foragePANTextField.padding
+        XCTAssertEqual(textPadding, padding)
+    }
+    
+    func test_borderColor() {
+        let borderColor = UIColor.black
+        foragePANTextField.borderColor = borderColor
+        
+        let color = foragePANTextField.borderColor
+        XCTAssertEqual(color, borderColor)
+    }
+    
+    func test_borderWidth() {
+        let borderWidth = 0.1
+        foragePANTextField.borderWidth = borderWidth
+        
+        let width = foragePANTextField.borderWidth
+        XCTAssertEqual(width, borderWidth)
+    }
 }

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -146,6 +146,15 @@ final class ForagePINTextFieldTests: XCTestCase {
         
         let color = foragePinTextField.borderColor
         XCTAssertEqual(color, borderColor)
+        
+        // Test BasisTheoryTextFieldWrapper border color
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.borderColor = .blue
+        XCTAssertEqual(btTextFieldWrapper.borderColor, .blue)
+        
+        // Test BasisTheoryTextFieldWrapper border color = .none
+        btTextFieldWrapper.borderColor = .none
+        XCTAssertEqual(btTextFieldWrapper.borderColor, nil)
     }
     
     func test_borderWidth() {
@@ -154,6 +163,16 @@ final class ForagePINTextFieldTests: XCTestCase {
         
         let width = foragePinTextField.borderWidth
         XCTAssertEqual(width, borderWidth)
+        
+        // Test VGSTextFieldWrapper border width
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.borderWidth = 10
+        XCTAssertEqual(vgsTextFieldWrapper.borderWidth, 10)
+        
+        // Test BasisTheoryTextFieldWrapper border width
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.borderWidth = 10
+        XCTAssertEqual(btTextFieldWrapper.borderWidth, 10)
     }
     
     func test_elementHeight() {
@@ -170,6 +189,14 @@ final class ForagePINTextFieldTests: XCTestCase {
 
         let width = foragePinTextField.inputWidth
         XCTAssertEqual(newWidth, width)
+        
+        // Test BasisTheoryTextFieldWrapper input width = default
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        XCTAssertEqual(btTextFieldWrapper.inputWidth, 342)
+        
+        // Test BasisTheoryTextFieldWrapper input width = custom
+        btTextFieldWrapper.inputWidth = 100
+        XCTAssertEqual(btTextFieldWrapper.inputWidth, 100)
     }
 
     func test_inputHeight() {
@@ -178,6 +205,14 @@ final class ForagePINTextFieldTests: XCTestCase {
 
         let height = foragePinTextField.inputHeight
         XCTAssertEqual(newHeight, height)
+        
+        // Test BasisTheoryTextFieldWrapper input height = default
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        XCTAssertEqual(btTextFieldWrapper.inputHeight, 36)
+        
+        // Test BasisTheoryTextFieldWrapper input height = custom
+        btTextFieldWrapper.inputHeight = 100
+        XCTAssertEqual(btTextFieldWrapper.inputHeight, 100)
     }
     
     func test_tintColor() {
@@ -194,6 +229,23 @@ final class ForagePINTextFieldTests: XCTestCase {
         
         let textAlignment = foragePinTextField.textAlignment
         XCTAssertEqual(alignment, textAlignment)
+        
+        // Test VGSTextFieldWrapper text alignment
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.textAlignment = .center
+        XCTAssertEqual(vgsTextFieldWrapper.textAlignment, .center)
+        
+        // Test BasisTheoryTextFieldWrapper text alignment
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.textAlignment = .center
+        XCTAssertEqual(btTextFieldWrapper.textAlignment, .center)
+    }
+    
+    func test_padding() {
+        // Test VGSTextFieldWrapper padding
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.padding = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        XCTAssertEqual(vgsTextFieldWrapper.padding,  UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
     }
     
     func test_font() {
@@ -202,6 +254,12 @@ final class ForagePINTextFieldTests: XCTestCase {
         
         let font = foragePinTextField.font
         XCTAssertEqual(newFont, font)
+        
+        // Test BasisTheoryTextFieldWrapper font
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        let btFont = UIFont.systemFont(ofSize: 20, weight: .bold)
+        btTextFieldWrapper.font = btFont
+        XCTAssertEqual(btTextFieldWrapper.font, btFont)
     }
     
     func test_textColor() {
@@ -210,6 +268,11 @@ final class ForagePINTextFieldTests: XCTestCase {
         
         let textColor = foragePinTextField.textColor
         XCTAssertEqual(color, textColor)
+        
+        // Test BasisTheoryTextFieldWrapper text color
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.textColor = .blue
+        XCTAssertEqual(btTextFieldWrapper.textColor, .blue)
     }
     
     func test_placeholder() {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -12,10 +12,12 @@ import VGSCollectSDK
 final class ForagePINTextFieldTests: XCTestCase {
     
     var observableState: ObservableState?
+    var foragePinTextField: ForagePINTextField!
     
     override func setUp() {
         ForageSDK.setup(ForageSDK.Config(environment: .sandbox))
         observableState = nil
+        foragePinTextField = ForagePINTextField()
     }
     
     class mockState: ObservableState {
@@ -56,8 +58,6 @@ final class ForagePINTextFieldTests: XCTestCase {
     }
     
     func test_forageElementDelegate_focusDidChange() {
-        let foragePinTextField = ForagePINTextField()
-        
         let expectedIsFirstResponder = true
         let expectedIsEmpty = false
         let expectedIsValid = true
@@ -80,8 +80,6 @@ final class ForagePINTextFieldTests: XCTestCase {
     }
     
     func test_forageElementDelegate_textFieldDidChange() {
-        let foragePinTextField = ForagePINTextField()
-        
         let expectedIsFirstResponder = false
         let expectedIsEmpty = true
         let expectedIsValid = false
@@ -105,7 +103,6 @@ final class ForagePINTextFieldTests: XCTestCase {
     
     func test_BackgroundColor() {
         // Test ForagePINTextField background color
-        let foragePinTextField = ForagePINTextField()
         foragePinTextField.backgroundColor = .lightGray
         XCTAssertEqual(foragePinTextField.backgroundColor, .lightGray)
         
@@ -126,7 +123,6 @@ final class ForagePINTextFieldTests: XCTestCase {
     
     func test_CornerRadius() {
         // Test ForagePINTextField border radius
-        let foragePinTextField = ForagePINTextField()
         foragePinTextField.borderRadius = 10
         XCTAssertEqual(foragePinTextField.borderRadius, 10)
         
@@ -139,6 +135,86 @@ final class ForagePINTextFieldTests: XCTestCase {
         let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
         btTextFieldWrapper.borderRadius = 10
         XCTAssertEqual(btTextFieldWrapper.borderRadius, 10)
+    }
+    
+    func test_borderColor() {
+        let borderColor = UIColor.black
+        foragePinTextField.borderColor = borderColor
+        
+        let color = foragePinTextField.borderColor
+        XCTAssertEqual(color, borderColor)
+    }
+    
+    func test_borderWidth() {
+        let borderWidth = 0.1
+        foragePinTextField.borderWidth = borderWidth
+        
+        let width = foragePinTextField.borderWidth
+        XCTAssertEqual(width, borderWidth)
+    }
+    
+    func test_elementHeight() {
+        let newHeight = 200.0
+        foragePinTextField.elementHeight = newHeight
+        
+        let height = foragePinTextField.elementHeight
+        XCTAssertEqual(newHeight, height)
+    }
+    
+    func test_inputWidth() {
+        let newWidth = 300.0
+        foragePinTextField.inputWidth = newWidth
+
+        let width = foragePinTextField.inputWidth
+        XCTAssertEqual(newWidth, width)
+    }
+
+    func test_inputHeight() {
+        let newHeight = 100.0
+        foragePinTextField.inputHeight = newHeight
+
+        let height = foragePinTextField.inputHeight
+        XCTAssertEqual(newHeight, height)
+    }
+    
+    func test_tintColor() {
+        let tintColor = UIColor.red
+        foragePinTextField.tfTintColor = tintColor
+        
+        let tint = foragePinTextField.tfTintColor
+        XCTAssertEqual(tintColor, tint)
+    }
+    
+    func test_textAlignment() {
+        let alignment = NSTextAlignment.center
+        foragePinTextField.textAlignment = alignment
+        
+        let textAlignment = foragePinTextField.textAlignment
+        XCTAssertEqual(alignment, textAlignment)
+    }
+    
+    func test_font() {
+        let newFont = UIFont.systemFont(ofSize: 14, weight: .regular)
+        foragePinTextField.font = newFont
+        
+        let font = foragePinTextField.font
+        XCTAssertEqual(newFont, font)
+    }
+    
+    func test_textColor() {
+        let color = UIColor.red
+        foragePinTextField.textColor = color
+        
+        let textColor = foragePinTextField.textColor
+        XCTAssertEqual(color, textColor)
+    }
+    
+    func test_placeholder() {
+        let placeholder = "Test placeholder"
+        foragePinTextField.placeholder = placeholder
+        
+        let textPlaceholder = foragePinTextField.placeholder
+        XCTAssertEqual(textPlaceholder, placeholder)
     }
 }
 


### PR DESCRIPTION
## What
- Enable customization of styling of PIN input width and height

<img width="335" alt="Screenshot 2023-09-03 at 17 45 07" src="https://github.com/teamforage/forage-ios-sdk/assets/136574617/315e120e-25c0-4d35-bef8-dcff3461af25">


## Test Plan
- ✅  iOS QA Tests passed locally
- ✅ Unit Tests passed locally
