### PR TITLE
[FX-1274] Mark pinTextField.placeholder as deprecated

### DIFF
--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -40,7 +40,6 @@ class RequestBalanceView: BaseSampleView {
 
     public let foragePinTextField: ForagePINTextField = {
         let tf = ForagePINTextField()
-        tf.placeholder = "PIN Field"
         tf.accessibilityIdentifier = "tf_pin_balance"
         tf.isAccessibilityElement = true
         tf.borderWidth = 2.0

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -40,6 +40,7 @@ class RequestBalanceView: BaseSampleView {
 
     public let foragePinTextField: ForagePINTextField = {
         let tf = ForagePINTextField()
+        tf.placeholder = "PIN Field"
         tf.accessibilityIdentifier = "tf_pin_balance"
         tf.isAccessibilityElement = true
         tf.borderWidth = 2.0

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -51,7 +51,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     }
 
     /// Placeholder for the text field
-    @available(*, deprecated, message: "Setting the placeholder on the PIN textfield is no longer supported.")
+    @available(*, deprecated, message: "Setting ForagePINTextField.placeholder is unsupported.")
     @IBInspectable public var placeholder: String? {
         get { textField.placeholder }
         set { textField.placeholder = newValue }

--- a/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/ForagePINTextField.swift
@@ -51,6 +51,7 @@ public class ForagePINTextField: UIView, Identifiable, ForageElement {
     }
 
     /// Placeholder for the text field
+    @available(*, deprecated, message: "Setting the placeholder on the PIN textfield is no longer supported.")
     @IBInspectable public var placeholder: String? {
         get { textField.placeholder }
         set { textField.placeholder = newValue }


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

-  Mark setting `foragePinTextField.placeholder` as deprecated
- `foragePanTextField.placholder` is still supported


<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- UX
- `pin.placeholder` was a no-op prior to this change

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

<img width="967" alt="image" src="https://github.com/teamforage/forage-ios-sdk/assets/32694765/e7aac1d2-f24e-4caf-9c43-4767f6365b73">

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Can be released as-is