### PR TITLE
[POP-180] Adding jitter to retry logic

### DIFF
--- a/Sample/SampleForageSDK/Foundation/Network/Provider.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Provider.swift
@@ -105,7 +105,7 @@ internal class Provider {
         return completion(.success(result))
     }
     
-    internal func processVGSData<T: Decodable>(model: T.Type, code: Int?, data: Data?, response: URLResponse?, completion: @escaping (Result<T, Error>) -> Void) {
+    internal func processVaultData<T: Decodable>(model: T.Type, code: Int?, data: Data?, response: URLResponse?, completion: @escaping (Result<T, Error>) -> Void) {
         
         guard let data = data else {
             return completion(.failure(NSError(domain: "Invalid data", code: code ?? -991, userInfo: nil)))

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -144,7 +144,11 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     }()
     
     private lazy var textField: VaultWrapper = {
-        let vaultType = LDManager.shared.getVaultType()
+        let vaultType = LDManager.shared.getVaultType(
+            ldClient: LDManager.getDefaultLDClient(),
+            genRandomDouble: LDManager.generateRandomDouble,
+            fromCache: true
+        )
         
         var tf: VaultWrapper?
 

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -47,7 +47,7 @@ public class ForageSDK {
         
         VGSCollectLogger.shared.disableAllLoggers()
         let provider = Provider(logger: logger)
-        self.service = LiveForageService(provider: provider, logger: logger)
+        self.service = LiveForageService(provider: provider, logger: logger, ldManager: LDManager.shared)
     }
     
     /**

--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -14,7 +14,7 @@ import Foundation
 enum ForageAPI {
     case tokenizeNumber(request: ForagePANRequestModel)
     case xKey(sessionToken: String, merchantID: String)
-    case message(request: MessageResponseModel, sessionToken: String, merchantID: String)
+    case message(contentId: String, sessionToken: String, merchantID: String)
     case getPaymentMethod(sessionToken: String, merchantID: String, paymentMethodRef: String)
     case getPayment(sessionToken: String, merchantID: String, paymentRef: String)
 }
@@ -28,7 +28,7 @@ extension ForageAPI: ServiceProtocol {
         switch self {
         case .tokenizeNumber: return "/api/payment_methods/"
         case .xKey: return "/iso_server/encryption_alias/"
-        case .message(request: let response, _, _): return "/api/message/\(response.contentId)/"
+        case .message(contentId: let contentId, _, _): return "/api/message/\(contentId)/"
         case .getPaymentMethod(request: let request): return "/api/payment_methods/\(request.paymentMethodRef)/"
         case .getPayment(request: let request): return "/api/payments/\(request.paymentRef)/"
         }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -311,16 +311,13 @@ extension LiveForageService: Polling {
         }
     }
 
-    protocol RandomNumberGeneratorProtocol { mutating func next() -> UInt64 }
-
     /// We generate a random jitter amount to add to our retry delay when polling for the status of
     /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
     /// several requests retrying at the same exact time.
     /// 
     /// Returns a random double between -25 and 25  
-    internal func getJitterAmount(randomNumberGenerator: RandomNumberGeneratorProtocol? = nil) -> Double {
-        let rng = randomNumberGenerator ?? SystemRandomNumberGenerator() // fallback to system one
-        return Double(Int.random(in: -25...25, using: &rng)) / 1000.0
+    internal func getJitterAmount() -> Double {
+        return Double(Int.random(in: -25...25)) / 1000.0
     }
     
     /// Support function to update retry count and interval between attempts.

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -317,7 +317,7 @@ extension LiveForageService: Polling {
     /// 
     /// Returns a random double between -25 and 25  
     internal func getJitterAmount() -> Double {
-        return Int.random(in: -25...25) / 1000.0
+        return Double(Int.random(in: -25...25)) / 1000.0
     }
     
     /// Support function to update retry count and interval between attempts.

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import VGSCollectSDK
 
 internal class LiveForageService: ForageService {
     // MARK: Properties
@@ -15,13 +14,15 @@ internal class LiveForageService: ForageService {
     internal var provider: Provider
     
     private var logger: ForageLogger?
+    private var ldManager: LDManagerProtocol
     private var maxAttempts: Int = 90
-    private var intervalBetweenAttempts: Double = 1.0
+    private var defaultPollingIntervalInMS: Int = 1000
     private var retryCount = 0
     
-    init(provider: Provider = Provider(), logger: ForageLogger? = nil) {
+    init(provider: Provider = Provider(), logger: ForageLogger? = nil, ldManager: LDManagerProtocol) {
         self.provider = provider
         self.logger = logger?.setPrefix("")
+        self.ldManager = ldManager
     }
     
     // MARK: Tokenize EBT card
@@ -51,7 +52,7 @@ internal class LiveForageService: ForageService {
     
     // MARK: Check balance
     
-    /// Perform VGS SDK request to retrieve balance.
+    /// Perform Vault request to retrieve balance.
     ///
     /// - Parameters:
     ///  - pinCollector: The pin collection service
@@ -135,7 +136,7 @@ internal class LiveForageService: ForageService {
     
     // MARK: Capture payment
     
-    /// Perform VGS SDK request to capture payment.
+    /// Perform Vault request to capture payment.
     ///
     /// - Parameters:
     ///  - pinCollector: The pin collection service
@@ -204,10 +205,10 @@ internal class LiveForageService: ForageService {
 // MARK: - Polling
 
 extension LiveForageService: Polling {
-    /// Process VGSData for polling message.
+    /// Process Vault Data for polling message.
     ///
     /// - Parameters:
-    ///  - response: The *VGSResponse* which contains the result from VGS SDK.
+    ///  - response: The Vault response.
     ///  - request: Model element with data to perform request.
     ///  - completion: Which will return the result.
     internal func polling(response: VaultResponse, request: ForageRequestModel, completion: @escaping (Result<Data?, Error>) -> Void) {
@@ -216,11 +217,11 @@ extension LiveForageService: Polling {
         if let error = response.error {
             completion(.failure(error))
         } else if let data = response.data, let urlResponse = response.urlResponse {
-            provider.processVGSData(model: MessageResponseModel.self, code: response.statusCode, data: data, response: urlResponse) { [weak self] messageResponse in
+            provider.processVaultData(model: MessageResponseModel.self, code: response.statusCode, data: data, response: urlResponse) { [weak self] messageResponse in
                 switch messageResponse {
                 case .success(let message):
                     self?.pollingMessage(
-                        message: message,
+                        contentId: message.contentId,
                         request: request) { pollingResult in
                             switch pollingResult {
                             case .success:
@@ -245,16 +246,16 @@ extension LiveForageService: Polling {
     /// Polls message to check payment status
     ///
     /// - Parameters:
-    ///  - message: The *MessageResponseModel* which contains the message.
+    ///  - contentId: The *MessageResponseModel* which contains the message.
     ///  - request: Model element with data to perform request.
     ///  - completion: Which will return the message for another retry or success.
     internal func pollingMessage(
-        message: MessageResponseModel,
+        contentId: String,
         request: ForageRequestModel,
         completion: @escaping (Result<MessageResponseModel, Error>) -> Void) -> Void
     {
         do {
-            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(request: message, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
+            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(contentId: contentId, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success(let data):
@@ -287,7 +288,7 @@ extension LiveForageService: Polling {
                     } else if self.retryCount < self.maxAttempts {
                         self.waitNextAttempt {
                             self.pollingMessage(
-                                message: data,
+                                contentId: data.contentId,
                                 request: request,
                                 completion: completion
                             )
@@ -311,17 +312,14 @@ extension LiveForageService: Polling {
         }
     }
     
-    private static func defaultRNG() -> Int {
-        return Int.random(in: -25...25)
-    }
-    
     /// We generate a random jitter amount to add to our retry delay when polling for the status of
     /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
     /// several requests retrying at the same exact time.
     ///
     /// Returns a random double between -.025 and .025
-    internal func jitterAmountInSeconds(using rng: () -> Int = defaultRNG) -> Double {
-        return Double(rng()) / 1000.0
+    @objc
+    internal func jitterAmountInSeconds() -> Double {
+        return Double(Int.random(in: -25...25)) / 1000.0
     }
     
     /// Support function to update retry count and interval between attempts.
@@ -329,8 +327,16 @@ extension LiveForageService: Polling {
     /// - Parameters:
     ///  - completion: Which will return after a wait.
     internal func waitNextAttempt(completion: @escaping () -> ()) {
+        var interval = self.defaultPollingIntervalInMS
+        let pollingIntervals = ldManager.getPollingIntervals(ldClient: LDManager.getDefaultLDClient())
+        if (retryCount < pollingIntervals.count) {
+            interval = pollingIntervals[retryCount]
+        }
+        let intervalAsDouble = Double(interval) / 1000.0
+        let nextPollTime = intervalAsDouble + self.jitterAmountInSeconds()
+        
         retryCount = retryCount + 1
-        let nextPollTime = self.intervalBetweenAttempts + self.jitterAmountInSeconds()
+
         DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
             completion()
         }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -310,14 +310,18 @@ extension LiveForageService: Polling {
             completion(.failure(error))
         }
     }
-
+    
+    private static func defaultRNG() -> Int {
+        return Int.random(in: -25...25)
+    }
+    
     /// We generate a random jitter amount to add to our retry delay when polling for the status of
     /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
     /// several requests retrying at the same exact time.
-    /// 
-    /// Returns a random double between -25 and 25  
-    internal func getJitterAmount() -> Double {
-        return Double(Int.random(in: -25...25)) / 1000.0
+    ///
+    /// Returns a random double between -.025 and .025
+    internal func jitterAmountInSeconds(using rng: () -> Int = defaultRNG) -> Double {
+        return Double(rng()) / 1000.0
     }
     
     /// Support function to update retry count and interval between attempts.
@@ -326,7 +330,7 @@ extension LiveForageService: Polling {
     ///  - completion: Which will return after a wait.
     internal func waitNextAttempt(completion: @escaping () -> ()) {
         retryCount = retryCount + 1
-        let nextPollTime = self.intervalBetweenAttempts + self.getJitterAmount()
+        let nextPollTime = self.intervalBetweenAttempts + self.jitterAmountInSeconds()
         DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
             completion()
         }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -326,8 +326,8 @@ extension LiveForageService: Polling {
     ///  - completion: Which will return after an wait.
     private func waitNextAttempt(completion: @escaping () -> ()) {
         retryCount = retryCount + 1
-        let nextPollTime = .now() + self.intervalBetweenAttempts + self.getJitterAmount()
-        DispatchQueue.main.asyncAfter(deadline: nextPollTime) {
+        let nextPollTime = self.intervalBetweenAttempts + self.getJitterAmount()
+        DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
             completion()
         }
     }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -310,6 +310,15 @@ extension LiveForageService: Polling {
             completion(.failure(error))
         }
     }
+
+    /// We generate a random jitter amount to add to our retry delay when polling for the status of
+    /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
+    /// several requests retrying at the same exact time.
+    /// 
+    /// Returns a random double between -25 and 25  
+    internal func getJitterAmount() -> Double {
+        return Int.random(in: -25...25) / 1000.0
+    }
     
     /// Support function to update retry count and interval between attempts.
     ///
@@ -317,7 +326,7 @@ extension LiveForageService: Polling {
     ///  - completion: Which will return after an wait.
     private func waitNextAttempt(completion: @escaping () -> ()) {
         retryCount = retryCount + 1
-        DispatchQueue.main.asyncAfter(deadline: .now() + self.intervalBetweenAttempts) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.intervalBetweenAttempts + self.getJitterAmount()) {
             completion()
         }
     }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -323,8 +323,8 @@ extension LiveForageService: Polling {
     /// Support function to update retry count and interval between attempts.
     ///
     /// - Parameters:
-    ///  - completion: Which will return after an wait.
-    private func waitNextAttempt(completion: @escaping () -> ()) {
+    ///  - completion: Which will return after a wait.
+    internal func waitNextAttempt(completion: @escaping () -> ()) {
         retryCount = retryCount + 1
         let nextPollTime = self.intervalBetweenAttempts + self.getJitterAmount()
         DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {

--- a/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
@@ -13,10 +13,10 @@ import VGSCollectSDK
  Interface for Polling
  */
 internal protocol Polling: AnyObject {
-    /// Handle VGS Response to start polling
+    /// Handle Vault Response to start polling
     ///
     /// - Parameters:
-    ///  - response: Response from VGS request. (See more [here](https://verygoodsecurity.github.io/vgs-collect-ios/Enums/VGSResponse.html))
+    ///  - response: Response from Vault request.
     ///  - request: Model composed with info to identify the polling.
     ///  - completion: Which will return a `Result` to be handle.
     func polling(
@@ -27,11 +27,11 @@ internal protocol Polling: AnyObject {
     /// Polling method
     ///
     /// - Parameters:
-    ///  - message: Message object to be used to polling.
+    ///  - contentId: Message object to be used to polling.
     ///  - request: Model composed with info to identify the polling.
     ///  - completion: Return a `MessageResponseModel` to check its validation. It will trigger another request using its object or it will return a completion `.success` or `.failure`.
     func pollingMessage(
-        message: MessageResponseModel,
+        contentId: String,
         request: ForageRequestModel,
         completion: @escaping (Result<MessageResponseModel, Error>) -> Void) -> Void
 }

--- a/Sources/ForageSDK/Foundation/Network/Provider.swift
+++ b/Sources/ForageSDK/Foundation/Network/Provider.swift
@@ -57,7 +57,7 @@ internal class Provider {
                             completion(.success(data))
                         case .failure:
                             if let data = data {
-                                self.processVGSData(
+                                self.processVaultData(
                                     model: ForageServiceError.self,
                                     code: nil,
                                     data: data,
@@ -170,7 +170,7 @@ internal class Provider {
         return "\(host)\(path)"
     }
     
-    internal func processVGSData<T: Decodable>(model: T.Type, code: Int?, data: Data?, response: URLResponse?, completion: @escaping (Result<T, Error>) -> Void) {
+    internal func processVaultData<T: Decodable>(model: T.Type, code: Int?, data: Data?, response: URLResponse?, completion: @escaping (Result<T, Error>) -> Void) {
         var httpResponse: HTTPURLResponse?
         
         processResponse(response: response) { (result) in

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -212,7 +212,7 @@ final class ForageServiceTests: XCTestCase {
         mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
         
-        let jitterAmount = service.getJitterAmount(randomNumberGenerator: customGenerator)
+        let jitterAmount = service.getJitterAmount()
         print(jitterAmount)
         
         // Assert

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -211,16 +211,9 @@ final class ForageServiceTests: XCTestCase {
         mockSession.data = forageMocks.capturePaymentSuccess
         mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
-
-        struct FixedSeedRandomNumberGenerator: RandomNumberGeneratorProtocol { 
-            mutating func next() -> UInt64 { return 42 } 
-        }
-
-        // Arrange
-        let customGenerator = FixedSeedRandomNumberGenerator()
         
-        // Act
         let jitterAmount = service.getJitterAmount(randomNumberGenerator: customGenerator)
+        print(jitterAmount)
         
         // Assert
         XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -205,6 +205,27 @@ final class ForageServiceTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
     }
+
+    func testGetJitterAmountWithCustomRandomGenerator() {
+        let mockSession = URLSessionMock()
+        mockSession.data = forageMocks.capturePaymentSuccess
+        mockSession.response = forageMocks.mockSuccessResponse
+        let service = LiveForageService(provider: Provider(mockSession))
+
+        struct FixedSeedRandomNumberGenerator: RandomNumberGeneratorProtocol { 
+            mutating func next() -> UInt64 { return 42 } 
+        }
+
+        // Arrange
+        let customGenerator = FixedSeedRandomNumberGenerator()
+        
+        // Act
+        let jitterAmount = service.getJitterAmount(randomNumberGenerator: customGenerator)
+        
+        // Assert
+        XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
+        XCTAssertTrue(jitterAmount >= -0.025 && jitterAmount <= 0.025, "Jitter amount should be within -0.025 and 0.025")
+    }
     
     func test_getBalance_onSuccess_checkExpectedPayload() {
         _ = XCTSkip("Need to clean up and decouple checkBalance before we can test it properly")

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -206,17 +206,19 @@ final class ForageServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testGetJitterAmountWithCustomRandomGenerator() {
+    func test_getJitterAmountInSeconds() {
         let mockSession = URLSessionMock()
-        mockSession.data = forageMocks.capturePaymentSuccess
-        mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
         
-        let jitterAmount = service.getJitterAmount()
+        func mockRNG() -> Int {
+            return 1000
+        }
+
+        let jitterAmount = service.jitterAmountInSeconds(using: mockRNG)
         
         // Assert
         XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
-        XCTAssertTrue(jitterAmount >= -0.025 && jitterAmount <= 0.025, "Jitter amount should be within -0.025 and 0.025")
+        XCTAssertTrue(jitterAmount == 1)
     }
     
     func testWaitNextAttempt() {

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -216,15 +216,12 @@ final class ForageServiceTests: XCTestCase {
 
         let jitterAmount = service.jitterAmountInSeconds(using: mockRNG)
         
-        // Assert
         XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
         XCTAssertTrue(jitterAmount == 1)
     }
     
-    func testWaitNextAttempt() {
+    func test_waitNextAttempt() {
         let mockSession = URLSessionMock()
-        mockSession.data = forageMocks.capturePaymentSuccess
-        mockSession.response = forageMocks.mockSuccessResponse
         let service = LiveForageService(provider: Provider(mockSession))
         
         let failureExpectation = XCTestExpectation(description: "Completion called before delay")


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
Adding +/- 25ms jitter to polling so that we can avoid a thundering herd issue if our clients retry all at the same time. Now all retries to polling will have some randomness added to their delay interval.

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ | ❌ Not a front-end change
- ✅ | ❌ iOS QA Tests passed locally
- ✅ | ❌ Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
