### PR TITLE
[FX-728] Add ForageSDK+ForageServices unit tests

### DIFF
--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -91,6 +91,7 @@ extension ForageSDK: ForageSDKService {
 
         guard let forageService = service else {
             reportIllegalState(for: "checkBalance", dueTo: "ForageService was not initialized")
+            completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
             return
         }
 
@@ -105,7 +106,8 @@ extension ForageSDK: ForageSDKService {
         // -----------------------------------------------------
         let responseMonitor = CustomerPerceivedResponseMonitor.newMeasurement(
             vaultType: pinCollector.getVaultType(),
-            vaultAction: VaultAction.balanceCheck
+            vaultAction: VaultAction.balanceCheck,
+            metricsLogger: ForageSDK.logger
         )
         responseMonitor.start()
         // ------------------------------------------------------
@@ -148,6 +150,7 @@ extension ForageSDK: ForageSDKService {
 
         guard let forageService = service else {
             reportIllegalState(for: "capturePayment", dueTo: "ForageService was not initialized")
+            completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
             return
         }
 
@@ -162,7 +165,8 @@ extension ForageSDK: ForageSDKService {
         // -----------------------------------------------------
         let responseMonitor = CustomerPerceivedResponseMonitor.newMeasurement(
             vaultType: pinCollector.getVaultType(),
-            vaultAction: VaultAction.capturePayment
+            vaultAction: VaultAction.capturePayment,
+            metricsLogger: ForageSDK.logger
         )
         responseMonitor.start()
         // ------------------------------------------------------
@@ -190,7 +194,7 @@ extension ForageSDK: ForageSDKService {
         }
     }
 
-    /// Reports an illegal state by logging a critical error and triggering an assertion failure.
+    /// Reports an illegal state by logging a critical error .
     ///
     /// This method is utilized to indicate that a precondition has not been met or an object is in an
     /// illegal state when invoking a particular method, aiding in identifying and rectifying improper
@@ -202,7 +206,6 @@ extension ForageSDK: ForageSDKService {
     private func reportIllegalState(for methodName: String, dueTo reason: String) {
         let assertionMessage = "Attempted to call \(methodName), but \(reason)"
         ForageSDK.logger?.critical(assertionMessage, error: nil, attributes: nil)
-        assertionFailure(assertionMessage)
     }
 
     /// Validates the completeness of the PIN entered in the specified text field.

--- a/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
@@ -25,15 +25,23 @@ final class CustomerPerceivedResponseMonitor: ResponseMonitor {
     private var eventOutcome: EventOutcome?
     private var eventName: EventName = .customerPerceivedResponse
 
-    init(vaultType: VaultType, vaultAction: VaultAction) {
+    init(vaultType: VaultType, vaultAction: VaultAction, metricsLogger: ForageLogger?) {
         self.vaultType = vaultType
         self.vaultAction = vaultAction
-        super.init()
+        super.init(metricsLogger: metricsLogger)
     }
 
     /// Factory method for creating new CustomerPerceivedResponseMonitor instances
-    static func newMeasurement(vaultType: VaultType, vaultAction: VaultAction) -> CustomerPerceivedResponseMonitor {
-        CustomerPerceivedResponseMonitor(vaultType: vaultType, vaultAction: vaultAction)
+    static func newMeasurement(
+        vaultType: VaultType,
+        vaultAction: VaultAction,
+        metricsLogger: ForageLogger? = nil
+    ) -> CustomerPerceivedResponseMonitor {
+        CustomerPerceivedResponseMonitor(
+            vaultType: vaultType,
+            vaultAction: vaultAction,
+            metricsLogger: metricsLogger
+        )
     }
 
     // override to set event_outcome to "failure" if we know the event has a forage_error_code

--- a/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
@@ -51,7 +51,7 @@ class ResponseMonitor: NetworkMonitor {
             ForageLoggerConfig(prefix: "Metrics")
         )
     ) {
-        self.metricsLogger = metricsLogger?.setLogKind(ForageLogKind.metric)
+        self.metricsLogger = metricsLogger?.setLogKind(ForageLogKind.metric).setPrefix("Metrics")
     }
 
     func start() {

--- a/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
+++ b/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
@@ -1,0 +1,384 @@
+//
+//  ForagePublicSubmitMethodTests.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-12-14.
+//
+
+import XCTest
+
+@testable import ForageSDK
+
+class MockForageService : LiveForageService {
+    internal var doesCheckBalanceThrow: Bool = false
+    internal var doesCapturePaymentThrow: Bool = false
+    internal var doesTokenizeEBTCardThrow: Bool = false
+    
+    override func checkBalance(pinCollector: VaultCollector, paymentMethodReference: String) async throws -> BalanceModel {
+        if (doesCheckBalanceThrow) {
+            throw ForageError.create(
+                httpStatusCode: 400,
+                code: "ebt_error_55",
+                message: "Invalid PIN or PIN not selected - Invalid PIN"
+            )
+        }
+        
+        return BalanceModel(snap: "100.0", cash: "1.0", updated: "2023-4-20T12:36:57.482668-08:00")
+    }
+    
+    override func tokenizeEBTCard(request: ForagePANRequestModel, completion: @escaping (Result<PaymentMethodModel, Error>) -> Void) {
+        if (doesTokenizeEBTCardThrow) {
+            let error = ForageError.create(
+                httpStatusCode: 400,
+                code: "card_not_reusable",
+                message: "Payment method acdef123 is not reusable"
+            )
+            
+            completion(.failure(error))
+            return
+        }
+        
+        let paymentMethodModel = try! JSONDecoder().decode(
+            PaymentMethodModel.self,
+            from: ForageMocks().tokenizeSuccess
+        )
+        
+        completion(.success(paymentMethodModel))
+    }
+    
+    override func capturePayment(pinCollector: VaultCollector, paymentReference: String) async throws -> PaymentModel {
+        if (doesCapturePaymentThrow) {
+            throw ForageError.create(
+                httpStatusCode: 400,
+                code: "ebt_error_43",
+                message: "Lost/stolen card - Cannot Process - Call Customer Service"
+            )
+        }
+        
+        let paymentModel = try! JSONDecoder().decode(
+            PaymentModel.self,
+            from: ForageMocks().capturePaymentSuccess
+        )
+        return paymentModel
+        
+    }
+}
+
+class MockForagePINTextField: ForagePINTextField {
+    internal var mockIsComplete: Bool = true
+    
+    @IBInspectable public override var isComplete: Bool {
+        return mockIsComplete
+    }
+}
+
+let EXPECTED_INCOMPLETE_PIN_MESSAGE = "Invalid EBT Card PIN entered. Please enter your 4-digit PIN."
+let EXPECTED_UNKNOWN_SERVER_ERROR = "Unknown error. This is a problem on Forage’s end."
+
+final class ForagePublicSubmitMethodTests: XCTestCase {
+    
+    var mockService: MockForageService!
+    var mockLogger: MockLogger!
+    
+    override func setUpWithError() throws {
+        super.setUp()
+        mockService = createMockService()
+        mockLogger = MockLogger()
+        setupMockSDK()
+    }
+    
+    override func tearDownWithError() throws {
+        mockService = nil
+        mockLogger = nil
+        super.tearDown()
+    }
+    
+    func createMockService() -> MockForageService {
+        MockForageService(
+            provider: Provider(URLSessionMock()),
+            ldManager: MockLDManager(),
+            pollingService: MockPollingService(ldManager: MockLDManager())
+        )
+    }
+    
+    func setupMockSDK() {
+        MockForageSDK.setup(ForageSDK.Config(
+            merchantID: "merchantID123",
+            sessionToken: "dev_authToken123"
+        ))
+        MockForageSDK.logger = mockLogger
+        MockForageSDK.shared.service = mockService
+    }
+    
+    func createMockPinTextField(isComplete: Bool = true) -> MockForagePINTextField {
+        let mockPinTextField = MockForagePINTextField(frame: .zero)
+        mockPinTextField.mockIsComplete = isComplete
+        return mockPinTextField
+    }
+    
+    func executeBalanceCheck(
+        doesThrow: Bool = false,
+        pinComplete: Bool = true,
+        description: String,
+        validation: @escaping (Result<BalanceModel, Error>
+        ) -> Void) {
+        mockService.doesCheckBalanceThrow = doesThrow
+        let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
+        let expectation = XCTestExpectation(description: description)
+        
+        MockForageSDK.shared.checkBalance(
+            foragePinTextField: mockPinTextField,
+            paymentMethodReference: "abcdef123"
+        ) { result in
+            validation(result)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func executeCapturePayment(
+        doesThrow: Bool = false,
+        pinComplete: Bool = true,
+        description: String,
+        validation: @escaping (Result<PaymentModel, Error>
+        ) -> Void) {
+        mockService.doesCapturePaymentThrow = doesThrow
+        let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
+        let expectation = XCTestExpectation(description: description)
+        
+        MockForageSDK.shared.capturePayment(
+            foragePinTextField: mockPinTextField,
+            paymentReference: "11767381fd"
+        ) { result in
+            validation(result)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testTokenizeEBTCard_Success() {
+        let expectation = XCTestExpectation(description: "Returns PaymentMethod response")
+        let mockPanTextField = ForagePANTextField(frame: .zero)
+        
+        MockForageSDK.shared.tokenizeEBTCard(
+            foragePanTextField: mockPanTextField,
+            customerID: "test-ios-customer-id"
+        ) { result in
+            switch result {
+            case .success(let paymentMethod):
+                XCTAssertEqual(paymentMethod.paymentMethodIdentifier, "d0c47b0ed5")
+                XCTAssertEqual(paymentMethod.type, "ebt")
+                XCTAssertNil(paymentMethod.balance)
+                XCTAssertEqual(paymentMethod.card.last4, "3412")
+                XCTAssertEqual(paymentMethod.customerID, "test-ios-customer-id")
+                XCTAssertEqual(paymentMethod.reusable, true)
+
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Expected success but got \(String(describing: result))")
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testTokenizeEBTCard_Throws_DoesRejectWithError() {
+        let expectation = XCTestExpectation(description: "tokenizeEBTCard rejects with ForageError")
+        let mockPanTextField = ForagePANTextField(frame: .zero)
+        
+        (MockForageSDK.shared.service as! MockForageService).doesTokenizeEBTCardThrow = true
+        
+        MockForageSDK.shared.tokenizeEBTCard(
+            foragePanTextField: mockPanTextField,
+            customerID: "test-ios-customer-id"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected ForageError but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                
+                XCTAssertEqual(firstForageError.code, "card_not_reusable")
+                XCTAssertEqual(firstForageError.message, "Payment method acdef123 is not reusable")
+                XCTAssertEqual(firstForageError.httpStatusCode, 400)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testCheckBalanceSuccess_ReportsMetricAndResolvesWithBalance() {
+        executeBalanceCheck(description: "Balance check succeeds") { result in
+            switch result {
+            case .success(let balance):
+                XCTAssertEqual(balance.snap, "100.0")
+                XCTAssertEqual(balance.cash, "1.0")
+                XCTAssertEqual(balance.updated, "2023-4-20T12:36:57.482668-08:00")
+                
+                // Are metrics-related events being reported correctly?
+                XCTAssertEqual(self.mockLogger.lastInfoMsg, "Reported customer-perceived response event")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["response_time_ms"] is Double)
+                XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
+                XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "balance")
+            case .failure:
+                XCTFail("Expected success but got \(String(describing: result))")
+            }
+        }
+    }
+    
+    func testCheckBalance_IncompletePIN_LogsAndReturnsUserError() {
+        executeBalanceCheck(
+            pinComplete: false,
+            description: "checkBalance rejects with user_error"
+        ){ result in
+            switch result {
+            case .success:
+                XCTFail("Expected user_error but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                
+                XCTAssertEqual(firstForageError.code, "user_error")
+                XCTAssertEqual(firstForageError.message, EXPECTED_INCOMPLETE_PIN_MESSAGE)
+                XCTAssertEqual(firstForageError.httpStatusCode, 400)
+                
+            }
+        }
+    }
+    
+    func testCheckBalance_IllegalStateException_LogsAndRejectsWithError() {
+        MockForageSDK.shared.service = nil
+        
+        executeBalanceCheck(
+            pinComplete: false,
+            description: "checkBalance rejects with generic unknown_server_error"
+        ){ result in
+            switch result {
+            case .success:
+                XCTFail("Expected unknown_server_error but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                
+                XCTAssertEqual(firstForageError.code, "unknown_server_error")
+                XCTAssertEqual(firstForageError.message, EXPECTED_UNKNOWN_SERVER_ERROR)
+                XCTAssertEqual(firstForageError.httpStatusCode, 500)
+                
+                XCTAssertEqual(self.mockLogger.lastCriticalMessage, "Attempted to call checkBalance, but ForageService was not initialized")
+            }
+        }
+    }
+    
+    func testCheckBalance_ThrowsCardError_ReportsAndRejectsWithError() {
+        executeBalanceCheck(
+            doesThrow: true,
+            description: "checkBalance rejects with card error"
+        ){ result in
+            switch result {
+            case .success:
+                XCTFail("Expected ebt_error_55 but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                
+                // Assert ForageError response
+                XCTAssertEqual(firstForageError.code, "ebt_error_55")
+                XCTAssertEqual(firstForageError.message, "Invalid PIN or PIN not selected - Invalid PIN")
+                XCTAssertEqual(firstForageError.httpStatusCode, 400)
+                
+                XCTAssertEqual(self.mockLogger.lastErrorMsg, "Balance check failed for PaymentMethod abcdef123")
+                
+                
+                // Are metrics-related events being reported correctly?
+                XCTAssertEqual(self.mockLogger.lastInfoMsg, "Reported customer-perceived response event")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["response_time_ms"] is Double)
+                XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
+                XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "balance")
+                
+            }
+        }
+    }
+    
+    func testCapturePayment_Success_ReportsMetricAndResolvesWithPayment() {
+        executeCapturePayment(description: "Capture payment succeeds") { result in
+            if case .success(let payment) = result {
+                XCTAssertEqual(payment.paymentRef, "11767381fd")
+                XCTAssertEqual(payment.amount, "10.00")
+                
+                // Are metrics-related events being reported correctly?
+                XCTAssertEqual(self.mockLogger.lastInfoMsg, "Reported customer-perceived response event")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["response_time_ms"] is Double)
+                XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
+                XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "capture")
+            } else {
+                XCTFail("Expected success but got \(String(describing: result))")
+            }
+        }
+    }
+    
+    func testCapturePayment_IncompletePIN_LogsAndReturnsUserError() {
+        executeCapturePayment(
+            pinComplete: false,
+            description: "Capture payment rejects with user_error"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected user_error but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                XCTAssertEqual(firstForageError.code, "user_error")
+                XCTAssertEqual(firstForageError.message, EXPECTED_INCOMPLETE_PIN_MESSAGE)
+                XCTAssertEqual(firstForageError.httpStatusCode, 400)
+            }
+        }
+    }
+    
+    func testCapturePayment_ThrowsCardError_RejectsWithError() {
+        executeCapturePayment(
+            doesThrow: true,
+            description: "Capture payment rejects with ebt_error_43"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected ebt_error_43 but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                XCTAssertEqual(firstForageError.code, "ebt_error_43")
+                XCTAssertEqual(firstForageError.message, "Lost/stolen card - Cannot Process - Call Customer Service")
+                XCTAssertEqual(firstForageError.httpStatusCode, 400)
+                
+                // Are metrics-related events being reported correctly?
+                XCTAssertEqual(self.mockLogger.lastInfoMsg, "Reported customer-perceived response event")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["response_time_ms"] is Double)
+                XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
+                XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "capture")
+            }
+        }
+    }
+    
+    func testCapturePayment_IllegalStateException_LogsAndRejectsWithError() {
+        MockForageSDK.shared.service = nil
+        
+        executeCapturePayment(
+            pinComplete: false,
+            description: "capturePayment rejects with generic unknown_server_error"
+        ){ result in
+            switch result {
+            case .success:
+                XCTFail("Expected unknown_server_error but got \(String(describing: result))")
+            case .failure(let error):
+                let firstForageError = (error as! ForageError).errors.first!
+                
+                XCTAssertEqual(firstForageError.code, "unknown_server_error")
+                XCTAssertEqual(firstForageError.message, EXPECTED_UNKNOWN_SERVER_ERROR)
+                XCTAssertEqual(firstForageError.httpStatusCode, 500)
+                
+                XCTAssertEqual(self.mockLogger.lastCriticalMessage, "Attempted to call capturePayment, but ForageService was not initialized")
+            }
+        }
+    }
+}

--- a/Tests/ForageSDKTests/ForageSDKTests.swift
+++ b/Tests/ForageSDKTests/ForageSDKTests.swift
@@ -11,19 +11,6 @@ import XCTest
 
 @testable import ForageSDK
 
-class MockForageSDK: ForageSDK {
-    static var initializedLogger: Bool = false
-    static var initializedLaunchDarkly: Bool = false
-
-    override static func initializeLogger(_ environment: Environment) {
-        MockForageSDK.initializedLogger = true
-    }
-
-    override static func initializeLaunchDarkly(_ environment: Environment) {
-        MockForageSDK.initializedLaunchDarkly = true
-    }
-}
-
 final class ForageSDKTests: XCTestCase {
     var mockLogger: MockLogger!
 

--- a/Tests/ForageSDKTests/Mock/MockForageSDK.swift
+++ b/Tests/ForageSDKTests/Mock/MockForageSDK.swift
@@ -1,0 +1,21 @@
+//
+//  MockForageSDK.swift
+//
+//
+//  Created by Danilo Joksimovic on 2023-12-14.
+//
+
+@testable import ForageSDK
+
+class MockForageSDK: ForageSDK {
+    static var initializedLogger: Bool = false
+    static var initializedLaunchDarkly: Bool = false
+
+    override static func initializeLogger(_ environment: Environment) {
+        MockForageSDK.initializedLogger = true
+    }
+
+    override static func initializeLaunchDarkly(_ environment: Environment) {
+        MockForageSDK.initializedLaunchDarkly = true
+    }
+}

--- a/Tests/ForageSDKTests/Mock/MockLogger.swift
+++ b/Tests/ForageSDKTests/Mock/MockLogger.swift
@@ -10,7 +10,9 @@ import Foundation
 class MockLogger: NoopLogger {
     var lastInfoMsg: String = ""
     var lastErrorMsg: String = ""
+    var lastCriticalMessage: String = ""
     var lastNoticeMsg: String = ""
+    var lastAttributes: [String: Encodable]? = nil
 
     required init(_ config: ForageLoggerConfig? = nil) {
         super.init(config)
@@ -18,13 +20,21 @@ class MockLogger: NoopLogger {
 
     override func info(_ message: String, attributes: [String: Encodable]?) {
         lastInfoMsg = message
+        lastAttributes = attributes
     }
 
     override func error(_ message: String, error: Error?, attributes: [String: Encodable]?) {
         lastErrorMsg = message
+        lastAttributes = attributes
+    }
+    
+    override func critical(_ message: String, error: Error?, attributes: [String: Encodable]?) {
+        lastCriticalMessage = message
+        lastAttributes = attributes
     }
 
     override func notice(_ message: String, attributes: [String: Encodable]?) {
         lastNoticeMsg = message
+        lastAttributes = attributes
     }
 }

--- a/Tests/ForageSDKTests/PollingServiceTests.swift
+++ b/Tests/ForageSDKTests/PollingServiceTests.swift
@@ -486,7 +486,7 @@ final class PollingServiceTests: XCTestCase {
         // Mark the expectation as fulfilled only if it failed
         failureExpectation.isInverted = true
 
-        let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: [100]))
+        let pollingService = MockPollingService(provider: Provider(mockSession), ldManager: MockLDManager(pollingIntervals: [500]))
 
         pollingService.waitNextAttempt {
             successExpectation.fulfill()
@@ -494,8 +494,8 @@ final class PollingServiceTests: XCTestCase {
         }
 
         // Ensure that the failureExpectation wasn't fulfilled in the extremely short period of time
-        wait(for: [failureExpectation], timeout: 0.09)
+        wait(for: [failureExpectation], timeout: 0.49)
         // Ensure that the successExpectation was fulfilled before the longer period of time
-        wait(for: [successExpectation], timeout: 0.11)
+        wait(for: [successExpectation], timeout: 0.51)
     }
 }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Pass "origin" logger to metrics/monitor service
- Reject with error instead of assertionFailure
- Adds unit tests for "Public submit methods" (tokenizeEBTCard, checkBalance, capturePayment)

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-728/add-ios-unit-tests-for-foragesdkforagesdkservice-extension

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Added unit tests
- [x] Verify metrics are being emitted as desired

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is, will be used to facilitate testing for #131 
