### PR TITLE
[FX-598] Run qa-tests once a day and alert if they fail

### DIFF
--- a/.github/workflows/Alert.yaml
+++ b/.github/workflows/Alert.yaml
@@ -1,0 +1,24 @@
+name: Alert
+
+on:
+  workflow_run:
+    workflows: ["QA Tests"]
+    types:
+      - completed
+
+jobs:
+  send-alert:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send alert to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "message": "QA Tests failed on main branch in forage-ios-sdk!",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  
+  schedule:
+    - cron: '0 12 * * *' # Run every day at 7/8 AM Eastern
 
 env:
   DEVELOPER_DIR: '/Applications/Xcode_14.3.1.app/Contents/Developer'


### PR DESCRIPTION
## What
Run the QA Tests once a day on main and alert in slack if they fail.

## Test Plan
Merge into main and see if it works!
