### PR TITLE
[FX-547] Remove setPlaceholderText

### DIFF
--- a/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePANTextField/ForagePANTextField.swift
@@ -279,9 +279,7 @@ public class ForagePANTextField: UIView, Identifiable, ForageElement, ForageElem
     override public var intrinsicContentSize: CGSize {
         return CGSize(width: frame.width, height: 83)
     }
-    
-    public func setPlaceholderText(_ text: String) {}
-    
+        
     public func clearText() {
         self.enhancedTextField.text = ""
         self.enhancedTextField.actualPAN = ""

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -300,9 +300,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     
     public func clearText() {
         textField.clearText()
-    }
-    
-    public func setPlaceholderText(_ text: String) {}
+    }    
 }
 
 // MARK: - VaultWrapperDelegate

--- a/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Protocol/VaultWrapper.swift
@@ -47,6 +47,5 @@ internal protocol InternalStyle {
 internal protocol VaultWrapper: UIView, InternalObservableState, InternalAppearance, InternalStyle {
     var collector: VaultCollector { get set }
     var delegate: VaultWrapperDelegate? { get set }
-    func setPlaceholderText(_ text: String)
     func clearText() -> Void
 }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -150,10 +150,6 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     
     // MARK: - Public API
     
-    func setPlaceholderText(_ text: String) {
-        textField.placeholder = text
-    }
-    
     func clearText() {
         textField.text = ""
     }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -107,10 +107,6 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     
     // MARK: - Public API
     
-    func setPlaceholderText(_ text: String) {
-        textField.placeholder = text
-    }
-    
     func clearText() {
         textField.cleanText()
     }

--- a/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
+++ b/Sources/ForageSDK/Foundation/Protocol/ForageElement.swift
@@ -44,9 +44,6 @@ public protocol Style {
 public protocol ForageElement: UIView, Appearance, ObservableState, Style {
     var delegate: ForageElementDelegate? { get set }
     
-    /// Set the placeholder text of the input field.
-    func setPlaceholderText(_ text: String)
-    
     /// Clear the value in the input field.
     func clearText() -> Void
     


### PR DESCRIPTION

<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Remove redundant `setPlaceholderText`

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- https://linear.app/joinforage/issue/FX-547/bug-setplaceholdertext-is-not-implemented
- I could have deprecated this method and removed it gracefully, but no one is/should be using this method

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ iOS QA Tests passed locally
- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is. Technically a breaking change, but given no one is/should have been using this redundant method – it is safe to remove.