### PR TITLE
[FX-759] Call clearText on the main thread

### DIFF
--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -130,12 +130,14 @@ class CapturePaymentView: UIView {
 
         let inputFieldReference = isEbtSnap ? snapTextField : nonSnapTextField
 
-        ForageSDK.shared.capturePayment(
-            foragePinTextField: inputFieldReference,
-            paymentReference: paymentReference
-        ) { result in
-            inputFieldReference.clearText()
-            self.printResult(result: result)
+        DispatchQueue.global(qos: .userInitiated).async {
+            ForageSDK.shared.capturePayment(
+                foragePinTextField: inputFieldReference,
+                paymentReference: paymentReference
+            ) { result in
+                inputFieldReference.clearText()
+                self.printResult(result: result)
+            }
         }
     }
 

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -158,12 +158,14 @@ class RequestBalanceView: UIView {
     // MARK: Fileprivate Methods
 
     @objc fileprivate func getBalanceInfo(_ gesture: UIGestureRecognizer) {
-        ForageSDK.shared.checkBalance(
-            foragePinTextField: foragePinTextField,
-            paymentMethodReference: ClientSharedData.shared.paymentMethodReference
-        ) { result in
-            self.foragePinTextField.clearText()
-            self.printPINResult(result: result)
+        DispatchQueue.global(qos: .userInitiated).async {
+            ForageSDK.shared.checkBalance(
+                foragePinTextField: self.foragePinTextField,
+                paymentMethodReference: ClientSharedData.shared.paymentMethodReference
+            ) { result in
+                self.foragePinTextField.clearText()
+                self.printPINResult(result: result)
+            }
         }
     }
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -256,7 +256,9 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     // MARK: - Public API
 
     public func clearText() {
-        textField.clearText()
+        DispatchQueue.main.async {
+            self.textField.clearText()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- ensure `pin.clearText()` is called on main thread for all vault providers
- call `checkBalance` and `capturePayment` on concurrent background threads

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->


## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅  Unit Tests passed locally

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is