### PR TITLE
[FX-529] Add support for error details

### DIFF
--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -72,71 +72,34 @@ class CapturePaymentView: UIView {
         return button
     }()
     
-    private let statusTypeLabel: UILabel = {
+    private let statusTypeLabel = makeLabel()
+    private let statusLabel = makeLabel()
+    private let paymentRefLabel = makeLabel()
+    private let fundingTypeLabel = makeLabel()
+    private let amountLabel = makeLabel()
+    private let errorLabel = makeLabel()
+    private let remainingBalanceLabel = makeLabel()
+
+    private static func makeLabel() -> UILabel {
         let label = UILabel()
         label.text = ""
         label.textColor = .black
         label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
         label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_status_type"
         label.isAccessibilityElement = true
         return label
-    }()
-    
-    private let statusLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_status"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let paymentRefLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_payment_ref"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let fundingTypeLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_funding_type"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let amountLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_amount"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let errorLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_error"
-        label.isAccessibilityElement = true
-        return label
-    }()
+    }
+
+    /// Set accessibilityIdentifier for all of the elements, used by mobile-qa-tests service.
+    private func configureIdentifiers() {
+        statusTypeLabel.accessibilityIdentifier = "lbl_status_type"
+        statusLabel.accessibilityIdentifier = "lbl_status"
+        paymentRefLabel.accessibilityIdentifier = "lbl_payment_ref"
+        fundingTypeLabel.accessibilityIdentifier = "lbl_funding_type"
+        amountLabel.accessibilityIdentifier = "lbl_amount"
+        errorLabel.accessibilityIdentifier = "lbl_error"
+        remainingBalanceLabel.accessibilityIdentifier = "lbl_remaining_balance"
+    }
     
     // MARK: Fileprivate Methods
     
@@ -153,6 +116,8 @@ class CapturePaymentView: UIView {
     public func render() {
         snapTextField.delegate = self
         nonSnapTextField.delegate = self
+        
+        configureIdentifiers()
         setupView()
         setupConstraints()
     }
@@ -183,6 +148,16 @@ class CapturePaymentView: UIView {
                 self.amountLabel.text = "amount=\(response.amount)"
                 self.errorLabel.text = ""
             case .failure(let error):
+                if let forageError = error as? ForageError? {
+                    let firstError = forageError?.errors.first
+                    
+                    if (firstError?.code == "ebt_error_51") {
+                        let snapBalance = firstError?.details?.snapBalance ?? "N/A"
+                        let cashBalance = firstError?.details?.cashBalance ?? "N/A"
+                        
+                        self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalance), EBT Cash: \(cashBalance)"
+                    }
+                }
                 self.errorLabel.text = "\(error)"
                 self.paymentRefLabel.text = ""
                 self.fundingTypeLabel.text = ""
@@ -196,6 +171,7 @@ class CapturePaymentView: UIView {
     
     private func setupView() {
         self.addSubview(contentView)
+        
         contentView.addSubview(titleLabel)
         contentView.addSubview(snapTextField)
         contentView.addSubview(captureSnapPaymentButton)
@@ -207,6 +183,7 @@ class CapturePaymentView: UIView {
         contentView.addSubview(fundingTypeLabel)
         contentView.addSubview(amountLabel)
         contentView.addSubview(errorLabel)
+        contentView.addSubview(remainingBalanceLabel)
     }
     
     private func setupConstraints() {
@@ -319,6 +296,15 @@ class CapturePaymentView: UIView {
         
         errorLabel.anchor(
             top: amountLabel.safeAreaLayoutGuide.bottomAnchor,
+            leading: contentView.safeAreaLayoutGuide.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
+        )
+        
+        remainingBalanceLabel.anchor(
+            top: errorLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -265,7 +265,15 @@ extension LiveForageService: Polling {
                         let statusCode = error.statusCode
                         let forageErrorCode = error.forageCode
                         let message = error.message
-                        let forageError = ForageError(errors: [ForageErrorObj(httpStatusCode: statusCode, code: forageErrorCode, message: message)])
+                        let details = error.details
+                        let forageError = ForageError(errors: [
+                            ForageErrorObj(
+                                httpStatusCode: statusCode,
+                                code: forageErrorCode,
+                                message: message,
+                                details: details
+                            )
+                        ])
                         
                         self.logger?.error(
                             "Received SQS Error message for \(self.getLogSuffix(request))",

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -23,12 +23,50 @@ internal struct ForageErrorSource: Codable {
     let ref: String
 }
 
+/// Represents an error that occurs when a request to submit a `ForageElement` to the Forage API fails.
 public struct ForageError: Error, Codable {
+    /// An array of error objects returned from the Forage API.
     public let errors: [ForageErrorObj]
 }
 
+/// Contains additional details about a Forage API error.
+public struct ForageErrorDetails: Codable {
+    /// The remaining SNAP balance
+    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
+    public let snapBalance: String?
+    
+    /// The remaining EBT Cash balance.
+    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
+    public let cashBalance: String?
+    
+    private enum CodingKeys : String, CodingKey {
+        case snapBalance = "snap_balance"
+        case cashBalance = "cash_balance"
+    }
+}
+
+/// Represents a detailed error object returned by the Forage API.
+/// Provides additional context about the HTTP status, error code, and developer-facing message.
+/// [Learn more about SDK errors](https://docs.joinforage.app/reference/errors#sdk-errors)
 public struct ForageErrorObj: Codable {
+    /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int
+    
+    /// A short string explaining why the request failed. The error code string corresponds to the HTTP status code.
+    /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
     public let code: String
+    
+    /// A developer-facing message about the error, not to be displayed to customers.
     public let message: String
+    
+    /// Additional details about the error, such as remaining EBT card balances.
+    /// Only non-nil when additional context is available (e.g. when the error code is `ebt_error_51`)
+    public let details: ForageErrorDetails?
+    
+    internal init(httpStatusCode: Int, code: String, message: String, details: ForageErrorDetails? = nil) {
+        self.httpStatusCode = httpStatusCode
+        self.code = code
+        self.message = message
+        self.details = details
+    }
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
@@ -11,11 +11,13 @@ internal struct ForageSQSError: Codable {
     let statusCode: Int
     let forageCode: String
     let message: String
+    let details: ForageErrorDetails?
     
     private enum CodingKeys: String, CodingKey {
         case statusCode = "status_code"
         case forageCode = "forage_code"
         case message
+        case details
     }
 }
 
@@ -41,7 +43,7 @@ internal struct MessageResponseModel: Codable {
         messageType = try container.decode(String.self, forKey: .messageType)
         status = try container.decode(String.self, forKey: .status)
         failed = try container.decode(Bool.self, forKey: .failed)
-        
+
         do {
             errors = try container.decode([ForageSQSError].self, forKey: .errors)
         } catch {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Add support for `ForageErrorObj.details` 
- Add helpful comments to error structs, to improve dev experience and reduce integration time
- Show details in payment capture page
- Reduce duplication in sample app payment capture page

<img src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/25436bfc-ac12-4234-a3ce-0157d174c006" width="300px">


<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-529/ios-expose-details-field-for-forageerror

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

Used this [test card](https://docs.joinforage.app/docs/test-ebt-cards#:~:text=Expired%20card-,4444444444444451,-Insufficient%20funds) to force insufficient funds error

Created [this ticket](https://linear.app/joinforage/issue/FX-532/ios-add-e2e-test-assertion-for-error-details-on-insufficient-funds) to add e2e tests for covering this change.

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is.

Can share the following snippet with GoPuff for error-handling info:

```swift
 case .failure(let error):
    if let forageError = error as? ForageError? {
        let firstError = forageError?.errors.first
        
        if (firstError?.code == "ebt_error_51") {
            let snapBalance = firstError?.details?.snapBalance ?? "N/A"
            let cashBalance = firstError?.details?.cashBalance ?? "N/A"

            // display these details
            print("firstForageError.details: remaining balances are SNAP: \(snapBalance), EBT Cash: \(cashBalance)")
        }
    }
```