### PR TITLE
[FX-572] Add customer-perceived response metrics

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/Collector.swift
+++ b/Sources/ForageSDK/Foundation/Network/Collector.swift
@@ -21,6 +21,7 @@ internal protocol VaultCollector {
         extraData: [String: Any],
         completion: @escaping (VaultResponse) -> Void)
     func getPaymentMethodToken(paymentMethodToken: String) throws -> String
+    func getVaultType() -> VaultType
     
 }
 
@@ -32,11 +33,6 @@ struct VGSCollectConfig {
 struct BasisTheoryConfig {
     let publicKey: String
     let proxyKey: String
-}
-
-internal enum VaultAction: String {
-    case balanceCheck = "balance"
-    case capture
 }
 
 // Wrapper class for VGSCollect
@@ -97,6 +93,10 @@ class VGSCollectWrapper: VaultCollector {
             return paymentMethodToken.components(separatedBy: tokenDelimiter)[0]
         }
         return paymentMethodToken
+    }
+    
+    internal func getVaultType() -> VaultType {
+        return VaultType.vgsVaultType
     }
 }
 
@@ -203,6 +203,10 @@ class BasisTheoryWrapper: VaultCollector {
             )
             completion(vaultResponse)
         }
+    }
+    
+    internal func getVaultType() -> VaultType {
+        return VaultType.btVaultType
     }
 }
 

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -158,7 +158,7 @@ internal class LiveForageService: ForageService {
 
         pinCollector.sendData(
             path: "/api/payments/\(request.paymentReference)/capture/",
-            vaultAction: VaultAction.capture,
+            vaultAction: VaultAction.capturePayment,
             extraData: extraData) { [weak self] result in
                 self?.polling(response: result, request: request, completion: { pollingResult in
                     switch pollingResult {

--- a/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
@@ -1,0 +1,84 @@
+//
+//  CustomerPerceivedResponseMonitor.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-10-12.
+//
+
+import Foundation
+
+internal let UnknownErrorCode = "unknown"
+
+/*
+ CustomerPerceivedResponseMonitor is used to track the response time that a customer
+ experiences while executing a balance or capture action. There are multiple chained requests
+ that come from the client when executing a balance or capture action.
+ 
+ The timer begins when the first HTTP request is sent from the SDK and ends when the the SDK returns information back to the user. Ex of a balance action:
+ 
+ Timer Begins -> [GET] EncryptionKey -> [GET] PaymentMethod -> [POST] to VGS/BT ->
+ [GET] Poll for Response -> [GET] PaymentMethod -> Timer Ends -> Return Balance
+ */
+internal final class CustomerPerceivedResponseMonitor: ResponseMonitor {
+    
+    private var vaultType: VaultType
+    private var vaultAction: VaultAction
+    private var eventOutcome: EventOutcome?
+    private var eventName: EventName = .customerPerceivedResponse
+    
+    internal init(vaultType: VaultType, vaultAction: VaultAction) {
+        self.vaultType = vaultType
+        self.vaultAction = vaultAction
+        super.init()
+    }
+    
+    /// Factory method for creating new CustomerPerceivedResponseMonitor instances
+    internal static func newMeasurement(vaultType: VaultType, vaultAction: VaultAction) -> CustomerPerceivedResponseMonitor {
+        return CustomerPerceivedResponseMonitor(vaultType: vaultType, vaultAction: vaultAction)
+    }
+    
+    // override to set event_outcome to "failure" if we know the event has a forage_error_code
+    @discardableResult
+    internal override func setForageErrorCode(_ error: Error) -> ResponseMonitor {
+        self.setEventOutcome(.failure)
+        super.setForageErrorCode(error)
+        return self
+    }
+    
+    @discardableResult
+    internal func setEventOutcome(_ outcome: EventOutcome) -> CustomerPerceivedResponseMonitor {
+        self.eventOutcome = outcome
+        return self
+    }
+    
+    internal override func logWithResponseAttributes(
+        metricsLogger: ForageLogger?,
+        responseAttributes: ResponseAttributes
+    ) {
+        
+        guard
+            let responseTimeMs = responseAttributes.responseTimeMs,
+            let eventOutcome = self.eventOutcome
+        else {
+            metricsLogger?.error("Incomplete or missing response attributes. Could not log metric.", error: nil, attributes: nil)
+            return
+        }
+        
+        if (eventOutcome == .failure && responseAttributes.forageErrorCode == nil) {
+            metricsLogger?.error("Failure event did not include forage_error_code.", error: nil, attributes: nil)
+        }
+        
+        metricsLogger?.info(
+            "Reported customer-perceived response event",
+            attributes: mapEnumKeysToStrings(from: [
+                .action: self.vaultAction.rawValue,
+                .eventName: self.eventName.rawValue,
+                .eventOutcome: eventOutcome.rawValue,
+                .forageErrorCode: responseAttributes.forageErrorCode,
+                .logType: ForageLogKind.metric.rawValue,
+                .responseTimeMs: responseTimeMs,
+                .vaultType: self.vaultType.rawValue,
+            ])
+        )
+    }
+}

--- a/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
@@ -39,7 +39,7 @@ internal final class CustomerPerceivedResponseMonitor: ResponseMonitor {
     
     // override to set event_outcome to "failure" if we know the event has a forage_error_code
     @discardableResult
-    internal override func setForageErrorCode(_ error: Error) -> ResponseMonitor {
+    internal override func setForageErrorCode(_ error: Error) -> CustomerPerceivedResponseMonitor {
         self.setEventOutcome(.failure)
         super.setForageErrorCode(error)
         return self

--- a/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
@@ -60,7 +60,7 @@ internal final class CustomerPerceivedResponseMonitor: ResponseMonitor {
             let responseTimeMs = responseAttributes.responseTimeMs,
             let eventOutcome = self.eventOutcome
         else {
-            metricsLogger?.error("Incomplete or missing response attributes. Could not log metric.", error: nil, attributes: nil)
+            metricsLogger?.error("Incomplete or missing response attributes. Could not report metric event.", error: nil, attributes: nil)
             return
         }
         

--- a/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
@@ -1,0 +1,121 @@
+//
+//  ResponseMonitor.swift
+//  
+//
+//  Created by Danilo Joksimovic on 2023-10-12.
+//
+
+import Foundation
+
+internal enum MetricsAttributeName: String {
+    case logType = "log_type"
+    case responseTimeMs = "response_time_ms"
+    case vaultType = "vault_type"
+    case action = "action"
+    case path = "path"
+    case method = "method"
+    case httpStatus = "http_status"
+    case eventName = "event_name"
+    case eventOutcome = "event_outcome"
+    case forageErrorCode = "forage_error_code"
+}
+
+internal struct ResponseAttributes {
+    var responseTimeMs: Double?
+    var path: String?
+    var method: HttpMethod?
+    var code: Int?
+    var forageErrorCode: String?
+}
+
+internal enum VaultAction: String {
+    case balanceCheck = "balance"
+    case capturePayment = "capture"
+}
+
+internal enum EventOutcome: String {
+    case success = "success"
+    case failure = "failure"
+}
+
+/// `ResponseMonitor` serves as the base class for monitoring network metrics
+internal class ResponseMonitor: NetworkMonitor {
+    private var startTime: DispatchTime?
+    private var endTime: DispatchTime?
+    
+    private var responseAttributes: ResponseAttributes = ResponseAttributes()
+    private var metricsLogger: ForageLogger?
+    
+    
+    init(
+        metricsLogger: ForageLogger? = DatadogLogger(
+            ForageLoggerConfig(prefix: "Metrics")
+        )
+    ) {
+        self.metricsLogger = metricsLogger?.setLogKind(ForageLogKind.metric)
+    }
+    
+    internal func start() {
+        startTime = DispatchTime.now()
+    }
+    
+    internal func end() {
+        endTime = DispatchTime.now()
+    }
+    
+    @discardableResult
+    internal func setPath(_ httpPath: String) -> NetworkMonitor {
+        self.responseAttributes.path = httpPath
+        return self
+    }
+    
+    @discardableResult
+    internal func setMethod(_ httpMethod: HttpMethod) -> NetworkMonitor {
+        self.responseAttributes.method = httpMethod
+        return self
+    }
+    
+    @discardableResult
+    internal func setHttpStatusCode(_ httpStatusCode: Int?) -> NetworkMonitor {
+        self.responseAttributes.code = httpStatusCode
+        return self
+    }
+    
+    @discardableResult
+    internal func setForageErrorCode(_ error: Error) -> ResponseMonitor {
+        self.responseAttributes.forageErrorCode = (error as? ForageError)?.errors.first?.code ?? UnknownErrorCode
+        return self
+    }
+    
+    /// Converts a dictionary with `MetricsAttributeName` enum keys to a dictionary with String keys.
+    internal func mapEnumKeysToStrings(from metricsAttributes: [MetricsAttributeName: Encodable]) -> [String: Encodable] {
+        var attributes: [String: Encodable] = [:]
+        for (key, value) in metricsAttributes {
+            attributes[key.rawValue] = value
+        }
+        return attributes
+    }
+    
+    internal func logResult() {
+        guard let startTime = self.startTime, let endTime = self.endTime else {
+            metricsLogger?.error("Missing startTime or endTime. Could not log metric.", error: nil, attributes: nil)
+            return
+        }
+        responseAttributes.responseTimeMs = calculateDurationMs(from: startTime, to: endTime)
+        
+        // handled by subclass
+        logWithResponseAttributes(
+            metricsLogger: self.metricsLogger,
+            responseAttributes: responseAttributes
+        )
+    }
+    
+    /// Calculates the time in milliseconds between the start and end time
+    private func calculateDurationMs(from startTime: DispatchTime, to endTime: DispatchTime) -> Double {
+        let nanoseconds = endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
+        return Double(nanoseconds) / 1_000_000
+    }
+    
+    // Do nothing here; meant to be overridden by subclasses
+    internal func logWithResponseAttributes(metricsLogger: ForageLogger?, responseAttributes: ResponseAttributes) {}
+}

--- a/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
@@ -98,7 +98,7 @@ internal class ResponseMonitor: NetworkMonitor {
     
     internal func logResult() {
         guard let startTime = self.startTime, let endTime = self.endTime else {
-            metricsLogger?.error("Missing startTime or endTime. Could not log metric.", error: nil, attributes: nil)
+            metricsLogger?.error("Missing startTime or endTime. Could not report metric event.", error: nil, attributes: nil)
             return
         }
         responseAttributes.responseTimeMs = calculateDurationMs(from: startTime, to: endTime)

--- a/Sources/ForageSDK/Foundation/Telemetry/VaultProxyResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/VaultProxyResponseMonitor.swift
@@ -45,7 +45,7 @@ internal final class VaultProxyResponseMonitor: ResponseMonitor {
               let path = responseAttributes.path,
               let httpStatus = responseAttributes.code,
               let responseTimeMs = responseAttributes.responseTimeMs else {
-            metricsLogger?.error("Incomplete or missing response attributes. Could not log metric.", error: nil, attributes: nil)
+            metricsLogger?.error("Incomplete or missing response attributes. Could not report metric event.", error: nil, attributes: nil)
             return
         }
         

--- a/Sources/ForageSDK/Foundation/Telemetry/VaultProxyResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/VaultProxyResponseMonitor.swift
@@ -8,84 +8,27 @@
 
 import Foundation
 
-internal struct ResponseAttributes {
-    var responseTimeMs: Double?
-    var path: String?
-    var method: HttpMethod?
-    var code: Int?
+internal enum EventName: String {
+    /// vaultResponse refers to a response from the VGS or BT submit actions.
+    case vaultResponse = "vault_response"
+    /**
+     customer_perceived_response refers to the response from a balance or capture action. There are
+     multiple chained requests that come from the client when executing a balance or capture action.
+     Example of a balance action:
+     [GET] EncryptionKey -> [GET] PaymentMethod -> [POST] to VGS/BT -> [GET] Poll for Response ->
+     [GET] PaymentMethod -> Return Balance
+     */
+    case customerPerceivedResponse = "customer_perceived_response"
 }
 
-/// `ResponseMonitor` serves as the base class for monitoring network metrics
-internal class ResponseMonitor: NetworkMonitor {
-    private var startTime: DispatchTime?
-    private var endTime: DispatchTime?
-    
-    private var responseAttributes: ResponseAttributes = ResponseAttributes()
-    private var metricsLogger: ForageLogger?
-    
-    init(
-        metricsLogger: ForageLogger? = DatadogLogger(
-            ForageLoggerConfig(prefix: "Metrics")
-        )
-    ) {
-        self.metricsLogger = metricsLogger?.setLogKind(ForageLogKind.metric)
-    }
-    
-    internal func start() {
-        startTime = DispatchTime.now()
-    }
-    
-    internal func end() {
-        endTime = DispatchTime.now()
-    }
-    
-    @discardableResult
-    internal func setPath(_ httpPath: String) -> NetworkMonitor {
-        self.responseAttributes.path = httpPath
-        return self
-    }
-    
-    @discardableResult
-    internal func setMethod(_ httpMethod: HttpMethod) -> NetworkMonitor {
-        self.responseAttributes.method = httpMethod
-        return self
-    }
-    
-    @discardableResult
-    internal func setHttpStatusCode(_ httpStatusCode: Int?) -> NetworkMonitor {
-        self.responseAttributes.code = httpStatusCode
-        return self
-    }
-    
-    internal func logResult() {
-        guard let startTime = self.startTime, let endTime = self.endTime else {
-            metricsLogger?.error("Missing startTime or endTime. Could not log metric.", error: nil, attributes: nil)
-            return
-        }
-        responseAttributes.responseTimeMs = calculateDurationMs(from: startTime, to: endTime)
-        
-        // handled by subclass
-        logWithResponseAttributes(
-            metricsLogger: self.metricsLogger,
-            responseAttributes: responseAttributes
-        )
-    }
-    
-    /// Calculates the time in milliseconds between the start and end time
-    private func calculateDurationMs(from startTime: DispatchTime, to endTime: DispatchTime) -> Double {
-        let nanoseconds = endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
-        return Double(nanoseconds) / 1_000_000
-    }
-    
-    // Do nothing here; meant to be overridden by subclasses
-    internal func logWithResponseAttributes(metricsLogger: ForageLogger?, responseAttributes: ResponseAttributes) {}
-}
-
-/// `VaultProxyResponseMonitor` is a specialized `ResponseMonitor` for handling Vault-related network metrics
+/*
+ `VaultProxyResponseMonitor` is a specialized `ResponseMonitor` for handling Vault-related network metrics. VaultProxyResponseMonitor is used to track the errors and response times from the VGS and BT submit functions. The timer begins when a balance or capture request is submitted to VGS/BT and ends when a response is received by the SDK.
+ */
 internal final class VaultProxyResponseMonitor: ResponseMonitor {
     
     private let vaultAction: VaultAction
     private let vaultType: VaultType
+    private var eventName: EventName = .vaultResponse
     
     private init(vaultType: VaultType, vaultAction: VaultAction) {
         self.vaultType = vaultType
@@ -106,16 +49,20 @@ internal final class VaultProxyResponseMonitor: ResponseMonitor {
             return
         }
         
-        let vaultName = self.vaultType.rawValue
-        let vaultAction = self.vaultAction.rawValue
+        let vaultType = self.vaultType.rawValue
         
-        metricsLogger?.info("Received response from \(vaultName) proxy", attributes: [
-            "vault_type": vaultName,
-            "action": vaultAction,
-            "path": path,
-            "method": httpMethod,
-            "http_status": httpStatus,
-            "response_time_ms": responseTimeMs,
-        ])
+        metricsLogger?.info(
+            "Received response from \(vaultType) proxy",
+            attributes: mapEnumKeysToStrings(from: [
+                .action: self.vaultAction.rawValue,
+                .eventName: self.eventName.rawValue,
+                .httpStatus: httpStatus,
+                .logType: ForageLogKind.metric.rawValue,
+                .method: httpMethod,
+                .path: path,
+                .responseTimeMs: responseTimeMs,
+                .vaultType: self.vaultType.rawValue,
+            ])
+        )
     }
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Add customer-perceived response metrics to `checkBalance` and `capturePayment`

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

https://linear.app/joinforage/issue/FX-572/ios-include-customer-perceived-metric-in-monitoring

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ | ❌ Not a front-end change
- ✅ | ❌ iOS QA Tests passed locally
- ✅ | ❌ Unit Tests passed locally

## How

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

- PATCH-level change
- Will follow-up with a cleanup PR for `checkBalance` and `capturePayment` ([FX-631](https://linear.app/joinforage/issue/FX-631/ios-clean-up-checkbalance-and-capturepayment))
