### PR TITLE
[FX-1183] Pin all endpoints that don't require a version to default

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
+++ b/Sources/ForageSDK/Foundation/Network/ForageAPI.swift
@@ -46,6 +46,7 @@ extension ForageAPI: ServiceProtocol {
             "content-type": "application/json",
             "accept": "application/json",
             "x-datadog-trace-id": ForageSDK.shared.traceId,
+            "API-VERSION": "default"
         ])
         switch self {
         case let .tokenizeNumber(

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -265,6 +265,7 @@ class LiveForageService: ForageService {
             "IDEMPOTENCY-KEY": idempotencyKey,
             "Merchant-Account": request.merchantID,
             "x-datadog-trace-id": ForageSDK.shared.traceId,
+            "API-VERSION": "default"
         ], xKey: request.xKey)
 
         let extraData = [


### PR DESCRIPTION
## What
Add a default version header to all endpoints in the SDK to avoid backwards compatibility behavior that can be introduced by setting an API version header in the dashboard.

## Test Plan
Let QA tests run.
