### PR TITLE
[FX-631] Clean up checkBalance and capturePayment

### DIFF
--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -10,8 +10,6 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     
     // MARK: - Properties
     
-    internal var collector: VaultCollector?
-    
     /// Delegate that updates client's side about state of the entered pin
     public weak var delegate: ForageElementDelegate?
     
@@ -151,7 +149,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         )
         
         var tf: VaultWrapper?
-
+        
         if (vaultType == VaultType.vgsVaultType) {
             tf = VGSTextFieldWrapper()
         } else if (vaultType == VaultType.btVaultType) {
@@ -159,7 +157,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         } else {
             tf = VGSTextFieldWrapper()
         }
-
+        
         tf?.textColor = UIColor.black
         tf?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         tf?.borderWidth = 0
@@ -167,8 +165,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         tf?.masksToBounds = true
         tf?.borderColor = .clear
         tf?.backgroundColor = .systemGray6
-        collector = tf?.collector
-
+        
         return tf ?? VGSTextFieldWrapper()
     }()
     
@@ -184,6 +181,10 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
         imgView.isAccessibilityElement = true
         return imgView
     }()
+    
+    internal func getPinCollector() -> VaultCollector {
+        return textField.collector
+    }
     
     // MARK: - Lifecycle methods
     
@@ -289,12 +290,12 @@ extension ForagePINTextField {
     @discardableResult override public func becomeFirstResponder() -> Bool {
         return textField.becomeFirstResponder()
     }
-
+    
     /// Remove focus from `ForagePINTextField`.
     @discardableResult override public func resignFirstResponder() -> Bool {
         return textField.resignFirstResponder()
     }
-
+    
     /// Check if `ForagePINTextField` is focused.
     override public var isFirstResponder: Bool {
         return textField.isFirstResponder

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -28,10 +28,27 @@ internal struct ForageErrorSource: Codable {
 public struct ForageError: Error, Codable {
     /// An array of error objects returned from the Forage API.
     public let errors: [ForageErrorObj]
+    
+    /// Creates a `ForageError` instance with a single `ForageErrorObj` object
+    static internal func create(
+        httpStatusCode: Int,
+        code: String,
+        message: String
+    ) -> ForageError {
+        return ForageError(
+            errors: [
+                ForageErrorObj(
+                    httpStatusCode: httpStatusCode,
+                    code: code,
+                    message: message
+                )
+            ]
+        )
+    }
 }
 
 /// Contains additional details about a Forage API error.
-/// 
+///
 public enum ForageErrorDetails: Codable {
     /// Use this to display the SNAP and EBT Cash balances when an [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51) error occurs
     case ebtError51(snapBalance: String?, cashBalance: String?)

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageRequestModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageRequestModel.swift
@@ -1,5 +1,5 @@
 //
-//  ForageRetrieveModel.swift
+//  ForageRequestModel.swift
 //  ForageSDK
 //
 //  Created by Tiago Oliveira on 16/11/22.

--- a/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
@@ -16,12 +16,12 @@ internal protocol ForageService: AnyObject {
     /// Provider provides the interface for performing HTTP requests.
     var provider: Provider { get }
     
-    /// Retrieve X-key header for requests
+    /// Retrieves the EncryptionKey from the Forage API, to be utilized as the X-Key header.
     ///
     /// - Parameters:
-    ///  - sessionToken: Authorization token.
-    ///  - merchantID: merchant ID.
-    ///  - completion: Which will return the x-key object.
+    ///  - sessionToken: Short-lived session token that authorizes requests to the Forage API.
+    ///  - merchantID: The unique ID of the Merchant.
+    ///  - completion: The closure returns a `Result` containing either a `ForageXKeyModel` or an `Error`.
     func getXKey(
         sessionToken: String,
         merchantID: String,
@@ -30,57 +30,65 @@ internal protocol ForageService: AnyObject {
     /// Perform a GET request for the PaymentMethod
     ///
     /// - Parameters:
-    ///  - sessionToken: Authorization token.
-    ///  - merchantID: merchant ID.
-    ///  - paymentMethodRef: The PaymentMethod ref.
-    ///  - completion: Returns the PaymentMethod
+    ///  - sessionToken: Short-lived session token that authorizes requests to the Forage API.
+    ///  - merchantID: The unique ID of the Merchant.
+    ///  - paymentMethodRef: The reference hash of the PaymentMethod.
+    ///  - completion: The closure returns a `Result` containing either a `PaymentMethodModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/get-payment-method)
     func getPaymentMethod(
         sessionToken: String,
         merchantID: String,
         paymentMethodRef: String,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) -> Void
     
-    /// Perform a GET request for the Payment
+    /// Performs a GET request to retrieve the specified Payment.
     ///
     /// - Parameters:
-    ///  - sessionToken: Authorization token.
-    ///  - merchantID: merchant ID.
-    ///  - paymentRef: The Payment ref.
-    ///  - completion: Returns the Payment
+    ///  - sessionToken: Short-lived session token that authorizes requests to the Forage API.
+    ///  - merchantID: The unique ID of the Merchant.
+    ///  - paymentRef: The reference hash of the Payment.
+    ///  - completion: The closure returns a `Result` containing either a `PaymentModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/get-payment-details)
     func getPayment(
         sessionToken: String,
         merchantID: String,
         paymentRef: String,
         completion: @escaping (Result<PaymentModel, Error>) -> Void)
     
-    /// Tokenize a given *ForagePANRequestModel* object
+    /// Tokenize an EBT card using the given *ForagePANRequestModel* object
     ///
     /// - Parameters:
-    ///  - request: *ForagePANRequestModel* contains ebt card object.
-    ///  - completion: Returns tokenized object. (See more [here](https://docs.joinforage.app/reference/create-payment-method-1))
+    ///  - request: An instance of `ForagePANRequestModel` containing the EBT card details.
+    ///  - completion: The closure returns a `Result` containing either a `PaymentMethodModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/create-payment-method)
     func tokenizeEBTCard(
         request: ForagePANRequestModel,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) -> Void
     
-    /// Perform request through VGS to retrieve balance
+    /// Asynchronously checks the balance of a PaymentMethod using the given `pinCollector` and `paymentMethodReference`
     ///
     /// - Parameters:
-    ///  - pinCollector: The pin collection service
-    ///  - request: `ForageRequestModel` info to request balance.
-    ///  - completion: Which will return the balance object.
+    ///   - pinCollector: The service responsible for securely collecting PINs.
+    ///   - paymentMethodReference: The reference hash of the PaymentMethod.
+    ///
+    /// - Throws:
+    ///   - `ForageError`: If there's an issue at any stage of the balance check process.
+    ///
+    /// - Returns:
+    ///   - A `BalanceModel` object containing the balance of the PaymentMethod.
     func checkBalance(
         pinCollector: VaultCollector,
-        request: ForageRequestModel,
-        completion: @escaping (Result<BalanceModel, Error>) -> Void) -> Void
+        paymentMethodReference: String) async throws -> BalanceModel
     
-    /// Perform request through VGS to capture payment
+    /// Asynchronously captures a payment using the given `pinCollector` and `paymentReference`
     ///
     /// - Parameters:
-    ///  - pinCollector: The pin collection service
-    ///  - request: `ForageRequestModel` info to request balance.
-    ///  - completion: Which will return the payment object.
+    ///   - pinCollector: The service responsible for securely collecting PINs.
+    ///   - paymentReference: The reference hash of the Payment.
+    ///
+    /// - Throws:
+    ///   - `ForageError`: If there's an issue at any stage of the payment capture process.
+    ///
+    /// - Returns:
+    ///   - A `PaymentModel` object containing the details of the captured payment.
     func capturePayment(
         pinCollector: VaultCollector,
-        request: ForageRequestModel,
-        completion: @escaping (Result<PaymentModel, Error>) -> Void)
+        paymentReference: String) async throws -> PaymentModel
 }

--- a/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
@@ -10,17 +10,17 @@ import Foundation
 import VGSCollectSDK
 
 /**
- Interface for Polling
+ Interface for Polling service.
  */
 internal protocol Polling: AnyObject {
     /// Handle Vault Response to start polling
     ///
     /// - Parameters:
-    ///  - response: Response from Vault request.
+    ///  - vaultResponse: Response from Vault request.
     ///  - request: Model composed with info to identify the polling.
     ///  - completion: Which will return a `Result` to be handle.
     func polling(
-        response: VaultResponse,
+        vaultResponse: VaultResponse,
         request: ForageRequestModel,
         completion: @escaping (Result<Data?, Error>) -> Void)
     

--- a/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
@@ -1,18 +1,21 @@
 //
-//  File.swift
-//  
+//  Constants.swift
+//
 //
 //  Created by Danny Leiser on 9/28/23.
 //
 
 import Foundation
 
-struct CommonErrors {
-    static let INCOMPLETE_PIN_ERROR = ForageError(errors: [
-        ForageErrorObj(
-            httpStatusCode: 400,
-            code: "user_error",
-            message: "Invalid EBT Card PIN entered. Please enter your 4-digit PIN."
-        )
-    ])
+internal struct CommonErrors {
+    static let INCOMPLETE_PIN_ERROR = ForageError.create(
+        httpStatusCode: 400,
+        code: "user_error",
+        message: "Invalid EBT Card PIN entered. Please enter your 4-digit PIN."
+    )
+    static let UNKNOWN_SERVER_ERROR = ForageError.create(
+        httpStatusCode: 500,
+        code: "unknown_server_error",
+        message: "Unknown error. This is a problem on Forage’s end."
+    )
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What

<!-- Describe your changes here -->

- Introduce use of async await (compatible with Swift v5.5, which [we use](https://github.com/teamforage/forage-ios-sdk/blob/95864356d1e840e411cfbfc77d367ad962cd5cb3/Package.swift#L1-L2)) to break the deep nesting of switch statements across the method chain for `checkBalance` and `capturePayment`

- Introduce `submitPinToVault` [method](https://github.com/teamforage/forage-ios-sdk/blob/95864356d1e840e411cfbfc77d367ad962cd5cb3/Sources/ForageSDK/Foundation/Network/LiveForageService.swift#L251-L252) to reduce duplication across checkBalance and capturePayment

- De-dupe calls to `monitor.end()`; [Previous state](https://github.com/teamforage/forage-ios-sdk/blob/9316d96bbd98f72c0eebdbe5e6f9d5d0987ba825/Sources/ForageSDK/Foundation/ForageSDK%2BForageServices.swift#L187-L233)

- De-dupe PIN `isComplete` validation across `checkBalance` and `capturePayment`

- Add [getter for VaultCollector](https://github.com/teamforage/forage-ios-sdk/blob/95864356d1e840e411cfbfc77d367ad962cd5cb3/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift#L181) to prevent crashes and avoid [unnecessarily force unwrapping textField.collector](https://github.com/teamforage/forage-ios-sdk/pull/118#discussion_r1360866637)

- Add ["IllegalState" reporting](https://github.com/teamforage/forage-ios-sdk/blob/95864356d1e840e411cfbfc77d367ad962cd5cb3/Sources/ForageSDK/Foundation/ForageSDK%2BForageServices.swift#L198-L199) if the client tries to call ForageSDK methods in the wrong state

- Wrap VGS and Basis Theory SDK submit methods in `DispatchQueue.main.async` to prevent crashes due to UI actions on background (non-main) thread!

- Contain the core network calls and steps of `checkBalance` and `capturePayment` flows in the same method instead of handling a portion in one method and a portion in another method with the same name. As [seen here](https://github.com/teamforage/forage-ios-sdk/blob/4afda4de9e3ecfbc2208903b64f84c8d8ff1cd73/Sources/ForageSDK/Foundation/Network/LiveForageService.swift#L77-L133)

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

- Improve reliability, readability, testability, and maintainability; [Linear ticket](https://linear.app/joinforage/issue/FX-631/ios-clean-up-checkbalance-and-capturepayment)

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- [x] Take a sample of before and after performance data to make sure I didn't degrade the performance
Trend lines are fairly flat and directed a bit downward, meaning no significant change in overall customer-perceived response time!

<img width="938" alt="image" src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/daff69b3-0070-43a6-93cb-237a22664ec0">


- [x] Make sure monitoring still works ✅ (See [dd dashboard](https://app.datadoghq.com/dashboard/ivu-m4y-3dy/customer-perception-metrics?refresh_mode=paused&tpl_var_action%5B0%5D=capture&tpl_var_env%5B0%5D=dev&tpl_var_sdk%5B0%5D=ios-sdk&tpl_var_vault_type%5B0%5D=basis_theory&from_ts=1697664388920&to_ts=1697675385762&live=false))

<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ | ❌ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How

- Can be released as-is (PATCH-level change)
- I'll follow up with other cleanup PRs on top of this one:
  - Add unit tests
  - Add concurrency for getting the encryption key with the payment / payment method

<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
