### PR TITLE
[FX-535] iOS expose cornerradius and maskstobound for pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A component the securely accepts an EBT PIN for balance requests and payment cap
 private let foragePinTextField: ForagePINTextField = {
     let tf = ForagePINTextField()
     tf.borderRadius = 10
-    tf.backgroundColor = .lightGray
+    tf.backgroundColor = .systemGray6
     tf.pinType = .balance
     return tf
 }()

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -44,7 +44,6 @@ class RequestBalanceView: UIView {
         tf.pinType = .balance
         tf.accessibilityIdentifier = "tf_pin_balance"
         tf.isAccessibilityElement = true
-        tf.cornerRadius = 10
         return tf
     }()
     

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -44,6 +44,7 @@ class RequestBalanceView: UIView {
         tf.pinType = .balance
         tf.accessibilityIdentifier = "tf_pin_balance"
         tf.isAccessibilityElement = true
+        tf.cornerRadius = 10
         return tf
     }()
     

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -36,9 +36,17 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     
     internal var collector: VaultCollector?
     
-    // TODO: This is a no-op for now
     /// CornerRadius for the text field
-    public var cornerRadius: CGFloat = 0
+    @IBInspectable public var cornerRadius: CGFloat {
+        get { return textField.cornerRadius }
+        set { textField.cornerRadius = newValue }
+    }
+    
+    /// MasksToBounds for the text field
+    @IBInspectable public var masksToBounds: Bool {
+        get { return textField.masksToBounds }
+        set { textField.masksToBounds = newValue }
+    }
     
     /// BorderWidth for the text field
     @IBInspectable public var borderWidth: CGFloat {
@@ -50,12 +58,6 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     @IBInspectable public var borderColor: UIColor? {
         get { return textField.borderColor }
         set { textField.borderColor = newValue }
-    }
-    
-    /// BorderRadius for the text field
-    @IBInspectable public var borderRadius: CGFloat {
-        get { return textField.borderRadius }
-        set { textField.borderRadius = newValue }
     }
     
     /// Padding for the text field
@@ -153,18 +155,21 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         
         var tf: VaultWrapper?
         
-        if (vaultType == VaultType.vgsVaultType) {
-            tf = VGSTextFieldWrapper()
-        } else if (vaultType == VaultType.btVaultType) {
-            tf = BasisTheoryTextFieldWrapper()
-        } else {
-            tf = VGSTextFieldWrapper()
-        }
+//        if (vaultType == VaultType.vgsVaultType) {
+//            tf = VGSTextFieldWrapper()
+//        } else if (vaultType == VaultType.btVaultType) {
+//            tf = BasisTheoryTextFieldWrapper()
+//        } else {
+//            tf = VGSTextFieldWrapper()
+//        }
+        
+        tf = BasisTheoryTextFieldWrapper()
         
         tf?.textColor = UIColor.black
         tf?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         tf?.borderWidth = 0.25
-        tf?.borderRadius = 4
+        tf?.cornerRadius = 4
+        tf?.masksToBounds = true
         tf?.borderColor = UIColor.lightGray
         tf?.backgroundColor = UIColor.white
         tf?.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -155,23 +155,21 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         
         var tf: VaultWrapper?
         
-//        if (vaultType == VaultType.vgsVaultType) {
-//            tf = VGSTextFieldWrapper()
-//        } else if (vaultType == VaultType.btVaultType) {
-//            tf = BasisTheoryTextFieldWrapper()
-//        } else {
-//            tf = VGSTextFieldWrapper()
-//        }
-        
-        tf = BasisTheoryTextFieldWrapper()
+        if (vaultType == VaultType.vgsVaultType) {
+            tf = VGSTextFieldWrapper()
+        } else if (vaultType == VaultType.btVaultType) {
+            tf = BasisTheoryTextFieldWrapper()
+        } else {
+            tf = VGSTextFieldWrapper()
+        }
         
         tf?.textColor = UIColor.black
         tf?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        tf?.borderWidth = 0.25
-        tf?.cornerRadius = 4
+        tf?.borderWidth = 0
+        tf?.cornerRadius = 16
         tf?.masksToBounds = true
-        tf?.borderColor = UIColor.lightGray
-        tf?.backgroundColor = UIColor.white
+        tf?.borderColor = .clear
+        tf?.backgroundColor = UIColor.lightGray
         tf?.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         collector = tf?.collector
         

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -169,7 +169,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         tf?.cornerRadius = 16
         tf?.masksToBounds = true
         tf?.borderColor = .clear
-        tf?.backgroundColor = UIColor.lightGray
+        tf?.backgroundColor = .systemGray6
         tf?.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         collector = tf?.collector
         

--- a/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
@@ -29,7 +29,8 @@ internal protocol InternalAppearance {
     var tfTintColor: UIColor? { get set }
     var borderWidth: CGFloat { get set }
     var borderColor: UIColor? { get set }
-    var borderRadius: CGFloat { get set }
+    var cornerRadius: CGFloat { get set }
+    var masksToBounds: Bool { get set }
     var backgroundColor: UIColor? { get set }
     var font: UIFont? { get set }
 }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -131,12 +131,21 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
         }
     }
     
-    var borderRadius: CGFloat {
+    var cornerRadius: CGFloat {
         get {
             return textField.layer.cornerRadius
         }
         set {
             textField.layer.cornerRadius = newValue
+        }
+    }
+    
+    var masksToBounds: Bool {
+        get {
+            return textField.layer.masksToBounds
+        }
+        set {
+            textField.layer.masksToBounds = newValue
         }
     }
     

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -91,7 +91,16 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
         }
     }
     
-    var borderRadius: CGFloat {
+    var masksToBounds: Bool {
+        get {
+            return textField.layer.masksToBounds
+        }
+        set {
+            textField.layer.masksToBounds = newValue
+        }
+    }
+    
+    var cornerRadius: CGFloat {
         get {
             return textField.cornerRadius
         }

--- a/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
+++ b/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
@@ -30,6 +30,7 @@ public protocol Appearance {
     var borderWidth: CGFloat { get set }
     var borderColor: UIColor? { get set }
     var cornerRadius: CGFloat { get set }
+    var masksToBounds: Bool { get set }
 }
 
 /// The visual characteristics that require input-specific customization.

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -128,20 +128,35 @@ final class ForagePINTextFieldTests: XCTestCase {
     }
     
     func test_CornerRadius() {
-        // Test ForagePINTextField border radius
+        // Test ForagePINTextField corner radius
         let foragePinTextField = ForagePINTextField()
-        foragePinTextField.borderRadius = 10
-        XCTAssertEqual(foragePinTextField.borderRadius, 10)
+        foragePinTextField.cornerRadius = 10
+        XCTAssertEqual(foragePinTextField.cornerRadius, 10)
         
-        // Test VGSTextFieldWrapper border radius
+        // Test VGSTextFieldWrapper corner radius
         let vgsTextFieldWrapper = VGSTextFieldWrapper()
-        vgsTextFieldWrapper.borderRadius = 10
-        XCTAssertEqual(vgsTextFieldWrapper.borderRadius, 10)
+        vgsTextFieldWrapper.cornerRadius = 10
+        XCTAssertEqual(vgsTextFieldWrapper.cornerRadius, 10)
         
-        // Test BasisTheoryTextFieldWrapper border radius
+        // Test BasisTheoryTextFieldWrapper corner radius
         let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
-        btTextFieldWrapper.borderRadius = 10
-        XCTAssertEqual(btTextFieldWrapper.borderRadius, 10)
+        btTextFieldWrapper.cornerRadius = 10
+        XCTAssertEqual(btTextFieldWrapper.cornerRadius, 10)
+    }
+    
+    func text_MasksToBounds() {
+        let foragePinTextField = ForagePINTextField()
+        let newVal = false
+        foragePinTextField.masksToBounds = newVal
+        XCTAssertEqual(foragePinTextField.masksToBounds, newVal)
+        
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.masksToBounds = newVal
+        XCTAssertEqual(vgsTextFieldWrapper.masksToBounds, newVal)
+        
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.masksToBounds = newVal
+        XCTAssertEqual(btTextFieldWrapper.masksToBounds, newVal)
     }
 }
 

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -132,19 +132,19 @@ final class ForagePINTextFieldTests: XCTestCase {
         let foragePinTextField = ForagePINTextField()
         foragePinTextField.cornerRadius = 10
         XCTAssertEqual(foragePinTextField.cornerRadius, 10)
-        
+
         // Test VGSTextFieldWrapper corner radius
         let vgsTextFieldWrapper = VGSTextFieldWrapper()
         vgsTextFieldWrapper.cornerRadius = 10
         XCTAssertEqual(vgsTextFieldWrapper.cornerRadius, 10)
-        
+
         // Test BasisTheoryTextFieldWrapper corner radius
         let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
         btTextFieldWrapper.cornerRadius = 10
         XCTAssertEqual(btTextFieldWrapper.cornerRadius, 10)
     }
     
-    func text_MasksToBounds() {
+    func test_MasksToBounds() {
         let foragePinTextField = ForagePINTextField()
         let newVal = false
         foragePinTextField.masksToBounds = newVal


### PR DESCRIPTION
## What
Expose PIN fields so that GoPuff doesn't need to hack to set the values.

BT:
<img width="324" alt="Screenshot 2023-09-07 at 10 56 35 AM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/d287374d-d4e0-41cc-8f0a-2044cbe668b7">

VGS:
<img width="330" alt="Screenshot 2023-09-07 at 10 58 59 AM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/457d3b07-0e0c-42ef-89ec-ce58350062a6">

