### PR TITLE
[FX-658] Potential fix for LDClient not being initialized

### DIFF
--- a/Sample/SampleForageSDK/AppDelegate.swift
+++ b/Sample/SampleForageSDK/AppDelegate.swift
@@ -12,13 +12,6 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        ForageSDK.setup(
-            ForageSDK.Config(
-                merchantID: ClientSharedData.shared.merchantID,
-                sessionToken: ClientSharedData.shared.sessionToken
-            )
-        )
-
         // Override point for customization after application launch.
         return true
     }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -57,7 +57,7 @@ extension ForageSDK: ForageSDKService {
         reusable: Bool? = true,
         completion: @escaping (Result<PaymentMethodModel, Error>) -> Void
     ) {
-        _ = logger?
+        _ = ForageSDK.logger?
             .setPrefix("tokenizeEBTCard")
             .addContext(ForageLogContext(
                 customerID: customerID,
@@ -81,7 +81,7 @@ extension ForageSDK: ForageSDKService {
         paymentMethodReference: String,
         completion: @escaping (Result<BalanceModel, Error>) -> Void
     ) {
-        _ = logger?
+        _ = ForageSDK.logger?
             .setPrefix("checkBalance")
             .addContext(ForageLogContext(
                 merchantRef: merchantID,
@@ -116,14 +116,14 @@ extension ForageSDK: ForageSDKService {
                     pinCollector: pinCollector,
                     paymentMethodReference: paymentMethodReference
                 )
-                self.logger?.notice("Balance check succeeded for PaymentMethod \(paymentMethodReference)", attributes: nil)
+                ForageSDK.logger?.notice("Balance check succeeded for PaymentMethod \(paymentMethodReference)", attributes: nil)
 
                 responseMonitor.setEventOutcome(.success).end()
                 responseMonitor.logResult()
 
                 completion(.success(balanceResult))
             } catch {
-                self.logger?.error("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil)
+                ForageSDK.logger?.error("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil)
 
                 responseMonitor.setForageErrorCode(error).end()
                 responseMonitor.logResult()
@@ -138,7 +138,7 @@ extension ForageSDK: ForageSDKService {
         paymentReference: String,
         completion: @escaping (Result<PaymentModel, Error>) -> Void
     ) {
-        _ = logger?
+        _ = ForageSDK.logger?
             .setPrefix("capturePayment")
             .addContext(ForageLogContext(
                 merchantRef: merchantID,
@@ -173,14 +173,14 @@ extension ForageSDK: ForageSDKService {
                     pinCollector: pinCollector,
                     paymentReference: paymentReference
                 )
-                self.logger?.notice("Capture succeeded for Payment \(paymentReference)", attributes: nil)
+                ForageSDK.logger?.notice("Capture succeeded for Payment \(paymentReference)", attributes: nil)
 
                 responseMonitor.setEventOutcome(.success).end()
                 responseMonitor.logResult()
 
                 completion(.success(paymentResult))
             } catch {
-                self.logger?.error("Capture failed for Payment \(paymentReference)", error: error, attributes: nil)
+                ForageSDK.logger?.error("Capture failed for Payment \(paymentReference)", error: error, attributes: nil)
 
                 responseMonitor.setForageErrorCode(error).end()
                 responseMonitor.logResult()
@@ -201,7 +201,7 @@ extension ForageSDK: ForageSDKService {
     ///   - reason: A description of the illegal state or the unmet precondition.
     private func reportIllegalState(for methodName: String, dueTo reason: String) {
         let assertionMessage = "Attempted to call \(methodName), but \(reason)"
-        logger?.critical(assertionMessage, error: nil, attributes: nil)
+        ForageSDK.logger?.critical(assertionMessage, error: nil, attributes: nil)
         assertionFailure(assertionMessage)
     }
 
@@ -211,7 +211,7 @@ extension ForageSDK: ForageSDKService {
         if foragePinTextField.isComplete {
             return true
         }
-        logger?.warn(
+        ForageSDK.logger?.warn(
             "User attempted to submit an incomplete PIN",
             error: CommonErrors.INCOMPLETE_PIN_ERROR,
             attributes: nil

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -119,7 +119,7 @@ class DatadogLogger: ForageLogger {
                 remoteLogThreshold: .info,
                 // we want to always emit to Datadog
                 // but we don't want to spam the client's console with our logs.
-                consoleLogFormat: nil
+                consoleLogFormat: .short
             ),
             in: datadogInstance
         )

--- a/Tests/ForageSDKTests/ForageSDKTests.swift
+++ b/Tests/ForageSDKTests/ForageSDKTests.swift
@@ -11,18 +11,40 @@ import XCTest
 
 @testable import ForageSDK
 
+class MockForageSDK : ForageSDK {
+    static var initializedLogger: Bool = false
+    static var initializedLaunchDarkly: Bool = false
+
+    override static func initializeLogger(_ environment: Environment) {
+        MockForageSDK.initializedLogger = true
+    }
+    
+    override static func initializeLaunchDarkly(_ environment: Environment) {
+        MockForageSDK.initializedLaunchDarkly = true
+    }
+}
+
 final class ForageSDKTests: XCTestCase {
     func testInit_shouldInitializeLogger() {
-        ForageSDK.setup(ForageSDK.Config(
+        MockForageSDK.setup(ForageSDK.Config(
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
 
-        XCTAssertNotNil(ForageSDK.shared.logger)
+        XCTAssertTrue(MockForageSDK.initializedLogger)
+    }
+    
+    func testInit_shouldInitializeLaunchDarkly() {
+        MockForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "authToken123"
+        ))
+
+        XCTAssertTrue(MockForageSDK.initializedLaunchDarkly)
     }
 
-    func testInit_shouldInitLiveForageService() {
-        ForageSDK.setup(ForageSDK.Config(
+    func testInit_shouldInitForageService() {
+        MockForageSDK.setup(ForageSDK.Config(
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
@@ -31,7 +53,7 @@ final class ForageSDKTests: XCTestCase {
     }
 
     func testSetMerchantID_shouldUpdateSharedMerchantID() {
-        ForageSDK.setup(ForageSDK.Config(
+        MockForageSDK.setup(ForageSDK.Config(
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))
@@ -42,7 +64,7 @@ final class ForageSDKTests: XCTestCase {
     }
 
     func testSetSessionToken_shouldUpdateSharedSessionToken() {
-        ForageSDK.setup(ForageSDK.Config(
+        MockForageSDK.setup(ForageSDK.Config(
             merchantID: "merchantID123",
             sessionToken: "authToken123"
         ))


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Initialize `LDManager` and consequently the `LDClient` at the earliest point in the SDK lifecycle (inside `ForageSDK.setup`) – instead of inside `ForageSDK.init`

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

Race condition that I think might have have been the cause:

1. Client calls `ForageSDK.setup(merchantID: ...)` in their app
2. ⏩  Client calls `let tf = ForagePINTextField()` in their app
3. SDK called `getVaultType(...)` ([here](https://github.com/teamforage/forage-ios-sdk/blob/896cabe60801c2bc54afa8886ce5f56640e25c13/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift#L138))
4. LaunchDarkly was not initialized by ForageSDK on time

⚠️ because the client did not call `ForageSDK.shared.<something>` yet

https://linear.app/joinforage/issue/FX-658/fix-ldclientget-ios-initialization-issue

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- [x] Added unit tests to make sure LD is being initialized
- [x] Added block `_ = ForagePINTextField()` to increase likelihood of catching potential race conditions in the sample app
- [x] Made sure logging to the right environment still works

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is.