### PR TITLE
[FX-933] Add support for single ForageError

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ ForageSDK.shared.tokenizeEBTCard(
     reusable: true
 ) { result in
     // Handle result and error here
+    switch result {
+    case .success(let paymentMethod):
+        // Handle the PaymentMethod here (balance, card, reusable, etc.)
+    case .failure(let error):
+        if let forageError = error as? ForageError {
+            // handle forageError.code, forageError.httpStatusCode and forageError.message
+        }
+    }
 }
 ```
 

--- a/Sample/SampleForageSDK/Foundation/Base/BaseSampleView.swift
+++ b/Sample/SampleForageSDK/Foundation/Base/BaseSampleView.swift
@@ -5,6 +5,7 @@
 //  Created by Danilo Joksimovic on 2023-12-13.
 //
 
+import ForageSDK
 import Foundation
 import UIKit
 
@@ -137,6 +138,14 @@ class BaseSampleView: UIView {
                 centerXAnchor: contentView.centerXAnchor,
                 padding: UIEdgeInsets(top: index == 0 ? 0 : 24, left: 24, bottom: 0, right: 24)
             )
+        }
+    }
+
+    func logForageError(_ error: Error) {
+        if let forageError = error as? ForageError {
+            print("Forage Error! code = \(forageError.code), httpStatusCode = \(forageError.httpStatusCode), message = \(forageError.message)")
+        } else {
+            print("Unexpected Error Type: Expected ForageError, received \(type(of: error)). Error details: \(error.localizedDescription)")
         }
     }
 }

--- a/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
+++ b/Sample/SampleForageSDK/Sections/CapturePayment/CapturePaymentView.swift
@@ -185,6 +185,7 @@ class CapturePaymentView: BaseSampleView {
 
     private func printError(_ error: Error) {
         DispatchQueue.main.async { [self] in
+            logForageError(error)
             errorLabel.text = "\(error)"
             paymentRefLabel.text = ""
             fundingTypeLabel.text = ""
@@ -204,10 +205,8 @@ class CapturePaymentView: BaseSampleView {
                 deferPaymentCaptureResponseLabel.text = ""
             case let .failure(error):
                 if let forageError = error as? ForageError? {
-                    let firstError = forageError?.errors.first
-
-                    if firstError?.code == "ebt_error_51" {
-                        switch firstError?.details {
+                    if forageError?.code == "ebt_error_51" && forageError?.httpStatusCode == 400 {
+                        switch forageError?.details {
                         case let .ebtError51(snapBalance, cashBalance):
                             let snapBalanceText = snapBalance ?? "N/A"
                             let cashBalanceText = cashBalance ?? "N/A"

--- a/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
+++ b/Sample/SampleForageSDK/Sections/CardNumber/CardNumberView.swift
@@ -137,6 +137,7 @@ class CardNumberView: BaseSampleView {
                 ClientSharedData.shared.paymentMethodReference = response.paymentMethodIdentifier
                 self.updateButtonState(isEnabled: true, button: self.nextButton)
             case let .failure(error):
+                self.logForageError(error)
                 self.errorLabel.text = "error: \n\(error)"
                 self.refLabel.text = ""
                 self.typeLabel.text = ""

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -182,6 +182,7 @@ class RequestBalanceView: BaseSampleView {
                 self.ebtCashBalanceLabel.text = "cash=\(response.cash)"
                 self.errorLabel.text = ""
             case let .failure(error):
+                self.logForageError(error)
                 self.errorLabel.text = "\(error)"
                 self.snapBalanceLabel.text = ""
                 self.ebtCashBalanceLabel.text = ""

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -26,14 +26,15 @@ struct ForageErrorSource: Codable {
 
 /// Represents an error that occurs when a request to submit a `ForageElement` to the Forage API fails.
 public struct ForageError: Error, Codable {
-    /// A short string explaining why the request failed.
+    /// A short string that helps identify the cause of the error.
     /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
+    /// Example: 'ebt_error_55' signifies that a user entered an invalid EBT Card PIN
     public let code: String
 
     /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int
 
-    /// A developer-facing message about the error.
+    /// A developer-facing description of the error.
     public let message: String
 
     /// Additional details about the error, included for your convenience.

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -26,23 +26,43 @@ struct ForageErrorSource: Codable {
 
 /// Represents an error that occurs when a request to submit a `ForageElement` to the Forage API fails.
 public struct ForageError: Error, Codable {
+    /// A short string explaining why the request failed. The error code string corresponds to the HTTP status code.
+    /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
+    public let code: String
+
+    /// The HTTP status that the Forage API returns in response to the request.
+    public let httpStatusCode: Int
+
+    /// A developer-facing message about the error, not to be displayed to customers.
+    public let message: String
+
+    /// Additional details about the error, included for your convenience.
+    /// Not nil when details are available, e.g. when the error code is [ebt_error_51](https://docs.joinforage.app/reference/errors#ebt_error_51)
+    public let details: ForageErrorDetails?
+
     /// An array of error objects returned from the Forage API.
+    @available(*, deprecated, message: "Access forageError.code directly instead of unpacking the .errors list")
     public let errors: [ForageErrorObj]
 
     /// Creates a `ForageError` instance with a single `ForageErrorObj` object
     static func create(
-        httpStatusCode: Int,
         code: String,
-        message: String
+        httpStatusCode: Int,
+        message: String,
+        details: ForageErrorDetails? = nil
     ) -> ForageError {
-        ForageError(
-            errors: [
-                ForageErrorObj(
-                    httpStatusCode: httpStatusCode,
-                    code: code,
-                    message: message
-                ),
-            ]
+        let firstErrorObj = ForageErrorObj(
+            httpStatusCode: httpStatusCode,
+            code: code,
+            message: message,
+            details: details
+        )
+        return ForageError(
+            code: firstErrorObj.code,
+            httpStatusCode: firstErrorObj.httpStatusCode,
+            message: firstErrorObj.message,
+            details: firstErrorObj.details,
+            errors: [firstErrorObj]
         )
     }
 }
@@ -81,6 +101,7 @@ public struct EbtError51Details: Codable {
 /// Represents a detailed error object returned by the Forage API.
 /// Provides additional context about the HTTP status, error code, and developer-facing message.
 /// [Learn more about SDK errors](https://docs.joinforage.app/reference/errors#sdk-errors)
+@available(*, deprecated, renamed: "ForageError")
 public struct ForageErrorObj: Codable {
     /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -26,14 +26,14 @@ struct ForageErrorSource: Codable {
 
 /// Represents an error that occurs when a request to submit a `ForageElement` to the Forage API fails.
 public struct ForageError: Error, Codable {
-    /// A short string explaining why the request failed. The error code string corresponds to the HTTP status code.
+    /// A short string explaining why the request failed.
     /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
     public let code: String
 
     /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int
 
-    /// A developer-facing message about the error, not to be displayed to customers.
+    /// A developer-facing message about the error.
     public let message: String
 
     /// Additional details about the error, included for your convenience.
@@ -106,11 +106,12 @@ public struct ForageErrorObj: Codable {
     /// The HTTP status that the Forage API returns in response to the request.
     public let httpStatusCode: Int
 
-    /// A short string explaining why the request failed. The error code string corresponds to the HTTP status code.
+    /// A short string that helps identify the cause of the error.
     /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
+    /// Example: 'ebt_error_55' signifies that a user entered an invalid EBT Card PIN
     public let code: String
 
-    /// A developer-facing message about the error, not to be displayed to customers.
+    /// A developer-facing description of the error.
     public let message: String
 
     /// Additional details about the error, included for your convenience.

--- a/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/ForageErrorModel.swift
@@ -28,6 +28,7 @@ struct ForageErrorSource: Codable {
 public struct ForageError: Error, Codable {
     /// A short string that helps identify the cause of the error.
     /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
+    ///
     /// Example: 'ebt_error_55' signifies that a user entered an invalid EBT Card PIN
     public let code: String
 
@@ -109,6 +110,7 @@ public struct ForageErrorObj: Codable {
 
     /// A short string that helps identify the cause of the error.
     /// [Learn more about SDK error codes](https://docs.joinforage.app/reference/errors#code-and-message-pairs-1)
+    ///
     /// Example: 'ebt_error_55' signifies that a user entered an invalid EBT Card PIN
     public let code: String
 

--- a/Sources/ForageSDK/Foundation/Network/PollingService.swift
+++ b/Sources/ForageSDK/Foundation/Network/PollingService.swift
@@ -90,19 +90,14 @@ class PollingService: Polling {
                     if self.didReceiveCompletedMessage(message) {
                         completion(.success(message))
                     } else if didReceiveFailedMessage {
-                        let error = message.errors[0]
-                        let statusCode = error.statusCode
-                        let forageErrorCode = error.forageCode
-                        let message = error.message
-                        let details = error.details
-                        let forageError = ForageError(errors: [
-                            ForageErrorObj(
-                                httpStatusCode: statusCode,
-                                code: forageErrorCode,
-                                message: message,
-                                details: details
-                            ),
-                        ])
+                        let sqsError = message.errors[0]
+
+                        let forageError = ForageError.create(
+                            code: sqsError.forageCode,
+                            httpStatusCode: sqsError.statusCode,
+                            message: sqsError.message,
+                            details: sqsError.details
+                        )
 
                         self.logger?.error(
                             "Received SQS Error message for \(self.getLogSuffix(request))",

--- a/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Constants.swift
@@ -9,13 +9,13 @@ import Foundation
 
 enum CommonErrors {
     static let INCOMPLETE_PIN_ERROR = ForageError.create(
-        httpStatusCode: 400,
         code: "user_error",
+        httpStatusCode: 400,
         message: "Invalid EBT Card PIN entered. Please enter your 4-digit PIN."
     )
     static let UNKNOWN_SERVER_ERROR = ForageError.create(
-        httpStatusCode: 500,
         code: "unknown_server_error",
+        httpStatusCode: 500,
         message: "Unknown error. This is a problem on Forage’s end."
     )
 }

--- a/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ResponseMonitor.swift
@@ -77,7 +77,7 @@ class ResponseMonitor: NetworkMonitor {
 
     @discardableResult
     func setForageErrorCode(_ error: Error) -> ResponseMonitor {
-        responseAttributes.forageErrorCode = (error as? ForageError)?.errors.first?.code ?? UnknownErrorCode
+        responseAttributes.forageErrorCode = (error as? ForageError)?.code ?? UnknownErrorCode
         return self
     }
 


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

ℹ️ The new `ForageError` format also orders the parameters in order of usage popularity:

1. code
2. httpStatusCode
3. message
4. details

- [x] Add support for `ForageError`
- [x] Mark `forageError.errors` as deprecated
- [x] Update tests to cover both paths
- [x] Add more `ForageError` coverage in the sample app and log `ForageError` 
- [x] Updated README to document Forage error handling

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

https://linear.app/joinforage/issue/FX-933/ios-support-single-error-for-client-facing-errors

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Updated unit tests
- ✅ Updated sample app
- ✅ Did some manual verification across edge cases like forage errors with `details` (ebt_error_51)

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Have to bump `MINOR` version level of the associated release.