### PR TITLE
[FX-480] Add Polling unit tests

### DIFF
--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -46,7 +46,17 @@ public class ForageSDK {
 
         VGSCollectLogger.shared.disableAllLoggers()
         let provider = Provider(logger: logger)
-        service = LiveForageService(provider: provider, logger: logger, ldManager: LDManager.shared)
+        let livePollingService = LivePollingService(
+            provider: provider,
+            logger: logger,
+            ldManager: LDManager.shared
+        )
+        service = LiveForageService(
+            provider: provider,
+            logger: logger,
+            ldManager: LDManager.shared,
+            pollingService: livePollingService
+        )
     }
 
     /**

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -46,7 +46,7 @@ public class ForageSDK {
 
         VGSCollectLogger.shared.disableAllLoggers()
         let provider = Provider(logger: logger)
-        let livePollingService = LivePollingService(
+        let pollingService = PollingService(
             provider: provider,
             logger: logger,
             ldManager: LDManager.shared
@@ -55,7 +55,7 @@ public class ForageSDK {
             provider: provider,
             logger: logger,
             ldManager: LDManager.shared,
-            pollingService: livePollingService
+            pollingService: pollingService
         )
     }
 

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -227,11 +227,11 @@ class LiveForageService: ForageService {
                     continuation.resume(returning: result)
                 }
             }
-            
+
             if let error = vaultResponse.error {
                 throw error
             }
-            
+
             return vaultResponse
         } catch {
             throw error

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -15,14 +15,18 @@ class LiveForageService: ForageService {
 
     private var logger: ForageLogger?
     private var ldManager: LDManagerProtocol
-    private var maxAttempts: Int = 90
-    private var defaultPollingIntervalInMS: Int = 1000
-    private var retryCount = 0
+    private var pollingService: Polling
 
-    init(provider: Provider = Provider(), logger: ForageLogger? = nil, ldManager: LDManagerProtocol) {
+    init(
+        provider: Provider = Provider(),
+        logger: ForageLogger? = nil,
+        ldManager: LDManagerProtocol,
+        pollingService: Polling
+    ) {
         self.provider = provider
         self.logger = logger?.setPrefix("")
         self.ldManager = ldManager
+        self.pollingService = pollingService
     }
 
     // MARK: Tokenize EBT card
@@ -79,7 +83,7 @@ class LiveForageService: ForageService {
             )
 
             _ = try await awaitResult { completion in
-                self.polling(
+                self.pollingService.execute(
                     vaultResponse: vaultResult,
                     request: balanceRequest,
                     completion: completion
@@ -167,7 +171,7 @@ class LiveForageService: ForageService {
             )
 
             _ = try await awaitResult { completion in
-                self.polling(
+                self.pollingService.execute(
                     vaultResponse: vaultResult,
                     request: captureRequest,
                     completion: completion
@@ -193,14 +197,6 @@ class LiveForageService: ForageService {
 
     // MARK: Private helper methods
 
-    private func awaitResult<T>(_ operation: @escaping (@escaping (Result<T, Error>) -> Void) -> Void) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            operation { result in
-                continuation.resume(with: result)
-            }
-        }
-    }
-
     /// Submit PIN to the Vault Proxy (Basis Theory or VGS)
     /// - Parameters:
     ///   - pinCollector: The PIN collection client
@@ -222,7 +218,7 @@ class LiveForageService: ForageService {
         ]
 
         do {
-            return try await withCheckedThrowingContinuation { continuation in
+            let vaultResponse = try await withCheckedThrowingContinuation { continuation in
                 pinCollector.sendData(
                     path: path,
                     vaultAction: VaultAction.capturePayment,
@@ -231,150 +227,14 @@ class LiveForageService: ForageService {
                     continuation.resume(returning: result)
                 }
             }
+            
+            if let error = vaultResponse.error {
+                throw error
+            }
+            
+            return vaultResponse
         } catch {
             throw error
         }
-    }
-}
-
-// MARK: - Polling
-
-extension LiveForageService: Polling {
-    func polling(vaultResponse: VaultResponse, request: ForageRequestModel, completion: @escaping (Result<Data?, Error>) -> Void) {
-        retryCount = 0
-
-        if let error = vaultResponse.error {
-            completion(.failure(error))
-        } else if let data = vaultResponse.data, let urlResponse = vaultResponse.urlResponse {
-            provider.processVaultData(model: MessageResponseModel.self, code: vaultResponse.statusCode, data: data, response: urlResponse) { [weak self] messageResponse in
-                switch messageResponse {
-                case let .success(message):
-                    self?.pollingMessage(
-                        contentId: message.contentId,
-                        request: request
-                    ) { pollingResult in
-                        switch pollingResult {
-                        case .success:
-                            completion(.success(nil))
-                        case let .failure(error):
-                            completion(.failure(error))
-                        }
-                    }
-                case let .failure(error):
-                    self?.logger?.error("Failed to process vault proxy response for \(self?.getLogSuffix(request) ?? "N/A")", error: error, attributes: nil)
-                    completion(.failure(error))
-                }
-            }
-        } else {
-            let emptyError = ServiceError.emptyError
-            logger?.error(emptyError.rawValue, error: emptyError, attributes: nil)
-            completion(.failure(emptyError))
-        }
-    }
-
-    func pollingMessage(
-        contentId: String,
-        request: ForageRequestModel,
-        completion: @escaping (Result<MessageResponseModel, Error>) -> Void
-    ) {
-        do {
-            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(contentId: contentId, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case let .success(data):
-                    /// check message is not failed and is completed
-                    if data.failed == false && data.status == "completed" {
-                        completion(.success(data))
-                        /// check message is failed to return error immediately
-                    } else if data.failed == true {
-                        /// Parse the error returned from SQS message and return it back
-                        let error = data.errors[0]
-                        let statusCode = error.statusCode
-                        let forageErrorCode = error.forageCode
-                        let message = error.message
-                        let details = error.details
-                        let forageError = ForageError(errors: [
-                            ForageErrorObj(
-                                httpStatusCode: statusCode,
-                                code: forageErrorCode,
-                                message: message,
-                                details: details
-                            ),
-                        ])
-
-                        self.logger?.error(
-                            "Received SQS Error message for \(self.getLogSuffix(request))",
-                            error: forageError,
-                            attributes: nil
-                        )
-                        completion(.failure(forageError))
-                        /// check maxAttempts to retry
-                    } else if self.retryCount < self.maxAttempts {
-                        self.waitNextAttempt {
-                            self.pollingMessage(
-                                contentId: data.contentId,
-                                request: request,
-                                completion: completion
-                            )
-                        }
-                        /// in case run out of attempts
-                    } else {
-                        self.logger?.error(
-                            "Max polling attempts reached for \(self.getLogSuffix(request))",
-                            error: nil,
-                            attributes: nil
-                        )
-                        completion(.failure(ForageError(errors: [ForageErrorObj(httpStatusCode: 500, code: "unknown_server_error", message: "Unknown Server Error")])))
-                    }
-
-                case let .failure(error):
-                    completion(.failure(error))
-                }
-            })
-        } catch {
-            completion(.failure(error))
-        }
-    }
-
-    /// We generate a random jitter amount to add to our retry delay when polling for the status of
-    /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
-    /// several requests retrying at the same exact time.
-    ///
-    /// Returns a random double between -.025 and .025
-    @objc
-    func jitterAmountInSeconds() -> Double {
-        Double(Int.random(in: -25...25)) / 1000.0
-    }
-
-    /// Support function to update retry count and interval between attempts.
-    ///
-    /// - Parameters:
-    ///  - completion: Which will return after a wait.
-    func waitNextAttempt(completion: @escaping () -> Void) {
-        var interval = defaultPollingIntervalInMS
-        let pollingIntervals = ldManager.getPollingIntervals(ldClient: LDManager.getDefaultLDClient())
-        if retryCount < pollingIntervals.count {
-            interval = pollingIntervals[retryCount]
-        }
-        let intervalAsDouble = Double(interval) / 1000.0
-        let nextPollTime = intervalAsDouble + jitterAmountInSeconds()
-
-        retryCount = retryCount + 1
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
-            completion()
-        }
-    }
-
-    // get the log suffix (action + resource name + resource ref)
-    // using the given ForageRequestModel
-    private func getLogSuffix(_ request: ForageRequestModel) -> String {
-        let paymentReference = request.paymentMethodReference
-        let paymentMethodReference = request.paymentMethodReference
-
-        if !paymentReference.isEmpty {
-            return "capture of Payment \(paymentReference)"
-        }
-        return "balance check of Payment Method \(paymentMethodReference)"
     }
 }

--- a/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
@@ -13,16 +13,16 @@ class LivePollingService: Polling {
     private var provider: Provider
     private var logger: ForageLogger?
     private var ldManager: LDManagerProtocol
-    
+
     private var defaultPollingIntervalInMS: Int = 1000
     private var retryCount = 0
-    
+
     init(provider: Provider = Provider(), logger: ForageLogger? = nil, ldManager: LDManagerProtocol) {
         self.provider = provider
         self.logger = logger?.setPrefix("")
         self.ldManager = ldManager
     }
-    
+
     /// - Parameters:
     ///   - vaultResponse: A `VaultResponse` object containing data, status code, and other response details.
     ///   - request: An instance of `ForageRequestModel` containing request-specific information.
@@ -33,7 +33,7 @@ class LivePollingService: Polling {
         completion: @escaping (Result<Data?, Error>) -> Void
     ) {
         retryCount = 0
-        
+
         if let data = vaultResponse.data, let urlResponse = vaultResponse.urlResponse {
             provider.processVaultData(
                 model: MessageResponseModel.self,
@@ -64,7 +64,7 @@ class LivePollingService: Polling {
             completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
         }
     }
-        
+
     /// Fetches an SQS message based on its content ID.
     /// This method is part of a polling mechanism, repeatedly checking the status of a message
     /// until it is marked as completed, failed or a maximum retry limit is reached.
@@ -81,12 +81,12 @@ class LivePollingService: Polling {
         do {
             try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(contentId: contentId, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
                 guard let self = self else { return }
-                
+
                 switch result {
                 case let .success(message):
                     let didReceiveFailedMessage = message.failed
                     let didNotExceedMaxAttempts = self.retryCount < self.getMaxAttempts()
-                    
+
                     if didReceiveCompletedMessage(message) {
                         completion(.success(message))
                     } else if didReceiveFailedMessage {
@@ -103,7 +103,7 @@ class LivePollingService: Polling {
                                 details: details
                             ),
                         ])
-                        
+
                         self.logger?.error(
                             "Received SQS Error message for \(self.getLogSuffix(request))",
                             error: forageError,
@@ -126,14 +126,14 @@ class LivePollingService: Polling {
                         )
                         completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
                     }
-                    
+
                 case let .failure(error):
                     // malformed response, API is unavailable, etc.
                     completion(.failure(error))
                 }
             })
         } catch {
-            self.logger?.error(
+            logger?.error(
                 "getMessage failed",
                 error: error,
                 attributes: nil
@@ -142,7 +142,7 @@ class LivePollingService: Polling {
             completion(.failure(error))
         }
     }
-    
+
     /// We generate a random jitter amount to add to our retry delay when polling for the status of
     /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
     /// several requests retrying at the same exact time.
@@ -152,7 +152,7 @@ class LivePollingService: Polling {
     func jitterAmountInSeconds() -> Double {
         Double(Int.random(in: -25...25)) / 1000.0
     }
-    
+
     /// Support function to update retry count and interval between attempts.
     ///
     /// - Parameters:
@@ -165,32 +165,32 @@ class LivePollingService: Polling {
         }
         let intervalAsDouble = Double(interval) / 1000.0
         let nextPollTime = intervalAsDouble + jitterAmountInSeconds()
-        
+
         incrementRetryCount()
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
             completion()
         }
     }
-    
+
     func didReceiveCompletedMessage(_ message: MessageResponseModel) -> Bool {
-        return message.failed == false && message.status == "completed"
+        message.failed == false && message.status == "completed"
     }
-    
+
     func incrementRetryCount() {
         retryCount += 1
     }
-    
+
     func getMaxAttempts() -> Int {
-        return 90
+        90
     }
-    
+
     // Get the log suffix (action + resource name + resource ref)
     // using the given ForageRequestModel
     private func getLogSuffix(_ request: ForageRequestModel) -> String {
         let paymentReference = request.paymentMethodReference
         let paymentMethodReference = request.paymentMethodReference
-        
+
         if !paymentReference.isEmpty {
             return "capture of Payment \(paymentReference)"
         }

--- a/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
@@ -1,0 +1,199 @@
+//
+//  LivePollingService.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-11-10.
+//
+
+import Foundation
+
+// MARK: - Polling
+
+class LivePollingService: Polling {
+    private var provider: Provider
+    private var logger: ForageLogger?
+    private var ldManager: LDManagerProtocol
+    
+    private var defaultPollingIntervalInMS: Int = 1000
+    private var retryCount = 0
+    
+    init(provider: Provider = Provider(), logger: ForageLogger? = nil, ldManager: LDManagerProtocol) {
+        self.provider = provider
+        self.logger = logger?.setPrefix("")
+        self.ldManager = ldManager
+    }
+    
+    /// - Parameters:
+    ///   - vaultResponse: A `VaultResponse` object containing data, status code, and other response details.
+    ///   - request: An instance of `ForageRequestModel` containing request-specific information.
+    ///   - completion: The closure returns a `Result` containing either `nil` (success) response or an `Error`.
+    func execute(
+        vaultResponse: VaultResponse,
+        request: ForageRequestModel,
+        completion: @escaping (Result<Data?, Error>) -> Void
+    ) {
+        retryCount = 0
+        
+        if let data = vaultResponse.data, let urlResponse = vaultResponse.urlResponse {
+            provider.processVaultData(
+                model: MessageResponseModel.self,
+                code: vaultResponse.statusCode,
+                data: data,
+                response: urlResponse
+            ) { [weak self] messageResponse in
+                switch messageResponse {
+                case let .success(message):
+                    self?.getMessage(
+                        contentId: message.contentId,
+                        request: request
+                    ) { pollingResult in
+                        switch pollingResult {
+                        case .success:
+                            completion(.success(nil))
+                        case let .failure(error):
+                            completion(.failure(error))
+                        }
+                    }
+                case let .failure(error):
+                    self?.logger?.error("Failed to process vault proxy response for \(self?.getLogSuffix(request) ?? "N/A")", error: error, attributes: nil)
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            logger?.error("Response from vault proxy was malformed: \(vaultResponse)", error: ServiceError.emptyError, attributes: nil)
+            completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
+        }
+    }
+        
+    /// Fetches an SQS message based on its content ID.
+    /// This method is part of a polling mechanism, repeatedly checking the status of a message
+    /// until it is marked as completed, failed or a maximum retry limit is reached.
+    ///
+    /// - Parameters:
+    ///  - contentId: ID of the SQS message to be fetched
+    ///  - request: An instance of `ForageRequestModel` containing request-specific information.
+    ///  - completion: The closure returns a `Result` containing either a `MessageResponseModel` or a `Error`.
+    func getMessage(
+        contentId: String,
+        request: ForageRequestModel,
+        completion: @escaping (Result<MessageResponseModel, Error>) -> Void
+    ) {
+        do {
+            try provider.execute(model: MessageResponseModel.self, endpoint: ForageAPI.message(contentId: contentId, sessionToken: request.authorization, merchantID: request.merchantID), completion: { [weak self] result in
+                guard let self = self else { return }
+                
+                switch result {
+                case let .success(message):
+                    let didReceiveFailedMessage = message.failed
+                    let didNotExceedMaxAttempts = self.retryCount < self.getMaxAttempts()
+                    
+                    if didReceiveCompletedMessage(message) {
+                        completion(.success(message))
+                    } else if didReceiveFailedMessage {
+                        let error = message.errors[0]
+                        let statusCode = error.statusCode
+                        let forageErrorCode = error.forageCode
+                        let message = error.message
+                        let details = error.details
+                        let forageError = ForageError(errors: [
+                            ForageErrorObj(
+                                httpStatusCode: statusCode,
+                                code: forageErrorCode,
+                                message: message,
+                                details: details
+                            ),
+                        ])
+                        
+                        self.logger?.error(
+                            "Received SQS Error message for \(self.getLogSuffix(request))",
+                            error: forageError,
+                            attributes: nil
+                        )
+                        completion(.failure(forageError))
+                    } else if didNotExceedMaxAttempts {
+                        self.waitNextAttempt {
+                            self.getMessage(
+                                contentId: message.contentId,
+                                request: request,
+                                completion: completion
+                            )
+                        }
+                    } else {
+                        self.logger?.error(
+                            "Max polling attempts reached for \(self.getLogSuffix(request))",
+                            error: nil,
+                            attributes: nil
+                        )
+                        completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
+                    }
+                    
+                case let .failure(error):
+                    // malformed response, API is unavailable, etc.
+                    completion(.failure(error))
+                }
+            })
+        } catch {
+            self.logger?.error(
+                "getMessage failed",
+                error: error,
+                attributes: nil
+            )
+            // Invalid request URL
+            completion(.failure(error))
+        }
+    }
+    
+    /// We generate a random jitter amount to add to our retry delay when polling for the status of
+    /// Payments and Payment Methods so that we can avoid a thundering herd scenario in which there are
+    /// several requests retrying at the same exact time.
+    ///
+    /// Returns a random double between -.025 and .025
+    @objc
+    func jitterAmountInSeconds() -> Double {
+        Double(Int.random(in: -25...25)) / 1000.0
+    }
+    
+    /// Support function to update retry count and interval between attempts.
+    ///
+    /// - Parameters:
+    ///  - completion: Which will return after a wait.
+    func waitNextAttempt(completion: @escaping () -> Void) {
+        var interval = defaultPollingIntervalInMS
+        let pollingIntervals = ldManager.getPollingIntervals(ldClient: LDManager.getDefaultLDClient())
+        if retryCount < pollingIntervals.count {
+            interval = pollingIntervals[retryCount]
+        }
+        let intervalAsDouble = Double(interval) / 1000.0
+        let nextPollTime = intervalAsDouble + jitterAmountInSeconds()
+        
+        incrementRetryCount()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + nextPollTime) {
+            completion()
+        }
+    }
+    
+    func didReceiveCompletedMessage(_ message: MessageResponseModel) -> Bool {
+        return message.failed == false && message.status == "completed"
+    }
+    
+    func incrementRetryCount() {
+        retryCount += 1
+    }
+    
+    func getMaxAttempts() -> Int {
+        return 90
+    }
+    
+    // Get the log suffix (action + resource name + resource ref)
+    // using the given ForageRequestModel
+    private func getLogSuffix(_ request: ForageRequestModel) -> String {
+        let paymentReference = request.paymentMethodReference
+        let paymentMethodReference = request.paymentMethodReference
+        
+        if !paymentReference.isEmpty {
+            return "capture of Payment \(paymentReference)"
+        }
+        return "balance check of Payment Method \(paymentMethodReference)"
+    }
+}

--- a/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LivePollingService.swift
@@ -87,7 +87,7 @@ class LivePollingService: Polling {
                     let didReceiveFailedMessage = message.failed
                     let didNotExceedMaxAttempts = self.retryCount < self.getMaxAttempts()
 
-                    if didReceiveCompletedMessage(message) {
+                    if self.didReceiveCompletedMessage(message) {
                         completion(.success(message))
                     } else if didReceiveFailedMessage {
                         let error = message.errors[0]

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
@@ -37,7 +37,19 @@ struct MessageResponseModel: Codable {
         case failed
         case errors
     }
-
+    
+    init(contentId: String,
+         messageType: String,
+         status: String,
+         failed: Bool,
+         errors: [ForageSQSError]) {
+        self.contentId = contentId
+        self.messageType = messageType
+        self.status = status
+        self.failed = failed
+        self.errors = errors
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         contentId = try container.decode(String.self, forKey: .contentId)

--- a/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/MessageResponseModel.swift
@@ -37,7 +37,7 @@ struct MessageResponseModel: Codable {
         case failed
         case errors
     }
-    
+
     init(contentId: String,
          messageType: String,
          status: String,
@@ -49,7 +49,7 @@ struct MessageResponseModel: Codable {
         self.failed = failed
         self.errors = errors
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         contentId = try container.decode(String.self, forKey: .contentId)

--- a/Sources/ForageSDK/Foundation/Network/PollingService.swift
+++ b/Sources/ForageSDK/Foundation/Network/PollingService.swift
@@ -1,5 +1,5 @@
 //
-//  LivePollingService.swift
+//  PollingService.swift
 //
 //
 //  Created by Danilo Joksimovic on 2023-11-10.
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Polling
 
-class LivePollingService: Polling {
+class PollingService: Polling {
     private var provider: Provider
     private var logger: ForageLogger?
     private var ldManager: LDManagerProtocol

--- a/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/Polling.swift
@@ -19,21 +19,9 @@ protocol Polling: AnyObject {
     ///  - vaultResponse: Response from Vault request.
     ///  - request: Model composed with info to identify the polling.
     ///  - completion: Which will return a `Result` to be handle.
-    func polling(
+    func execute(
         vaultResponse: VaultResponse,
         request: ForageRequestModel,
         completion: @escaping (Result<Data?, Error>) -> Void
-    )
-
-    /// Polling method
-    ///
-    /// - Parameters:
-    ///  - contentId: Message object to be used to polling.
-    ///  - request: Model composed with info to identify the polling.
-    ///  - completion: Return a `MessageResponseModel` to check its validation. It will trigger another request using its object or it will return a completion `.success` or `.failure`.
-    func pollingMessage(
-        contentId: String,
-        request: ForageRequestModel,
-        completion: @escaping (Result<MessageResponseModel, Error>) -> Void
     )
 }

--- a/Sources/ForageSDK/Foundation/Network/Utils/Concurrency.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Concurrency.swift
@@ -1,0 +1,19 @@
+//
+//  Concurrency.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-11-10.
+//
+
+import Foundation
+
+// Global functions should be used judiciously!
+
+/// `awaitResult` is a utility method that bridges the gap between traditional callback-based asynchronous code and the modern Swift 5.5+ async/await pattern.
+func awaitResult<T>(_ operation: @escaping (@escaping (Result<T, Error>) -> Void) -> Void) async throws -> T {
+    try await withCheckedThrowingContinuation { continuation in
+        operation { result in
+            continuation.resume(with: result)
+        }
+    }
+}

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -27,7 +27,7 @@ class MockLDManager: LDManagerProtocol {
     }
 }
 
-class MockPollingService: LivePollingService {
+class MockPollingService: PollingService {
     override func execute(vaultResponse: VaultResponse, request: ForageRequestModel, completion: @escaping (Result<Data?, Error>) -> Void) {
         completion(.success(nil))
     }

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -27,7 +27,11 @@ class MockLDManager: LDManagerProtocol {
     }
 }
 
-class MockForageService: LiveForageService {
+class MockPollingService: LivePollingService {
+    override func execute(vaultResponse: VaultResponse, request: ForageRequestModel, completion: @escaping (Result<Data?, Error>) -> Void) {
+        completion(.success(nil))
+    }
+
     override func jitterAmountInSeconds() -> Double {
         0.0
     }
@@ -44,11 +48,19 @@ final class ForageServiceTests: XCTestCase {
         forageMocks = ForageMocks()
     }
 
+    func createTestService(_ mockSession: URLSessionMock) -> ForageService {
+        LiveForageService(
+            provider: Provider(mockSession),
+            ldManager: MockLDManager(),
+            pollingService: MockPollingService(ldManager: MockLDManager())
+        )
+    }
+
     func test_tokenizeEBTCard_onSuccess_checkExpectedPayload() {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.tokenizeSuccess
         mockSession.response = forageMocks.mockSuccessResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let foragePANRequestModel = ForagePANRequestModel(
             authorization: "authToken123",
@@ -80,7 +92,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.error = forageMocks.tokenizeFailure
         mockSession.response = forageMocks.mockFailureResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let foragePANRequestModel = ForagePANRequestModel(
             authorization: "authToken123",
@@ -108,7 +120,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.xKeySuccess
         mockSession.response = forageMocks.mockSuccessResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the X-Key header - should succeed")
         service.getXKey(sessionToken: "auth1234", merchantID: "1234567") { result in
@@ -128,7 +140,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.error = forageMocks.generalError
         mockSession.response = forageMocks.mockFailureResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the X-Key header - result should be failure")
         service.getXKey(sessionToken: "auth1234", merchantID: "1234567") { result in
@@ -147,7 +159,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.getPaymentMethodSuccess
         mockSession.response = forageMocks.mockSuccessResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment Method - should succeed")
         service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
@@ -171,7 +183,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.error = forageMocks.getPaymentMethodFailure
         mockSession.response = forageMocks.mockFailureResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment Method - result should be failure")
         service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
@@ -190,7 +202,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.data = forageMocks.capturePaymentSuccess
         mockSession.response = forageMocks.mockSuccessResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
         service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
@@ -213,7 +225,7 @@ final class ForageServiceTests: XCTestCase {
         let mockSession = URLSessionMock()
         mockSession.error = forageMocks.getPaymentError
         mockSession.response = forageMocks.mockFailureResponse
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
+        let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - result should be failure")
         service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
@@ -226,81 +238,6 @@ final class ForageServiceTests: XCTestCase {
             }
         }
         wait(for: [expectation], timeout: 1.0)
-    }
-
-    func test_getJitterAmountInSeconds() {
-        let mockSession = URLSessionMock()
-        let service = LiveForageService(provider: Provider(mockSession), ldManager: MockLDManager())
-
-        let jitterAmount = service.jitterAmountInSeconds()
-
-        XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
-        XCTAssertTrue(jitterAmount >= -0.025 && jitterAmount <= 0.025)
-    }
-
-    func test_WaitNextAttempt_defaultIntervals() {
-        let mockSession = URLSessionMock()
-        let service = MockForageService(provider: Provider(mockSession), ldManager: MockLDManager())
-
-        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
-        let successExpectation = XCTestExpectation(description: "Completion called after delay")
-
-        // Mark the expectation as fulfilled only if it failed
-        failureExpectation.isInverted = true
-
-        service.waitNextAttempt {
-            failureExpectation.fulfill()
-            successExpectation.fulfill()
-        }
-
-        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
-        wait(for: [failureExpectation], timeout: 0.95)
-        // Ensure that the successExpectation was fulfilled before the longer period of time
-        wait(for: [successExpectation], timeout: 1.05)
-    }
-
-    func test_waitNextAttempt_noPollingIntervals() {
-        let mockSession = URLSessionMock()
-
-        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
-        let successExpectation = XCTestExpectation(description: "Completion called after delay")
-
-        // Mark the expectation as fulfilled only if it failed
-        failureExpectation.isInverted = true
-
-        let service = MockForageService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: []))
-
-        service.waitNextAttempt {
-            failureExpectation.fulfill()
-            successExpectation.fulfill()
-        }
-
-        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
-        wait(for: [failureExpectation], timeout: 0.95)
-        // Ensure that the successExpectation was fulfilled before the longer period of time
-        wait(for: [successExpectation], timeout: 1.05)
-    }
-
-    func test_waitNextAttempt_shorterIntervals() {
-        let mockSession = URLSessionMock()
-
-        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
-        let successExpectation = XCTestExpectation(description: "Completion called after delay")
-
-        // Mark the expectation as fulfilled only if it failed
-        failureExpectation.isInverted = true
-
-        let service = MockForageService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: [100]))
-
-        service.waitNextAttempt {
-            successExpectation.fulfill()
-            failureExpectation.fulfill()
-        }
-
-        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
-        wait(for: [failureExpectation], timeout: 0.09)
-        // Ensure that the successExpectation was fulfilled before the longer period of time
-        wait(for: [successExpectation], timeout: 0.11)
     }
 
     func test_getBalance_onSuccess_checkExpectedPayload() {

--- a/Tests/ForageSDKTests/LDManagerTests.swift
+++ b/Tests/ForageSDKTests/LDManagerTests.swift
@@ -10,23 +10,6 @@ import XCTest
 @testable import ForageSDK
 @testable import LaunchDarkly
 
-class MockLogger: NoopLogger {
-    var lastInfoMsg: String = ""
-    var lastErrorMsg: String = ""
-
-    required init(_ config: ForageLoggerConfig? = nil) {
-        super.init(config)
-    }
-
-    override func info(_ message: String, attributes: [String: Encodable]?) {
-        lastInfoMsg = message
-    }
-
-    override func error(_ message: String, error: Error?, attributes: [String: Encodable]?) {
-        lastErrorMsg = message
-    }
-}
-
 class MockLDClient: LDClientProtocol {
     var pollingIntervals: LDValue?
     var vaultPercentage: Double

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -206,4 +206,106 @@ class ForageMocks {
         """
         return NSError(domain: response, code: 400, userInfo: nil)
     }
+
+    // MARK: GET /message/ success responses
+
+    var getMessageCompleted: Data {
+        let response = """
+        {
+          "content_id": "d789c086-9c4f-41c3-854a-1c436eee1d63",
+          "message_type": "0200",
+          "status": "completed",
+          "failed": false,
+          "errors": []
+        }
+        """
+        return Data(response.utf8)
+    }
+    
+    // we continue to retry until we see status: "completed"
+    // so we permantly set the status to: "sent_to_proxy" to trigger retry attempts
+    var getMessageIncomplete: Data {
+        let response = """
+        {
+          "content_id": "i789c086-9c4f-41c3-854a-1c436eee1d63",
+          "message_type": "0200",
+          "status": "sent_to_proxy",
+          "failed": false,
+          "errors": []
+        }
+        """
+        return Data(response.utf8)
+    }
+
+    // MARK: GET /message/ error responses
+
+    var getMessageUnauthorized: Data {
+        let response = """
+        {
+            "path": "/api/message/1c53e9e0-92e9-4568-a128-deecf4c2194a/",
+            "errors": [
+              {
+                "code": "missing_merchant_account",
+                "message": "No merchant account FNS number was provided.",
+                "source": {
+                  "resource": "Merchant_Account_Header",
+                  "ref": ""
+                }
+              }
+            ]
+          }
+        """
+        return Data(response.utf8)
+    }
+
+    var getMessageExpiredCard: Data {
+        let response = """
+        {
+          "content_id": "36058ff7-0e9d-4025-94cd-80ef04a3bb1c",
+          "message_type": "0200",
+          "status": "received_on_django",
+          "failed": true,
+          "errors": [
+            {
+              "status_code": 400,
+              "forage_code": "ebt_error_54",
+              "message": "Expired card - Expired Card"
+            }
+          ]
+        }
+        """
+        return Data(response.utf8)
+    }
+
+    var getMessageFailed: Data {
+        let response = """
+        {
+          "content_id": "c2bf2b14-415f-4cb3-8687-7eea06f75369",
+          "message_type": "0200",
+          "status": "received_on_django",
+          "failed": true,
+          "errors": [
+            {
+              "status_code": 400,
+              "forage_code": "ebt_error_51",
+              "message": "Received failure response from EBT network"
+            }
+          ]
+        }
+        """
+        return Data(response.utf8)
+    }
+    
+    // missing "errors" list
+    var getMessageMalformed: Data {
+        let response = """
+        {
+          "content_id": "d789c086-9c4f-41c3-854a-1c436eee1d63",
+          "message_type": "0200",
+          "status": "completed",
+          "failed": false
+        }
+        """
+        return Data(response.utf8)
+    }
 }

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -221,7 +221,7 @@ class ForageMocks {
         """
         return Data(response.utf8)
     }
-    
+
     // we continue to retry until we see status: "completed"
     // so we permantly set the status to: "sent_to_proxy" to trigger retry attempts
     var getMessageIncomplete: Data {
@@ -295,7 +295,7 @@ class ForageMocks {
         """
         return Data(response.utf8)
     }
-    
+
     // missing "errors" list
     var getMessageMalformed: Data {
         let response = """

--- a/Tests/ForageSDKTests/Mock/MockLogger.swift
+++ b/Tests/ForageSDKTests/Mock/MockLogger.swift
@@ -1,0 +1,25 @@
+//
+//  MockLogger.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-11-11.
+//
+@testable import ForageSDK
+import Foundation
+
+class MockLogger: NoopLogger {
+    var lastInfoMsg: String = ""
+    var lastErrorMsg: String = ""
+
+    required init(_ config: ForageLoggerConfig? = nil) {
+        super.init(config)
+    }
+
+    override func info(_ message: String, attributes: [String: Encodable]?) {
+        lastInfoMsg = message
+    }
+
+    override func error(_ message: String, error: Error?, attributes: [String: Encodable]?) {
+        lastErrorMsg = message
+    }
+}

--- a/Tests/ForageSDKTests/Mock/TestUtils.swift
+++ b/Tests/ForageSDKTests/Mock/TestUtils.swift
@@ -1,0 +1,20 @@
+//
+//  TestUtils.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-11-11.
+//
+
+@testable import ForageSDK
+import Foundation
+
+// ⚠️ Utils should be used judiciously
+
+/// Need to call setUpForageSDK before running most tests
+/// Since initializing the SDK is a pre-condition for most SDK interactions
+func setUpForageSDK() {
+    ForageSDK.setup(ForageSDK.Config(
+        merchantID: "merchantID123",
+        sessionToken: "authToken123"
+    ))
+}

--- a/Tests/ForageSDKTests/PollingServiceTests.swift
+++ b/Tests/ForageSDKTests/PollingServiceTests.swift
@@ -14,13 +14,13 @@ class WithMockedWaitNextAttempt: LivePollingService {
     var maxAttempts: Int = 90
     var numTimesCalledWaitNextAttempt: Int = 0
     var didComplete: (() -> Bool) = { false }
-    
+
     override func waitNextAttempt(completion: @escaping () -> Void) {
         super.incrementRetryCount()
         numTimesCalledWaitNextAttempt += 1
         completion() // complete immediately
     }
-    
+
     override func getMessage(
         contentId: String,
         request: ForageRequestModel,
@@ -42,26 +42,26 @@ class WithMockedWaitNextAttempt: LivePollingService {
 
 final class PollingServiceTests: XCTestCase {
     // MARK: Setup
-    
+
     var forageMocks: ForageMocks!
     var mockLogger: MockLogger!
-    
+
     private func createTestPollingService(
         _ mockSession: URLSessionMock = URLSessionMock()
     ) -> LivePollingService {
-        return WithMockedWaitNextAttempt(
+        WithMockedWaitNextAttempt(
             provider: Provider(mockSession),
             logger: mockLogger,
             ldManager: MockLDManager()
         )
     }
-    
+
     override func setUp() {
         setUpForageSDK()
         mockLogger = MockLogger()
         forageMocks = ForageMocks()
     }
-    
+
     private func setupTestWithMockData(
         mockData: Data? = nil,
         response: HTTPURLResponse? = nil,
@@ -72,7 +72,7 @@ final class PollingServiceTests: XCTestCase {
         mockSession.response = response
         mockSession.error = error
         let pollingService = createTestPollingService(mockSession)
-        
+
         let requestModel = ForageRequestModel(
             authorization: "testAuthorization",
             paymentMethodReference: "testPaymentMethodRef",
@@ -81,10 +81,10 @@ final class PollingServiceTests: XCTestCase {
             merchantID: "testMerchantID",
             xKey: ["testKey": "testValue"]
         )
-        
+
         return (pollingService, requestModel)
     }
-    
+
     // MARK: test_execute - success
 
     func test_execute_Succeeds() async throws {
@@ -92,14 +92,14 @@ final class PollingServiceTests: XCTestCase {
             mockData: forageMocks.getMessageCompleted,
             response: forageMocks.mockSuccessResponse
         )
-        
+
         let vaultResponse = VaultResponse(
             statusCode: 200,
             urlResponse: forageMocks.mockSuccessResponse,
             data: forageMocks.getMessageCompleted,
             error: nil
         )
-        
+
         _ = try await awaitResult { completion in
             pollingService.execute(
                 vaultResponse: vaultResponse,
@@ -107,19 +107,19 @@ final class PollingServiceTests: XCTestCase {
                 completion: completion
             )
         }
-        
+
         // did not throw!
         XCTAssertTrue(true)
     }
-    
+
     // MARK: test_execute - errors
-    
+
     func test_execute_MalformedVaultResponseFromForage() {
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageCompleted,
             response: forageMocks.mockSuccessResponse
         )
-        
+
         // Vault responds with (incomplete) "sent_to_proxy" response
         let vaultResponse = VaultResponse(
             statusCode: 400,
@@ -127,15 +127,15 @@ final class PollingServiceTests: XCTestCase {
             data: forageMocks.getMessageUnauthorized,
             error: nil
         )
-        
+
         let expectation = XCTestExpectation(description: "getMessage should fail")
-        
+
         pollingService.execute(
             vaultResponse: vaultResponse,
             request: requestModel
         ) { result in
             switch result {
-            case .success(_):
+            case .success:
                 XCTFail("Expected failure, but got success")
             case let .failure(error):
                 guard let firstError = (error as! ForageError).errors.first else {
@@ -148,18 +148,17 @@ final class PollingServiceTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
 
-    
     func test_execute_vaultSucceeded_getMessageFailed() async throws {
         // getMessage responds with failed message
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageFailed,
             response: forageMocks.mockFailureResponse
         )
-        
+
         // Vault responds with (incomplete) "sent_to_proxy" response
         let vaultResponse = VaultResponse(
             statusCode: 200,
@@ -167,7 +166,7 @@ final class PollingServiceTests: XCTestCase {
             data: forageMocks.getMessageIncomplete,
             error: nil
         )
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.execute(
@@ -181,18 +180,18 @@ final class PollingServiceTests: XCTestCase {
                 XCTFail("Expected a ForageError")
                 return
             }
-            
+
             XCTAssertEqual(mockLogger.lastErrorMsg, "Received SQS Error message for capture of Payment testPaymentMethodRef")
             XCTAssertEqual(firstError.code, "ebt_error_51")
             XCTAssertEqual(firstError.httpStatusCode, 400)
         }
     }
-    
+
     func test_execute_MalformedVaultResponseFromVault() async throws {
         let (pollingService, requestModel) = setupTestWithMockData()
-        
+
         let malformedVaultResponse = VaultResponse(statusCode: 400, urlResponse: nil, data: nil, error: nil)
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.execute(
@@ -206,40 +205,40 @@ final class PollingServiceTests: XCTestCase {
                 XCTFail("Expected a ForageError")
                 return
             }
-            
+
             XCTAssertEqual(mockLogger.lastErrorMsg, "Response from vault proxy was malformed: VaultResponse(statusCode: Optional(400), urlResponse: nil, data: nil, error: nil)")
             XCTAssertEqual(firstError.code, "unknown_server_error")
             XCTAssertEqual(firstError.httpStatusCode, 500)
         }
     }
-    
+
     // MARK: test_getMessage - success
-    
+
     func test_getMessage_SuccessCompleted() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageCompleted,
             response: forageMocks.mockSuccessResponse
         )
-        
+
         let messageResponseModel = try await awaitResult { completion in
             pollingService.getMessage(contentId: "testContentId", request: requestModel, completion: completion)
         }
-        
+
         XCTAssertEqual(messageResponseModel.contentId, "d789c086-9c4f-41c3-854a-1c436eee1d63")
         XCTAssertEqual(messageResponseModel.messageType, "0200")
         XCTAssertEqual(messageResponseModel.status, "completed")
         XCTAssertEqual(messageResponseModel.failed, false)
         XCTAssertEqual(messageResponseModel.errors.isEmpty, true)
     }
-    
+
     // MARK: test_getMessage - error scenarios
-    
+
     func test_getMessage_Unauthorized() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageUnauthorized,
             response: forageMocks.mockFailureResponse
         )
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.getMessage(
@@ -261,13 +260,13 @@ final class PollingServiceTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
-    
+
     func test_getMessage_ExpiredCard() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageExpiredCard,
             response: forageMocks.mockFailureResponse
         )
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.getMessage(
@@ -289,13 +288,13 @@ final class PollingServiceTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
-    
+
     func test_getMessage_FailedResponse() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             mockData: forageMocks.getMessageFailed,
             response: forageMocks.mockFailureResponse
         )
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.getMessage(
@@ -317,7 +316,7 @@ final class PollingServiceTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
-    
+
     func test_getMessage_MalformedResponse() {
         // Received an invalid response (e.g. decode error)
         let (pollingService, requestModel) = setupTestWithMockData(
@@ -325,27 +324,27 @@ final class PollingServiceTests: XCTestCase {
             response: forageMocks.mockFailureResponse,
             error: forageMocks.generalError
         )
-        
+
         let expectation = XCTestExpectation(description: "getMessage should fail")
-        
+
         pollingService.getMessage(
             contentId: "testContentId",
             request: requestModel
         ) { result in
             switch result {
-            case .success(_):
+            case .success:
                 XCTFail("Expected failure, but got success")
             case let .failure(error):
                 XCTAssertNotNil(error)
                 expectation.fulfill()
             }
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
-    // MARK test_getMessage - retry logic
-    
+
+    // MARK: test_getMessage - retry logic
+
     func test_getMessage_CompletesAfterRetries() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             // we start with status: "sent_to_proxy" (incomplete)
@@ -353,11 +352,11 @@ final class PollingServiceTests: XCTestCase {
             mockData: forageMocks.getMessageIncomplete,
             response: forageMocks.mockSuccessResponse
         )
-        
+
         let mockedPollingService = pollingService as! WithMockedWaitNextAttempt
         // set a bound to make sure this test case doesn't hang indefinetely if it breaks
         mockedPollingService.maxAttempts = 10
-        
+
         mockedPollingService.didComplete = {
             // Change to "completed" after 3 retries
             let changeResponseAfterRetries = 3
@@ -366,7 +365,7 @@ final class PollingServiceTests: XCTestCase {
             }
             return false
         }
-        
+
         do {
             let message = try await awaitResult { completion in
                 mockedPollingService.getMessage(
@@ -381,7 +380,7 @@ final class PollingServiceTests: XCTestCase {
             XCTFail("getMessage Failed")
         }
     }
-    
+
     func test_getMessage_ReachedMaxAttempts() async throws {
         let (pollingService, requestModel) = setupTestWithMockData(
             // we continue to retry until we see status: "completed"
@@ -389,10 +388,10 @@ final class PollingServiceTests: XCTestCase {
             mockData: forageMocks.getMessageIncomplete,
             response: forageMocks.mockSuccessResponse
         )
-        
+
         // force reaching max attempts
         (pollingService as! WithMockedWaitNextAttempt).maxAttempts = -1
-        
+
         do {
             _ = try await awaitResult { completion in
                 pollingService.getMessage(
@@ -401,7 +400,7 @@ final class PollingServiceTests: XCTestCase {
                     completion: completion
                 )
             }
-            
+
             XCTFail("Expected failure, but got success")
         } catch let error as ForageError {
             guard let firstError = error.errors.first else {
@@ -414,90 +413,89 @@ final class PollingServiceTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
-    
+
     // MARK: test_getJitterAmountInSeconds
-    
+
     func test_getJitterAmountInSeconds() {
         let mockSession = URLSessionMock()
         let pollingService = LivePollingService(
             provider: Provider(mockSession),
             ldManager: MockLDManager()
         )
-        
+
         let jitterAmount = pollingService.jitterAmountInSeconds()
-        
+
         XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
         XCTAssertTrue(jitterAmount >= -0.025 && jitterAmount <= 0.025)
     }
-    
+
     // MARK: test_WaitNextAttempt
-    
+
     func test_WaitNextAttempt_defaultIntervals() {
         let mockSession = URLSessionMock()
         let pollingService = LivePollingService(
             provider: Provider(mockSession),
             ldManager: MockLDManager()
         )
-        
+
         let failureExpectation = XCTestExpectation(description: "Completion called before delay")
         let successExpectation = XCTestExpectation(description: "Completion called after delay")
-        
+
         // Mark the expectation as fulfilled only if it failed
         failureExpectation.isInverted = true
-        
+
         pollingService.waitNextAttempt {
             failureExpectation.fulfill()
             successExpectation.fulfill()
         }
-        
+
         // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
         wait(for: [failureExpectation], timeout: 0.95)
         // Ensure that the successExpectation was fulfilled before the longer period of time
         wait(for: [successExpectation], timeout: 1.05)
     }
-    
+
     func test_waitNextAttempt_noPollingIntervals() {
         let mockSession = URLSessionMock()
-        
+
         let failureExpectation = XCTestExpectation(description: "Completion called before delay")
         let successExpectation = XCTestExpectation(description: "Completion called after delay")
-        
+
         // Mark the expectation as fulfilled only if it failed
         failureExpectation.isInverted = true
-        
+
         let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: []))
-        
+
         pollingService.waitNextAttempt {
             failureExpectation.fulfill()
             successExpectation.fulfill()
         }
-        
+
         // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
         wait(for: [failureExpectation], timeout: 0.95)
         // Ensure that the successExpectation was fulfilled before the longer period of time
         wait(for: [successExpectation], timeout: 1.05)
     }
-    
+
     func test_waitNextAttempt_shorterIntervals() {
         let mockSession = URLSessionMock()
-        
+
         let failureExpectation = XCTestExpectation(description: "Completion called before delay")
         let successExpectation = XCTestExpectation(description: "Completion called after delay")
-        
+
         // Mark the expectation as fulfilled only if it failed
         failureExpectation.isInverted = true
-        
+
         let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: [100]))
-        
+
         pollingService.waitNextAttempt {
             successExpectation.fulfill()
             failureExpectation.fulfill()
         }
-        
+
         // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
         wait(for: [failureExpectation], timeout: 0.09)
         // Ensure that the successExpectation was fulfilled before the longer period of time
         wait(for: [successExpectation], timeout: 0.11)
     }
 }
-

--- a/Tests/ForageSDKTests/PollingServiceTests.swift
+++ b/Tests/ForageSDKTests/PollingServiceTests.swift
@@ -1,0 +1,503 @@
+//
+//  PollingServiceTests.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-11-10.
+//
+
+@testable import ForageSDK
+@testable import LaunchDarkly
+import Foundation
+import XCTest
+
+class WithMockedWaitNextAttempt: LivePollingService {
+    var maxAttempts: Int = 90
+    var numTimesCalledWaitNextAttempt: Int = 0
+    var didComplete: (() -> Bool) = { false }
+    
+    override func waitNextAttempt(completion: @escaping () -> Void) {
+        super.incrementRetryCount()
+        numTimesCalledWaitNextAttempt += 1
+        completion() // complete immediately
+    }
+    
+    override func getMessage(
+        contentId: String,
+        request: ForageRequestModel,
+        completion: @escaping (Result<MessageResponseModel, Error>) -> Void
+    ) {
+        if didComplete() {
+            completion(.success(MessageResponseModel(
+                contentId: "test-completed-content-id",
+                messageType: "0200",
+                status: "completed",
+                failed: false,
+                errors: []
+            )))
+        } else {
+            super.getMessage(contentId: contentId, request: request, completion: completion)
+        }
+    }
+}
+
+final class PollingServiceTests: XCTestCase {
+    // MARK: Setup
+    
+    var forageMocks: ForageMocks!
+    var mockLogger: MockLogger!
+    
+    private func createTestPollingService(
+        _ mockSession: URLSessionMock = URLSessionMock()
+    ) -> LivePollingService {
+        return WithMockedWaitNextAttempt(
+            provider: Provider(mockSession),
+            logger: mockLogger,
+            ldManager: MockLDManager()
+        )
+    }
+    
+    override func setUp() {
+        setUpForageSDK()
+        mockLogger = MockLogger()
+        forageMocks = ForageMocks()
+    }
+    
+    private func setupTestWithMockData(
+        mockData: Data? = nil,
+        response: HTTPURLResponse? = nil,
+        error: Error? = nil
+    ) -> (LivePollingService, ForageRequestModel) {
+        let mockSession = URLSessionMock()
+        mockSession.data = mockData
+        mockSession.response = response
+        mockSession.error = error
+        let pollingService = createTestPollingService(mockSession)
+        
+        let requestModel = ForageRequestModel(
+            authorization: "testAuthorization",
+            paymentMethodReference: "testPaymentMethodRef",
+            paymentReference: "testPaymentRef",
+            cardNumberToken: "testCardToken",
+            merchantID: "testMerchantID",
+            xKey: ["testKey": "testValue"]
+        )
+        
+        return (pollingService, requestModel)
+    }
+    
+    // MARK: test_execute - success
+
+    func test_execute_Succeeds() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageCompleted,
+            response: forageMocks.mockSuccessResponse
+        )
+        
+        let vaultResponse = VaultResponse(
+            statusCode: 200,
+            urlResponse: forageMocks.mockSuccessResponse,
+            data: forageMocks.getMessageCompleted,
+            error: nil
+        )
+        
+        _ = try await awaitResult { completion in
+            pollingService.execute(
+                vaultResponse: vaultResponse,
+                request: requestModel,
+                completion: completion
+            )
+        }
+        
+        // did not throw!
+        XCTAssertTrue(true)
+    }
+    
+    // MARK: test_execute - errors
+    
+    func test_execute_MalformedVaultResponseFromForage() {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageCompleted,
+            response: forageMocks.mockSuccessResponse
+        )
+        
+        // Vault responds with (incomplete) "sent_to_proxy" response
+        let vaultResponse = VaultResponse(
+            statusCode: 400,
+            urlResponse: forageMocks.mockFailureResponse,
+            data: forageMocks.getMessageUnauthorized,
+            error: nil
+        )
+        
+        let expectation = XCTestExpectation(description: "getMessage should fail")
+        
+        pollingService.execute(
+            vaultResponse: vaultResponse,
+            request: requestModel
+        ) { result in
+            switch result {
+            case .success(_):
+                XCTFail("Expected failure, but got success")
+            case let .failure(error):
+                guard let firstError = (error as! ForageError).errors.first else {
+                    XCTFail("Expected a ForageError")
+                    return
+                }
+                XCTAssertEqual(self.mockLogger.lastErrorMsg, "Failed to process vault proxy response for capture of Payment testPaymentMethodRef")
+                XCTAssertEqual(firstError.code, "missing_merchant_account")
+                XCTAssertEqual(firstError.httpStatusCode, 400)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    
+    func test_execute_vaultSucceeded_getMessageFailed() async throws {
+        // getMessage responds with failed message
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageFailed,
+            response: forageMocks.mockFailureResponse
+        )
+        
+        // Vault responds with (incomplete) "sent_to_proxy" response
+        let vaultResponse = VaultResponse(
+            statusCode: 200,
+            urlResponse: forageMocks.mockSuccessResponse,
+            data: forageMocks.getMessageIncomplete,
+            error: nil
+        )
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.execute(
+                    vaultResponse: vaultResponse,
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            
+            XCTAssertEqual(mockLogger.lastErrorMsg, "Received SQS Error message for capture of Payment testPaymentMethodRef")
+            XCTAssertEqual(firstError.code, "ebt_error_51")
+            XCTAssertEqual(firstError.httpStatusCode, 400)
+        }
+    }
+    
+    func test_execute_MalformedVaultResponseFromVault() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData()
+        
+        let malformedVaultResponse = VaultResponse(statusCode: 400, urlResponse: nil, data: nil, error: nil)
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.execute(
+                    vaultResponse: malformedVaultResponse,
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            
+            XCTAssertEqual(mockLogger.lastErrorMsg, "Response from vault proxy was malformed: VaultResponse(statusCode: Optional(400), urlResponse: nil, data: nil, error: nil)")
+            XCTAssertEqual(firstError.code, "unknown_server_error")
+            XCTAssertEqual(firstError.httpStatusCode, 500)
+        }
+    }
+    
+    // MARK: test_getMessage - success
+    
+    func test_getMessage_SuccessCompleted() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageCompleted,
+            response: forageMocks.mockSuccessResponse
+        )
+        
+        let messageResponseModel = try await awaitResult { completion in
+            pollingService.getMessage(contentId: "testContentId", request: requestModel, completion: completion)
+        }
+        
+        XCTAssertEqual(messageResponseModel.contentId, "d789c086-9c4f-41c3-854a-1c436eee1d63")
+        XCTAssertEqual(messageResponseModel.messageType, "0200")
+        XCTAssertEqual(messageResponseModel.status, "completed")
+        XCTAssertEqual(messageResponseModel.failed, false)
+        XCTAssertEqual(messageResponseModel.errors.isEmpty, true)
+    }
+    
+    // MARK: test_getMessage - error scenarios
+    
+    func test_getMessage_Unauthorized() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageUnauthorized,
+            response: forageMocks.mockFailureResponse
+        )
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.getMessage(
+                    contentId: "testContentId",
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+            XCTFail("Expected unauthorized error, but got success")
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            XCTAssertEqual(firstError.code, "missing_merchant_account")
+            XCTAssertEqual(firstError.httpStatusCode, 400)
+            XCTAssertEqual(firstError.message, "No merchant account FNS number was provided.")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+    
+    func test_getMessage_ExpiredCard() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageExpiredCard,
+            response: forageMocks.mockFailureResponse
+        )
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.getMessage(
+                    contentId: "testContentId",
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+            XCTFail("Expected unauthorized error, but got success")
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            XCTAssertEqual(firstError.code, "ebt_error_54")
+            XCTAssertEqual(firstError.httpStatusCode, 400)
+            XCTAssertEqual(firstError.message, "Expired card - Expired Card")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+    
+    func test_getMessage_FailedResponse() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: forageMocks.getMessageFailed,
+            response: forageMocks.mockFailureResponse
+        )
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.getMessage(
+                    contentId: "testContentId",
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+            XCTFail("Expected unauthorized error, but got success")
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            XCTAssertEqual(firstError.code, "ebt_error_51")
+            XCTAssertEqual(firstError.httpStatusCode, 400)
+            XCTAssertEqual(firstError.message, "Received failure response from EBT network")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+    
+    func test_getMessage_MalformedResponse() {
+        // Received an invalid response (e.g. decode error)
+        let (pollingService, requestModel) = setupTestWithMockData(
+            mockData: nil,
+            response: forageMocks.mockFailureResponse,
+            error: forageMocks.generalError
+        )
+        
+        let expectation = XCTestExpectation(description: "getMessage should fail")
+        
+        pollingService.getMessage(
+            contentId: "testContentId",
+            request: requestModel
+        ) { result in
+            switch result {
+            case .success(_):
+                XCTFail("Expected failure, but got success")
+            case let .failure(error):
+                XCTAssertNotNil(error)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    // MARK test_getMessage - retry logic
+    
+    func test_getMessage_CompletesAfterRetries() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            // we start with status: "sent_to_proxy" (incomplete)
+            // to force retries
+            mockData: forageMocks.getMessageIncomplete,
+            response: forageMocks.mockSuccessResponse
+        )
+        
+        let mockedPollingService = pollingService as! WithMockedWaitNextAttempt
+        // set a bound to make sure this test case doesn't hang indefinetely if it breaks
+        mockedPollingService.maxAttempts = 10
+        
+        mockedPollingService.didComplete = {
+            // Change to "completed" after 3 retries
+            let changeResponseAfterRetries = 3
+            if mockedPollingService.numTimesCalledWaitNextAttempt >= changeResponseAfterRetries {
+                return true
+            }
+            return false
+        }
+        
+        do {
+            let message = try await awaitResult { completion in
+                mockedPollingService.getMessage(
+                    contentId: "test-completed-content-id",
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+            XCTAssertEqual(message.contentId, "test-completed-content-id")
+            XCTAssertEqual(mockedPollingService.numTimesCalledWaitNextAttempt, 3)
+        } catch {
+            XCTFail("getMessage Failed")
+        }
+    }
+    
+    func test_getMessage_ReachedMaxAttempts() async throws {
+        let (pollingService, requestModel) = setupTestWithMockData(
+            // we continue to retry until we see status: "completed"
+            // but here we permantly set the status to: "sent_to_proxy"
+            mockData: forageMocks.getMessageIncomplete,
+            response: forageMocks.mockSuccessResponse
+        )
+        
+        // force reaching max attempts
+        (pollingService as! WithMockedWaitNextAttempt).maxAttempts = -1
+        
+        do {
+            _ = try await awaitResult { completion in
+                pollingService.getMessage(
+                    contentId: "testContentId",
+                    request: requestModel,
+                    completion: completion
+                )
+            }
+            
+            XCTFail("Expected failure, but got success")
+        } catch let error as ForageError {
+            guard let firstError = error.errors.first else {
+                XCTFail("Expected a ForageError")
+                return
+            }
+            XCTAssertEqual(firstError.code, "unknown_server_error")
+            XCTAssertEqual(firstError.httpStatusCode, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+    
+    // MARK: test_getJitterAmountInSeconds
+    
+    func test_getJitterAmountInSeconds() {
+        let mockSession = URLSessionMock()
+        let pollingService = LivePollingService(
+            provider: Provider(mockSession),
+            ldManager: MockLDManager()
+        )
+        
+        let jitterAmount = pollingService.jitterAmountInSeconds()
+        
+        XCTAssertNotNil(jitterAmount, "Jitter amount should not be nil")
+        XCTAssertTrue(jitterAmount >= -0.025 && jitterAmount <= 0.025)
+    }
+    
+    // MARK: test_WaitNextAttempt
+    
+    func test_WaitNextAttempt_defaultIntervals() {
+        let mockSession = URLSessionMock()
+        let pollingService = LivePollingService(
+            provider: Provider(mockSession),
+            ldManager: MockLDManager()
+        )
+        
+        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
+        let successExpectation = XCTestExpectation(description: "Completion called after delay")
+        
+        // Mark the expectation as fulfilled only if it failed
+        failureExpectation.isInverted = true
+        
+        pollingService.waitNextAttempt {
+            failureExpectation.fulfill()
+            successExpectation.fulfill()
+        }
+        
+        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
+        wait(for: [failureExpectation], timeout: 0.95)
+        // Ensure that the successExpectation was fulfilled before the longer period of time
+        wait(for: [successExpectation], timeout: 1.05)
+    }
+    
+    func test_waitNextAttempt_noPollingIntervals() {
+        let mockSession = URLSessionMock()
+        
+        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
+        let successExpectation = XCTestExpectation(description: "Completion called after delay")
+        
+        // Mark the expectation as fulfilled only if it failed
+        failureExpectation.isInverted = true
+        
+        let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: []))
+        
+        pollingService.waitNextAttempt {
+            failureExpectation.fulfill()
+            successExpectation.fulfill()
+        }
+        
+        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
+        wait(for: [failureExpectation], timeout: 0.95)
+        // Ensure that the successExpectation was fulfilled before the longer period of time
+        wait(for: [successExpectation], timeout: 1.05)
+    }
+    
+    func test_waitNextAttempt_shorterIntervals() {
+        let mockSession = URLSessionMock()
+        
+        let failureExpectation = XCTestExpectation(description: "Completion called before delay")
+        let successExpectation = XCTestExpectation(description: "Completion called after delay")
+        
+        // Mark the expectation as fulfilled only if it failed
+        failureExpectation.isInverted = true
+        
+        let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: [100]))
+        
+        pollingService.waitNextAttempt {
+            successExpectation.fulfill()
+            failureExpectation.fulfill()
+        }
+        
+        // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
+        wait(for: [failureExpectation], timeout: 0.09)
+        // Ensure that the successExpectation was fulfilled before the longer period of time
+        wait(for: [successExpectation], timeout: 0.11)
+    }
+}
+

--- a/Tests/ForageSDKTests/PollingServiceTests.swift
+++ b/Tests/ForageSDKTests/PollingServiceTests.swift
@@ -10,7 +10,7 @@
 import Foundation
 import XCTest
 
-class WithMockedWaitNextAttempt: LivePollingService {
+class WithMockedWaitNextAttempt: PollingService {
     var maxAttempts: Int = 90
     var numTimesCalledWaitNextAttempt: Int = 0
     var didComplete: (() -> Bool) = { false }
@@ -48,7 +48,7 @@ final class PollingServiceTests: XCTestCase {
 
     private func createTestPollingService(
         _ mockSession: URLSessionMock = URLSessionMock()
-    ) -> LivePollingService {
+    ) -> PollingService {
         WithMockedWaitNextAttempt(
             provider: Provider(mockSession),
             logger: mockLogger,
@@ -66,7 +66,7 @@ final class PollingServiceTests: XCTestCase {
         mockData: Data? = nil,
         response: HTTPURLResponse? = nil,
         error: Error? = nil
-    ) -> (LivePollingService, ForageRequestModel) {
+    ) -> (PollingService, ForageRequestModel) {
         let mockSession = URLSessionMock()
         mockSession.data = mockData
         mockSession.response = response
@@ -418,7 +418,7 @@ final class PollingServiceTests: XCTestCase {
 
     func test_getJitterAmountInSeconds() {
         let mockSession = URLSessionMock()
-        let pollingService = LivePollingService(
+        let pollingService = PollingService(
             provider: Provider(mockSession),
             ldManager: MockLDManager()
         )
@@ -433,7 +433,7 @@ final class PollingServiceTests: XCTestCase {
 
     func test_WaitNextAttempt_defaultIntervals() {
         let mockSession = URLSessionMock()
-        let pollingService = LivePollingService(
+        let pollingService = PollingService(
             provider: Provider(mockSession),
             ldManager: MockLDManager()
         )


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Move `Polling` to its own service; the `LiveForageService.swift` file was dealing with too many concerns and was hard to test
- Add unit tests for `Polling`
- Return `ForageError` for polling errors, where we were previously returning string errors to the client.

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-480/add-unit-tests-for-ios-polling

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅  Added an exhaustive suite of unit tests for `Polling`

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is.