### PR TITLE
[FX-594] Respond with user_error if invalid PIN is submitted

### DIFF
--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -89,9 +89,9 @@ extension ForageSDK: ForageSDKService {
             if (!foragePinTextField.isComplete) {
                 self.logger?.warn(
                     "User attempted to submit an invalid PIN",
-                    error: CommonErrors.INVALID_PIN_ERROR,
+                    error: CommonErrors.INCOMPLETE_PIN_ERROR,
                     attributes: nil)
-                completion(.failure(CommonErrors.INVALID_PIN_ERROR))
+                completion(.failure(CommonErrors.INCOMPLETE_PIN_ERROR))
                 return
             }
                         
@@ -139,9 +139,9 @@ extension ForageSDK: ForageSDKService {
             if (!foragePinTextField.isComplete) {
                 self.logger?.warn(
                     "User attempted to submit an invalid PIN",
-                    error: CommonErrors.INVALID_PIN_ERROR,
+                    error: CommonErrors.INCOMPLETE_PIN_ERROR,
                     attributes: nil)
-                completion(.failure(CommonErrors.INVALID_PIN_ERROR))
+                completion(.failure(CommonErrors.INCOMPLETE_PIN_ERROR))
                 return
             }
 

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -85,6 +85,15 @@ extension ForageSDK: ForageSDKService {
                     paymentMethodRef: paymentMethodReference
                 ))
                 .notice("Called ForageSDK.shared.checkBalance for Payment Method \(paymentMethodReference)", attributes: nil)
+            
+            if (!foragePinTextField.isComplete) {
+                self.logger?.warn(
+                    "User attempted to submit an invalid PIN",
+                    error: CommonErrors.INVALID_PIN_ERROR,
+                    attributes: nil)
+                completion(.failure(CommonErrors.INVALID_PIN_ERROR))
+                return
+            }
                         
             let sessionToken = ForageSDK.shared.sessionToken
             let merchantID = ForageSDK.shared.merchantID
@@ -126,6 +135,15 @@ extension ForageSDK: ForageSDKService {
                     paymentRef: paymentReference
                 ))
                 .notice("Called ForageSDK.shared.capturePayment for Payment \(paymentReference)", attributes: nil)
+            
+            if (!foragePinTextField.isComplete) {
+                self.logger?.warn(
+                    "User attempted to submit an invalid PIN",
+                    error: CommonErrors.INVALID_PIN_ERROR,
+                    attributes: nil)
+                completion(.failure(CommonErrors.INVALID_PIN_ERROR))
+                return
+            }
 
             let sessionToken = ForageSDK.shared.sessionToken
             let merchantID = ForageSDK.shared.merchantID

--- a/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Danny Leiser on 9/28/23.
+//
+
+import Foundation
+
+struct CommonErrors {
+    static let INVALID_PIN_ERROR = ForageError(errors: [
+        ForageErrorObj(
+            httpStatusCode: 400,
+            code: "user_error",
+            message: "Invalid EBT Card PIN entered. Please enter your 4-digit PIN."
+        )
+    ])
+}

--- a/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CommonErrors {
-    static let INVALID_PIN_ERROR = ForageError(errors: [
+    static let INCOMPLETE_PIN_ERROR = ForageError(errors: [
         ForageErrorObj(
             httpStatusCode: 400,
             code: "user_error",


### PR DESCRIPTION
## What
When a user tries to submit a PIN of an invalid length, we can respond immediately with a user_error.

## Test Plan
I tested this locally and will be adding a qa-test for the behavior!
