### PR TITLE
[FX-964] Use paymentRef for idempotency-key on capturePayment and deferPaymentCapture

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -79,6 +79,7 @@ class LiveForageService: ForageService {
             let vaultResult = try await submitPinToVault(
                 pinCollector: pinCollector,
                 vaultAction: .balanceCheck,
+                idempotencyKey: UUID().uuidString,
                 path: "/api/payment_methods/\(paymentMethodReference)/balance/",
                 request: balanceRequest
             )
@@ -231,6 +232,7 @@ class LiveForageService: ForageService {
             let vaultResponse = try await submitPinToVault(
                 pinCollector: pinCollector,
                 vaultAction: action,
+                idempotencyKey: paymentReference,
                 path: "\(basePath)\(action.endpointSuffix)",
                 request: collectPinRequest
             )
@@ -246,16 +248,18 @@ class LiveForageService: ForageService {
     /// - Parameters:
     ///   - pinCollector: The PIN collection client
     ///   - vaultAction: The action performed against the vault.
+    ///   - idempotencyKey: The value for the IDEMPOTENCY-KEY header
     ///   - path: The inbound HTTP path. Ends with /balance/, /capture/ or /collect_pin/
     ///   - request: Model  with data to perform request.
     private func submitPinToVault(
         pinCollector: VaultCollector,
         vaultAction: VaultAction,
+        idempotencyKey: String,
         path: String,
         request: ForageRequestModel
     ) async throws -> VaultResponse {
         pinCollector.setCustomHeaders(headers: [
-            "IDEMPOTENCY-KEY": UUID().uuidString,
+            "IDEMPOTENCY-KEY": idempotencyKey,
             "Merchant-Account": request.merchantID,
             "x-datadog-trace-id": ForageSDK.shared.traceId,
         ], xKey: request.xKey)

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -139,6 +139,7 @@ class LiveForageService: ForageService {
             let (vaultResponse, forageRequest) = try await collectPinForPayment(
                 pinCollector: pinCollector,
                 paymentReference: paymentReference,
+                idempotencyKey: paymentReference,
                 action: .capturePayment
             )
 
@@ -177,6 +178,7 @@ class LiveForageService: ForageService {
             let collectPinResult = try await collectPinForPayment(
                 pinCollector: pinCollector,
                 paymentReference: paymentReference,
+                idempotencyKey: UUID().uuidString,
                 action: .deferCapture
             )
             return collectPinResult.vaultResponse
@@ -191,6 +193,7 @@ class LiveForageService: ForageService {
     private func collectPinForPayment(
         pinCollector: VaultCollector,
         paymentReference: String,
+        idempotencyKey: String,
         action: VaultAction
     ) async throws -> (vaultResponse: VaultResponse, forageRequest: ForageRequestModel) {
         let sessionToken = ForageSDK.shared.sessionToken
@@ -232,7 +235,7 @@ class LiveForageService: ForageService {
             let vaultResponse = try await submitPinToVault(
                 pinCollector: pinCollector,
                 vaultAction: action,
-                idempotencyKey: paymentReference,
+                idempotencyKey: idempotencyKey,
                 path: "\(basePath)\(action.endpointSuffix)",
                 request: collectPinRequest
             )


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- Will add unit + e2e tests to cover this

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

release ASAP, to deprecate v4.4.0 release and bump to 4.4.1

