### PR TITLE
[FX-529] Add support for error details

### DIFF
--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -72,71 +72,34 @@ class CapturePaymentView: UIView {
         return button
     }()
     
-    private let statusTypeLabel: UILabel = {
+    private let statusTypeLabel = makeLabel()
+    private let statusLabel = makeLabel()
+    private let paymentRefLabel = makeLabel()
+    private let fundingTypeLabel = makeLabel()
+    private let amountLabel = makeLabel()
+    private let errorLabel = makeLabel()
+    private let remainingBalanceLabel = makeLabel()
+
+    private static func makeLabel() -> UILabel {
         let label = UILabel()
         label.text = ""
         label.textColor = .black
         label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
         label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_status_type"
         label.isAccessibilityElement = true
         return label
-    }()
-    
-    private let statusLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_status"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let paymentRefLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_payment_ref"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let fundingTypeLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_funding_type"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let amountLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_amount"
-        label.isAccessibilityElement = true
-        return label
-    }()
-    
-    private let errorLabel: UILabel = {
-        let label = UILabel()
-        label.text = ""
-        label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        label.numberOfLines = 0
-        label.accessibilityIdentifier = "lbl_error"
-        label.isAccessibilityElement = true
-        return label
-    }()
+    }
+
+    /// Set accessibilityIdentifier for all of the elements, used by mobile-qa-tests service.
+    private func configureIdentifiers() {
+        statusTypeLabel.accessibilityIdentifier = "lbl_status_type"
+        statusLabel.accessibilityIdentifier = "lbl_status"
+        paymentRefLabel.accessibilityIdentifier = "lbl_payment_ref"
+        fundingTypeLabel.accessibilityIdentifier = "lbl_funding_type"
+        amountLabel.accessibilityIdentifier = "lbl_amount"
+        errorLabel.accessibilityIdentifier = "lbl_error"
+        remainingBalanceLabel.accessibilityIdentifier = "lbl_remaining_balance"
+    }
     
     // MARK: Fileprivate Methods
     
@@ -153,6 +116,8 @@ class CapturePaymentView: UIView {
     public func render() {
         snapTextField.delegate = self
         nonSnapTextField.delegate = self
+        
+        configureIdentifiers()
         setupView()
         setupConstraints()
     }
@@ -183,6 +148,16 @@ class CapturePaymentView: UIView {
                 self.amountLabel.text = "amount=\(response.amount)"
                 self.errorLabel.text = ""
             case .failure(let error):
+                if let forageError = error as? ForageError? {
+                    let firstError = forageError?.errors.first
+                    
+                    if (firstError?.code == "ebt_error_51") {
+                        let snapBalance = firstError?.details?.snapBalance ?? "N/A"
+                        let cashBalance = firstError?.details?.cashBalance ?? "N/A"
+                        
+                        self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalance), EBT Cash: \(cashBalance)"
+                    }
+                }
                 self.errorLabel.text = "\(error)"
                 self.paymentRefLabel.text = ""
                 self.fundingTypeLabel.text = ""
@@ -196,6 +171,7 @@ class CapturePaymentView: UIView {
     
     private func setupView() {
         self.addSubview(contentView)
+        
         contentView.addSubview(titleLabel)
         contentView.addSubview(snapTextField)
         contentView.addSubview(captureSnapPaymentButton)
@@ -207,6 +183,7 @@ class CapturePaymentView: UIView {
         contentView.addSubview(fundingTypeLabel)
         contentView.addSubview(amountLabel)
         contentView.addSubview(errorLabel)
+        contentView.addSubview(remainingBalanceLabel)
     }
     
     private func setupConstraints() {
@@ -317,6 +294,15 @@ class CapturePaymentView: UIView {
         
         errorLabel.anchor(
             top: amountLabel.safeAreaLayoutGuide.bottomAnchor,
+            leading: contentView.safeAreaLayoutGuide.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: UIEdgeInsets(top: 24, left: 24, bottom: 0, right: 24)
+        )
+        
+        remainingBalanceLabel.anchor(
+            top: errorLabel.safeAreaLayoutGuide.bottomAnchor,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: nil,
             trailing: contentView.safeAreaLayoutGuide.trailingAnchor,

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -153,7 +153,7 @@ class CapturePaymentView: UIView {
                     let errorDetails = firstError?.details
                                     
                     switch errorDetails {
-                    case .insufficientFunds(let snapBalance, let cashBalance):
+                    case .ebtError51(let snapBalance, let cashBalance):
                         let snapBalanceText = snapBalance ?? "N/A"
                         let cashBalanceText = cashBalance ?? "N/A"
                         

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -152,10 +152,13 @@ class CapturePaymentView: UIView {
                     let firstError = forageError?.errors.first
                     
                     if (firstError?.code == "ebt_error_51") {
-                        let snapBalance = firstError?.details?.snapBalance ?? "N/A"
-                        let cashBalance = firstError?.details?.cashBalance ?? "N/A"
-                        
-                        self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalance), EBT Cash: \(cashBalance)"
+                        let errorDetails = firstError?.details
+                                                
+                        if case .insufficientFunds(let snapBalance, let cashBalance)? = errorDetails {
+                            self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalance ?? "N/A"), EBT Cash: \(cashBalance ?? "N/A")"
+                        } else {
+                            self.remainingBalanceLabel.text = "firstForageError.details: Missing insufficient funds error details!"
+                        }
                     }
                 }
                 self.errorLabel.text = "\(error)"

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -150,15 +150,16 @@ class CapturePaymentView: UIView {
             case .failure(let error):
                 if let forageError = error as? ForageError? {
                     let firstError = forageError?.errors.first
-                    
-                    if (firstError?.code == "ebt_error_51") {
-                        let errorDetails = firstError?.details
-                                                
-                        if case .insufficientFunds(let snapBalance, let cashBalance)? = errorDetails {
-                            self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalance ?? "N/A"), EBT Cash: \(cashBalance ?? "N/A")"
-                        } else {
-                            self.remainingBalanceLabel.text = "firstForageError.details: Missing insufficient funds error details!"
-                        }
+                    let errorDetails = firstError?.details
+                                    
+                    switch errorDetails {
+                    case .insufficientFunds(let snapBalance, let cashBalance):
+                        let snapBalanceText = snapBalance ?? "N/A"
+                        let cashBalanceText = cashBalance ?? "N/A"
+                        
+                        self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalanceText), EBT Cash: \(cashBalanceText)"
+                    default:
+                        self.remainingBalanceLabel.text = "firstForageError.details: Missing insufficient funds error details!"
                     }
                 }
                 self.errorLabel.text = "\(error)"

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -267,7 +267,15 @@ extension LiveForageService: Polling {
                         let statusCode = error.statusCode
                         let forageErrorCode = error.forageCode
                         let message = error.message
-                        let forageError = ForageError(errors: [ForageErrorObj(httpStatusCode: statusCode, code: forageErrorCode, message: message)])
+                        let details = error.details
+                        let forageError = ForageError(errors: [
+                            ForageErrorObj(
+                                httpStatusCode: statusCode,
+                                code: forageErrorCode,
+                                message: message,
+                                details: details
+                            )
+                        ])
                         
                         self.logger?.error(
                             "Received SQS Error message for \(self.getLogSuffix(request))",

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -23,12 +23,50 @@ internal struct ForageErrorSource: Codable {
     let ref: String
 }
 
+/// Represents an error that occurs when a request to submit a `ForageElement` to the Forage API fails.
 public struct ForageError: Error, Codable {
+    /// An array of error objects returned from the Forage API.
     public let errors: [ForageErrorObj]
 }
 
+/// Contains additional details about a Forage API error.
+public struct ForageErrorDetails: Codable {
+    /// The remaining SNAP balance
+    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
+    public let snapBalance: String?
+    
+    /// The remaining EBT Cash balance.
+    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
+    public let cashBalance: String?
+    
+    private enum CodingKeys : String, CodingKey {
+        case snapBalance = "snap_balance"
+        case cashBalance = "cash_balance"
+    }
+}
+
+/// Represents a detailed error object returned by the Forage API.
+/// Provides additional context about the HTTP status, error code, and developer-facing message.
+/// [Learn more about SDK errors](https://docs.joinforage.app/reference/errors#sdk-errors)
 public struct ForageErrorObj: Codable {
+    /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int
+    
+    /// A short string explaining why the request failed. The error code string corresponds to the HTTP status code.
+    /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
     public let code: String
+    
+    /// A developer-facing message about the error, not to be displayed to customers.
     public let message: String
+    
+    /// Additional details about the error, such as remaining EBT card balances.
+    /// Only non-nil when additional context is available (e.g. when the error code is `ebt_error_51`)
+    public let details: ForageErrorDetails?
+    
+    internal init(httpStatusCode: Int, code: String, message: String, details: ForageErrorDetails? = nil) {
+        self.httpStatusCode = httpStatusCode
+        self.code = code
+        self.message = message
+        self.details = details
+    }
 }

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -32,18 +32,16 @@ public struct ForageError: Error, Codable {
 /// Contains additional details about a Forage API error.
 /// 
 public enum ForageErrorDetails: Codable {
-    /// Used for displaying SNAP and EBT Cash balances when an insufficient funds error occurs.
-    ///
-    /// - Important: Typically used when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
-    case insufficientFunds(snapBalance: String?, cashBalance: String?)
+    /// Use this to display the SNAP and EBT Cash balances when an [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51) error occurs
+    case ebtError51(snapBalance: String?, cashBalance: String?)
     
     /// Received a malformed details object from the Forage API
     case invalid
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let details = try? container.decode(InsufficientFundsDetails.self) {
-            self = .insufficientFunds(snapBalance: details.snapBalance, cashBalance: details.cashBalance)
+        if let details = try? container.decode(EbtError51Details.self) {
+            self = .ebtError51(snapBalance: details.snapBalance, cashBalance: details.cashBalance)
             return
         }
         
@@ -51,7 +49,7 @@ public enum ForageErrorDetails: Codable {
     }
 }
 
-public struct InsufficientFundsDetails: Codable {
+public struct EbtError51Details: Codable {
     public let snapBalance: String?
     
     public let cashBalance: String?

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -30,9 +30,15 @@ public struct ForageError: Error, Codable {
 }
 
 /// Contains additional details about a Forage API error.
+/// 
 public enum ForageErrorDetails: Codable {
+    /// Used for displaying SNAP and EBT Cash balances when an insufficient funds error occurs.
+    ///
+    /// - Important: Typically used when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
     case insufficientFunds(snapBalance: String?, cashBalance: String?)
-    case unexpected
+    
+    /// Received a malformed details object from the Forage API
+    case invalid
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -41,18 +47,13 @@ public enum ForageErrorDetails: Codable {
             return
         }
         
-        self = .unexpected
+        self = .invalid
     }
 }
 
-/// Allows you to display the SNAP balance and EBT Cash balance when an insufficient funds error (ebt_error_51) occurs
 public struct InsufficientFundsDetails: Codable {
-    /// The remaining SNAP balance
-    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
     public let snapBalance: String?
     
-    /// The remaining EBT Cash balance.
-    /// Only populated when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
     public let cashBalance: String?
     
     private enum CodingKeys : String, CodingKey {
@@ -75,8 +76,8 @@ public struct ForageErrorObj: Codable {
     /// A developer-facing message about the error, not to be displayed to customers.
     public let message: String
     
-    /// Additional details about the error, such as remaining EBT card balances.
-    /// Only non-nil when additional context is available (e.g. when the error code is `ebt_error_51`)
+    /// Additional details about the error, included for your convenience.
+    /// Not nil when details are available, e.g. when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
     public let details: ForageErrorDetails?
     
     internal init(httpStatusCode: Int, code: String, message: String, details: ForageErrorDetails? = nil) {

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
@@ -11,11 +11,13 @@ internal struct ForageSQSError: Codable {
     let statusCode: Int
     let forageCode: String
     let message: String
+    let details: ForageErrorDetails?
     
     private enum CodingKeys: String, CodingKey {
         case statusCode = "status_code"
         case forageCode = "forage_code"
         case message
+        case details
     }
 }
 
@@ -41,7 +43,7 @@ internal struct MessageResponseModel: Codable {
         messageType = try container.decode(String.self, forKey: .messageType)
         status = try container.decode(String.self, forKey: .status)
         failed = try container.decode(Bool.self, forKey: .failed)
-        
+
         do {
             errors = try container.decode([ForageSQSError].self, forKey: .errors)
         } catch {

--- a/Tests/ForageSDKTests/ForageErrorTests.swift
+++ b/Tests/ForageSDKTests/ForageErrorTests.swift
@@ -22,11 +22,11 @@ final class ForageErrorTests: XCTestCase {
         XCTAssertEqual(decodedError.code, "ebt_error_51")
         XCTAssertEqual(decodedError.message, "Insufficient Funds")
         
-        if case .insufficientFunds(let snapBalance, let cashBalance)? = decodedError.details {
+        if case .ebtError51(let snapBalance, let cashBalance)? = decodedError.details {
             XCTAssertEqual(snapBalance, "20.00")
             XCTAssertEqual(cashBalance, "30.12")
         } else {
-            XCTFail("Decoded details should be of type .insufficientFunds")
+            XCTFail("Decoded details should be of type .ebtError51")
         }
     }
     
@@ -47,11 +47,11 @@ final class ForageErrorTests: XCTestCase {
         XCTAssertEqual(decodedError.httpStatusCode, 400)
         XCTAssertEqual(decodedError.code, "ebt_error_51")
         XCTAssertEqual(decodedError.message, "Almost Insufficient Funds, but not")
-        if case .insufficientFunds(let snapBalance, let cashBalance)? = decodedError.details {
+        if case .ebtError51(let snapBalance, let cashBalance)? = decodedError.details {
             XCTAssertNil(snapBalance)
             XCTAssertEqual(cashBalance, "123.34")
         } else {
-            XCTFail("Decoded details should be of type .insufficientFunds")
+            XCTFail("Decoded details should be of type .ebtError51")
         }
     }
     

--- a/Tests/ForageSDKTests/ForageErrorTests.swift
+++ b/Tests/ForageSDKTests/ForageErrorTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import ForageSDK
+
+final class ForageErrorTests: XCTestCase {
+    func testDecoding_ErrorWithInsufficientFunds_SetsSnapAndCash() throws {
+        let jsonString = """
+            {
+                "httpStatusCode": 400,
+                "code": "ebt_error_51",
+                "message": "Insufficient Funds",
+                "details": {
+                    "snap_balance": "20.00",
+                    "cash_balance": "30.12"
+                }
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedError = try JSONDecoder().decode(ForageErrorObj.self, from: jsonData)
+        
+        XCTAssertEqual(decodedError.httpStatusCode, 400)
+        XCTAssertEqual(decodedError.code, "ebt_error_51")
+        XCTAssertEqual(decodedError.message, "Insufficient Funds")
+        
+        if case .insufficientFunds(let snapBalance, let cashBalance)? = decodedError.details {
+            XCTAssertEqual(snapBalance, "20.00")
+            XCTAssertEqual(cashBalance, "30.12")
+        } else {
+            XCTFail("Decoded details should be of type .insufficientFunds")
+        }
+    }
+    
+    func testDecoding_ErrorWithPartialInsufficientFundsDetails_SetsCashAndNilSnap() throws {
+        let jsonString = """
+            {
+               "httpStatusCode": 400,
+               "code": "ebt_error_51",
+               "message": "Almost Insufficient Funds, but not",
+               "details": {
+                   "cash_balance": "123.34"
+               }
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedError = try JSONDecoder().decode(ForageErrorObj.self, from: jsonData)
+        
+        XCTAssertEqual(decodedError.httpStatusCode, 400)
+        XCTAssertEqual(decodedError.code, "ebt_error_51")
+        XCTAssertEqual(decodedError.message, "Almost Insufficient Funds, but not")
+        if case .insufficientFunds(let snapBalance, let cashBalance)? = decodedError.details {
+            XCTAssertNil(snapBalance)
+            XCTAssertEqual(cashBalance, "123.34")
+        } else {
+            XCTFail("Decoded details should be of type .insufficientFunds")
+        }
+    }
+    
+    func testDecoding_ErrorWithUnexpectedCode_SetsDetailsToNil() throws {
+        let jsonString = """
+            {
+                "httpStatusCode": 400,
+                "code": "some_other_error",
+                "message": "Some Other Error",
+                "details": {
+                  "some_other_details": 123
+                }
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedError = try JSONDecoder().decode(ForageErrorObj.self, from: jsonData)
+        
+        XCTAssertEqual(decodedError.httpStatusCode, 400)
+        XCTAssertEqual(decodedError.code, "some_other_error")
+        XCTAssertEqual(decodedError.message, "Some Other Error")
+        XCTAssertNil(decodedError.details)
+    }
+    
+    func testDecoding_ErrorWithMissingDetails_SetsDetailsToNil() throws {
+        let jsonString = """
+            {
+                "httpStatusCode": 400,
+                "code": "some_other_error",
+                "message": "Some Other Error"
+            }
+            """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedError = try JSONDecoder().decode(ForageErrorObj.self, from: jsonData)
+        
+        XCTAssertEqual(decodedError.httpStatusCode, 400)
+        XCTAssertEqual(decodedError.code, "some_other_error")
+        XCTAssertEqual(decodedError.message, "Some Other Error")
+        XCTAssertNil(decodedError.details)
+    }
+}

--- a/Tests/ForageSDKTests/MessageResponseTests.swift
+++ b/Tests/ForageSDKTests/MessageResponseTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import ForageSDK
+
+final class MessageResponseTests: XCTestCase {
+    func testDecoding_MessageWithDetails_ReturnsCorrectDetails() throws {
+        let jsonString = """
+             {
+                 "content_id": "ee1889a2-7366-41a4-b918-bddae792d5f5",
+                 "message_type": "0200",
+                 "status": "completed",
+                 "failed": false,
+                 "errors": [
+                     {
+                         "status_code": 400,
+                         "forage_code": "ebt_error_51",
+                         "message": "Insufficient Funds",
+                         "details": {
+                             "snap_balance": "12.34",
+                             "cash_balance": "567.89"
+                         }
+                     }
+                 ]
+             }
+         """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedResponse = try JSONDecoder().decode(MessageResponseModel.self, from: jsonData)
+        
+        XCTAssertEqual(decodedResponse.contentId, "ee1889a2-7366-41a4-b918-bddae792d5f5")
+        XCTAssertEqual(decodedResponse.messageType, "0200")
+        XCTAssertEqual(decodedResponse.status, "completed")
+        XCTAssertEqual(decodedResponse.failed, false)
+        
+        guard let firstError = decodedResponse.errors.first else {
+            XCTFail("Should have at least one error")
+            return
+        }
+        
+        XCTAssertEqual(firstError.statusCode, 400)
+        XCTAssertEqual(firstError.forageCode, "ebt_error_51")
+        XCTAssertEqual(firstError.message, "Insufficient Funds")
+        
+        if case .insufficientFunds(let snapBalance, let cashBalance)? = firstError.details {
+            XCTAssertEqual(snapBalance, "12.34")
+            XCTAssertEqual(cashBalance, "567.89")
+        } else {
+            XCTFail("Decoded details should be of type .insufficientFunds")
+        }
+    }
+    
+    func testDecoding_MessageWithoutDetails_SetsDetailsToNil() throws {
+        let jsonString = """
+             {
+                 "content_id": "ee1889a2-7366-41a4-b918-bddae792d5f5",
+                 "message_type": "0200",
+                 "status": "received_on_django",
+                 "failed": true,
+                 "errors": [
+                     {
+                         "status_code": 500,
+                         "forage_code": "some_other_code",
+                         "message": "Some Error"
+                     }
+                 ]
+             }
+         """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedResponse = try JSONDecoder().decode(MessageResponseModel.self, from: jsonData)
+        
+        XCTAssertEqual(decodedResponse.contentId, "ee1889a2-7366-41a4-b918-bddae792d5f5")
+        XCTAssertEqual(decodedResponse.messageType, "0200")
+        XCTAssertEqual(decodedResponse.status, "received_on_django")
+        XCTAssertEqual(decodedResponse.failed, true)
+        
+        XCTAssertEqual(decodedResponse.errors.count, 1)
+        let firstError = decodedResponse.errors[0]
+        XCTAssertEqual(firstError.statusCode, 500)
+        XCTAssertEqual(firstError.forageCode, "some_other_code")
+        XCTAssertEqual(firstError.message, "Some Error")
+        
+        XCTAssertNil(firstError.details)
+        
+    }
+    
+    func testDecoding_MessageWithMissingErrorsArray_SetsErrorsToEmpty() throws {
+        let jsonString = """
+             {
+                 "content_id": "some_id",
+                 "message_type": "info",
+                 "status": "ok",
+                 "failed": false
+             }
+         """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedResponse = try JSONDecoder().decode(MessageResponseModel.self, from: jsonData)
+        
+        XCTAssertEqual(decodedResponse.contentId, "some_id")
+        XCTAssertEqual(decodedResponse.messageType, "info")
+        XCTAssertEqual(decodedResponse.status, "ok")
+        XCTAssertEqual(decodedResponse.failed, false)
+        
+        XCTAssertTrue(decodedResponse.errors.isEmpty)
+    }
+    
+    func testDecoding_MessageWithEmptyErrorsArray_ReturnsEmptyErrors() throws {
+        let jsonString = """
+             {
+                 "content_id": "some_id",
+                 "message_type": "info",
+                 "status": "ok",
+                 "failed": false,
+                 "errors": []
+             }
+         """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedResponse = try JSONDecoder().decode(MessageResponseModel.self, from: jsonData)
+        
+        XCTAssertEqual(decodedResponse.contentId, "some_id")
+        XCTAssertEqual(decodedResponse.messageType, "info")
+        XCTAssertEqual(decodedResponse.status, "ok")
+        XCTAssertEqual(decodedResponse.failed, false)
+        
+        XCTAssertTrue(decodedResponse.errors.isEmpty)
+    }
+}

--- a/Tests/ForageSDKTests/MessageResponseTests.swift
+++ b/Tests/ForageSDKTests/MessageResponseTests.swift
@@ -40,11 +40,11 @@ final class MessageResponseTests: XCTestCase {
         XCTAssertEqual(firstError.forageCode, "ebt_error_51")
         XCTAssertEqual(firstError.message, "Insufficient Funds")
         
-        if case .insufficientFunds(let snapBalance, let cashBalance)? = firstError.details {
+        if case .ebtError51(let snapBalance, let cashBalance)? = firstError.details {
             XCTAssertEqual(snapBalance, "12.34")
             XCTAssertEqual(cashBalance, "567.89")
         } else {
-            XCTFail("Decoded details should be of type .insufficientFunds")
+            XCTFail("Decoded details should be of type .ebtError51")
         }
     }
     


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- "v2" of PR #94 
- Add support for ForageErrorObj.details ([linear ticket](https://linear.app/joinforage/issue/FX-529/ios-expose-details-field-for-forageerror))
- Add helpful comments to error structs, to improve dev experience and reduce integration time
- Show details in payment capture page
- Reduce duplication in sample app payment capture page
- Add tests for `ForageError`
- Add tests for `MessageResponse`

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- Follow new design (strategy B) [described here](https://www.notion.so/joinforage/Details-in-Error-Object-Discussion-c1948a15620f477ea9e426e60ad701ca)
- Linear ticket: https://linear.app/joinforage/issue/FX-529/ios-expose-details-field-for-forageerror

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

- Added unit tests for `ForageError.swift` and `MessageResponseModel.swift`
- Used this [test card](https://docs.joinforage.app/docs/test-ebt-cards#:~:text=Expired%20card-,4444444444444451,-Insufficient%20funds) to force insufficient funds error
- Created [this ticket](https://linear.app/joinforage/issue/FX-532/ios-add-e2e-test-assertion-for-error-details-on-insufficient-funds) to add e2e tests for covering this change.

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is. Related Android PR should have ✅ before release   

Can share the following snippet with GoPuff:

```swift
case .failure(let error):
    if let forageError = error as? ForageError? {
        let firstError = forageError?.errors.first
        let errorDetails = firstError?.details

        // can add this where you check for error.code == "ebt_error_51"
        if case .insufficientFunds(let snapBalance, let cashBalance)? = errorDetails {
            let snapBalanceText = snapBalance ?? "N/A"
            let cashBalanceText = cashBalance ?? "N/A"
        }
    }
```

<img width="290" alt="image" src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/a6ca6c1c-1149-4d60-b3ed-5267c6df0cb0">

