### PR TITLE
[FX-838] Prevent concurrency issues for QA test runs

### DIFF
--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-  
+
   schedule:
     - cron: '0 12 * * *' # Run every day at 7/8 AM Eastern
 
@@ -15,6 +15,10 @@ env:
 jobs:
   CI:
     runs-on: macos-13
+
+    env:
+      # Avoid concurrency issues
+      BROWSER_STACK_CUSTOMER_ID: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && format('pr-{0}', github.sha) || 'iOSApp' }}
 
     steps:
       - name: Checkout repository
@@ -33,6 +37,8 @@ jobs:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSER_STACK_CUSTOMER_ID: ${{ env.BROWSER_STACK_CUSTOMER_ID }}
+
         run: |
           cd Sample/
           bundle exec fastlane build_ci_app
@@ -44,9 +50,11 @@ jobs:
           ssh-key: ${{ secrets.MOBILE_QA_DEPLOY_KEY }}
           path: 'mobile-qa-tests/'
       - name: Run Integration Tests
+        env:
+          BROWSER_STACK_CUSTOMER_ID: ${{ env.BROWSER_STACK_CUSTOMER_ID }}
         run: |
           cd mobile-qa-tests
           pip3 install -r requirements.txt
+          export BROWSER_STACK_CUSTOMER_ID=${{ env.BROWSER_STACK_CUSTOMER_ID }}
           pytest ios/tests/test_basic_flow.py || true
           pytest --lf --last-failed-no-failures none --suppress-no-test-exit-code ios/tests/test_basic_flow.py
-  

--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -56,5 +56,6 @@ jobs:
           cd mobile-qa-tests
           pip3 install -r requirements.txt
           export BROWSERSTACK_CUSTOM_ID=${{ env.BROWSERSTACK_CUSTOM_ID }}
+          echo $BROWSERSTACK_CUSTOM_ID
           pytest ios/tests/test_basic_flow.py || true
           pytest --lf --last-failed-no-failures none --suppress-no-test-exit-code ios/tests/test_basic_flow.py

--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       # Avoid concurrency issues
-      BROWSER_STACK_CUSTOMER_ID: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && format('pr-{0}', github.sha) || 'iOSApp' }}
+      BROWSERSTACK_CUSTOM_ID: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && format('pr-{0}', github.sha) || 'iOSApp' }}
 
     steps:
       - name: Checkout repository
@@ -37,7 +37,7 @@ jobs:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          BROWSER_STACK_CUSTOMER_ID: ${{ env.BROWSER_STACK_CUSTOMER_ID }}
+          BROWSERSTACK_CUSTOM_ID: ${{ env.BROWSERSTACK_CUSTOM_ID }}
 
         run: |
           cd Sample/
@@ -51,10 +51,10 @@ jobs:
           path: 'mobile-qa-tests/'
       - name: Run Integration Tests
         env:
-          BROWSER_STACK_CUSTOMER_ID: ${{ env.BROWSER_STACK_CUSTOMER_ID }}
+          BROWSERSTACK_CUSTOM_ID: ${{ env.BROWSERSTACK_CUSTOM_ID }}
         run: |
           cd mobile-qa-tests
           pip3 install -r requirements.txt
-          export BROWSER_STACK_CUSTOMER_ID=${{ env.BROWSER_STACK_CUSTOMER_ID }}
+          export BROWSERSTACK_CUSTOM_ID=${{ env.BROWSERSTACK_CUSTOM_ID }}
           pytest ios/tests/test_basic_flow.py || true
           pytest --lf --last-failed-no-failures none --suppress-no-test-exit-code ios/tests/test_basic_flow.py

--- a/Sample/fastlane/Fastfile
+++ b/Sample/fastlane/Fastfile
@@ -54,7 +54,7 @@ platform :ios do
       browserstack_username: ENV["BROWSERSTACK_USERNAME"],
       browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY"],
       file_path: "CI_APP.ipa",
-      custom_id: "iOSApp",
+      custom_id: ENV['BROWSER_STACK_CUSTOMER_ID'] || 'iOSApp',
     )
   end
 end


### PR DESCRIPTION
Use custom ID when the job is running against a PR or manual run (workflow_dispatch)

<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Pass `custom_id` to fastlane and mobile-qa-tests

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

Prevent [CI check concurrency issues](https://joinforage.slack.com/archives/C066KCQ5QSW/p1702436741682179?thread_ts=1702419846.399839&cid=C066KCQ5QSW)
- Use `custom_id` when deploying the sample app and when running QA tests.

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- [x] See if the checks pass on this PR
- [ ] Check browser stack to ensure `custom_id` is being used
- [ ] See if the checks pass when merged into main

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

There will be a separate PR in the mobile-qa-tests that consumes the `customer_id` environment var