### PR TITLE
Pin the VGS Collect package to avoid build failures in CI

### DIFF
--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.readme       = "https://raw.githubusercontent.com/teamforage/forage-ios-sdk/main/README.md"
   spec.source       = { :git => "https://github.com/teamforage/forage-ios-sdk.git", :tag => "4.4.1" }
   spec.source_files = ["Sources/ForageSDK/**/*.swift", "DatadogPrivate-Objc/**/*.{h,m}"]
-  spec.dependency 'VGSCollectSDK', '~> 1.11.2'
+  spec.dependency 'VGSCollectSDK', '1.15.3'
   spec.dependency 'LaunchDarkly', '~> 8.0.1'
   spec.dependency 'BasisTheoryElements', '~> 4.0.2'
   spec.resource_bundles = {

--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |spec|
   spec.readme       = "https://raw.githubusercontent.com/teamforage/forage-ios-sdk/main/README.md"
   spec.source       = { :git => "https://github.com/teamforage/forage-ios-sdk.git", :tag => "4.4.1" }
   spec.source_files = ["Sources/ForageSDK/**/*.swift", "DatadogPrivate-Objc/**/*.{h,m}"]
-  spec.dependency 'VGSCollectSDK', '1.15.3'
-  spec.dependency 'LaunchDarkly', '~> 8.0.1'
-  spec.dependency 'BasisTheoryElements', '~> 4.0.2'
+  spec.dependency 'VGSCollectSDK', '1.15.2'
+  spec.dependency 'LaunchDarkly', '8.0.1'
+  spec.dependency 'BasisTheoryElements', '4.1.0'
   spec.resource_bundles = {
     'ForageIcon' => ['Sources/Resources/*']
   }

--- a/Package.swift
+++ b/Package.swift
@@ -21,17 +21,17 @@ let package = Package(
         .package(
             name: "VGSCollectSDK",
             url: "https://github.com/verygoodsecurity/vgs-collect-ios.git",
-            from: "1.11.0"
+            .exact("1.15.3")
         ),
         .package(
             name: "LaunchDarkly",
             url: "https://github.com/launchdarkly/ios-client-sdk.git",
-            from: "8.0.1"
+            .exact("8.0.1")
         ),
         .package(
             name: "BasisTheoryElements",
             url: "https://github.com/Basis-Theory/basistheory-ios",
-            from: "4.0.2"
+            .exact("4.1.0")
         )
     ],
     targets: [


### PR DESCRIPTION
## What
Because of the optimistic operator we are seeing build failures on our automated CI tests run on main. VGS released version 1.16.0 yesterday which seems to be causing the issue. Our tests passed on the version before, which is 1.15.3.
