### PR TITLE
[FX-618] Make the balance field nullable to avoid throwing error

### DIFF
--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -75,9 +75,9 @@ class RequestBalanceView: UIView {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(goToCreatePayment(_:)), for: .touchUpInside)
         button.backgroundColor = .systemBlue
-        button.isEnabled = false
-        button.isUserInteractionEnabled = false
-        button.alpha = 0.5
+        button.isEnabled = true
+        button.isUserInteractionEnabled = true
+        button.alpha = 1.0
         button.accessibilityIdentifier = "bt_next"
         button.isAccessibilityElement = true
         return button
@@ -187,12 +187,10 @@ class RequestBalanceView: UIView {
                 self.snapBalanceLabel.text = "snap=\(response.snap)"
                 self.nonSnapBalanceLabel.text = "cash=\(response.cash)"
                 self.errorLabel.text = ""
-                self.updateButtonState(isEnabled: true, button: self.nextButton)
             case .failure(let error):
                 self.errorLabel.text = "\(error)"
                 self.snapBalanceLabel.text = ""
                 self.nonSnapBalanceLabel.text = ""
-                self.updateButtonState(isEnabled: false, button: self.nextButton)
             }
             
             self.layoutIfNeeded()
@@ -329,12 +327,6 @@ class RequestBalanceView: UIView {
             padding: .init(top: 0, left: 24, bottom: 0, right: 24),
             size: .init(width: 0, height: 48)
         )
-    }
-    
-    private func updateButtonState(isEnabled: Bool, button: UIButton) {
-        button.isEnabled = isEnabled
-        button.isUserInteractionEnabled = isEnabled
-        button.alpha = isEnabled ? 1.0 : 0.5
     }
     
     private func updateState(state: ObservableState) {

--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
@@ -38,7 +38,7 @@ public struct Receipt: Codable {
     public let ebtCashAmount: String
     public let otherAmount: String
     public let salesTaxApplied: String
-    public let balance: ReceiptBalance
+    public let balance: ReceiptBalance?
     public let last4: String
     public let message: String
     public let transactionType: String

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -176,7 +176,7 @@ final class ForageServiceTests: XCTestCase {
             case .success(let payment):
                 XCTAssertEqual(payment.paymentMethodRef, "81dab02290")
                 XCTAssertEqual(payment.receipt?.refNumber, "11767381fd")
-                XCTAssertEqual(payment.receipt?.balance.snap, "90.00")
+                XCTAssertEqual(payment.receipt?.balance?.snap, "90.00")
                 XCTAssertEqual(payment.lastProcessingError, nil)
                 XCTAssertEqual(payment.refunds[0], "9bf75154be")
                 expectation.fulfill()


### PR DESCRIPTION
## What
Make the balance object on the receipt field nullable. Currently, we throw a parsing error if a user attempts to test the lost card multiple times in production. If a payment capture fails, we do a GET for the Payment and there are times when there is no available `balance` for the card.

## Test Plan
I was able to recreate GoPuff's error locally and was able to solve the issue with this fix.
