### PR TITLE
[FX-622] Add temp workaround for clearText BT bug

### DIFF
--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -134,6 +134,7 @@ class CapturePaymentView: UIView {
         ForageSDK.shared.capturePayment(
             foragePinTextField: inputFieldReference,
             paymentReference: paymentReference) { result in
+                inputFieldReference.clearText()
                 self.printResult(result: result)
             }
     }
@@ -149,16 +150,17 @@ class CapturePaymentView: UIView {
             case .failure(let error):
                 if let forageError = error as? ForageError? {
                     let firstError = forageError?.errors.first
-                    let errorDetails = firstError?.details
-                                    
-                    switch errorDetails {
-                    case .ebtError51(let snapBalance, let cashBalance):
-                        let snapBalanceText = snapBalance ?? "N/A"
-                        let cashBalanceText = cashBalance ?? "N/A"
-                        
-                        self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalanceText), EBT Cash: \(cashBalanceText)"
-                    default:
-                        self.remainingBalanceLabel.text = "firstForageError.details: Missing insufficient funds error details!"
+                    
+                    if firstError?.code == "ebt_error_51" {
+                        switch firstError?.details {
+                        case .ebtError51(let snapBalance, let cashBalance):
+                            let snapBalanceText = snapBalance ?? "N/A"
+                            let cashBalanceText = cashBalance ?? "N/A"
+                            
+                            self.remainingBalanceLabel.text = "firstForageError.details: remaining balances are SNAP: \(snapBalanceText), EBT Cash: \(cashBalanceText)"
+                        default:
+                            self.remainingBalanceLabel.text = "firstForageError.details: Missing insufficient funds error details!"
+                        }
                     }
                 }
                 self.errorLabel.text = "\(error)"

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -162,6 +162,7 @@ class RequestBalanceView: UIView {
         ForageSDK.shared.checkBalance(
             foragePinTextField: foragePinTextField,
             paymentMethodReference: ClientSharedData.shared.paymentMethodReference) { result in
+                self.foragePinTextField.clearText()
                 self.printPINResult(result: result)
             }
     }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/BtPINTextField.swift
@@ -152,7 +152,9 @@ class BasisTheoryTextFieldWrapper: UIView, VaultWrapper {
     // MARK: - Public API
     
     func clearText() {
-        textField.text = ""
+        DispatchQueue.main.async {
+            self.textField.text = ""
+        }
     }
     
     var borderWidth: CGFloat {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -258,6 +258,24 @@ final class ForagePINTextFieldTests: XCTestCase {
         let textPlaceholder = foragePinTextField.placeholder
         XCTAssertEqual(textPlaceholder, placeholder)
     }
+    
+    func test_clearText() {
+        // VGS
+        let vgsTextFieldWrapper = VGSTextFieldWrapper()
+        vgsTextFieldWrapper.clearText()
+        vgsTextFieldWrapper.clearText()
+
+        // assert that it does not cause crash and resets isComplete=false!
+        XCTAssertEqual(vgsTextFieldWrapper.isComplete, false)
+        
+        // Basis Theory
+        let btTextFieldWrapper = BasisTheoryTextFieldWrapper()
+        btTextFieldWrapper.clearText()
+        btTextFieldWrapper.clearText()
+
+        // assert that it does not cause crash and resets isComplete=false!
+        XCTAssertEqual(btTextFieldWrapper.isComplete, false)
+    }
 }
 
 extension ForagePINTextFieldTests: ForageElementDelegate {


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Temp workaround for https://linear.app/joinforage/issue/FX-622/bug-make-basis-theory-pin-cleartext-not-crash-in-ios
- Clean up how we display error details in sample app

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-622/bug-make-basis-theory-pin-cleartext-not-crash-in-ios

## Test Plan

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- Added unit tests for clearText
- Call `clearText` in sample app

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

### ⚠️ Should be released with #120 , but can be released as-is (PATCH).

This change will ideally be [followed by a "full" fix once Basis Theory releases an official](https://linear.app/joinforage/issue/FX-622/bug-make-basis-theory-pin-cleartext-not-crash-in-ios#comment-1f9863a8) `clearText` method.
