### PR TITLE
[FX-605] Remove constant height constraint

### DIFF
--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -45,6 +45,10 @@ class RequestBalanceView: UIView {
         tf.pinType = .balance
         tf.accessibilityIdentifier = "tf_pin_balance"
         tf.isAccessibilityElement = true
+        tf.font = .systemFont(ofSize: 18)
+        let height = tf.heightAnchor.constraint(equalToConstant: 84)
+        height.priority = UILayoutPriority.defaultHigh + 10
+        height.isActive = true
         return tf
     }()
     

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -299,7 +299,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     
     private func changeElementHeight(value: CGFloat) {
         container.distribution = .equalCentering
-        container.heightAnchor.constraint(equalToConstant: value).isActive = true
+        container.heightAnchor.constraint(greaterThanOrEqualToConstant: value).isActive = true
     }
     
     // MARK: - Public API

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -299,7 +299,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     
     private func changeElementHeight(value: CGFloat) {
         container.distribution = .equalCentering
-        container.heightAnchor.constraint(greaterThanOrEqualToConstant: value).isActive = true
+        container.heightAnchor.constraint(equalToConstant: value).isActive = true
     }
     
     // MARK: - Public API

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -142,10 +142,10 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     // MARK: - Private API
     
     private func setupWidthHeightConstraints() {
-        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: 342)
+        inputWidthConstraint = textField.widthAnchor.constraint(greaterThanOrEqualToConstant: 342)
         inputWidthConstraint?.isActive = true
         
-        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: 36)
+        inputHeightConstraint = textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 36)
         inputHeightConstraint?.isActive = true
     }
     

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/VgsPINTextField.swift
@@ -99,10 +99,10 @@ class VGSTextFieldWrapper: UIView, VaultWrapper {
     // MARK: - Private API
     
     private func setupWidthHeightConstraints() {
-        inputWidthConstraint = textField.widthAnchor.constraint(equalToConstant: 342)
+        inputWidthConstraint = textField.widthAnchor.constraint(greaterThanOrEqualToConstant: 342)
         inputWidthConstraint?.isActive = true
         
-        inputHeightConstraint = textField.heightAnchor.constraint(equalToConstant: 36)
+        inputHeightConstraint = textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 36)
         inputHeightConstraint?.isActive = true
     }
     


### PR DESCRIPTION
## What
Remove hard height constraint set on our internal PIN fields. 

## Demo
I implemented the ForagePINTextField identically to how GoPuff does in our BalanceRequestPage in the sample app. I show how the current implementation blocks the height value that they are applying at the highest level and how loosening the constraint has the desired outcome.

https://github.com/teamforage/forage-ios-sdk/assets/89605898/74acc7f6-f125-48cc-ad01-94e3bad0fd43


