### PR TITLE
[FX-1351] Relax optional PaymentModel fields for deferred capture

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
@@ -64,12 +64,12 @@ public struct PaymentModel: Codable {
     public let paymentRef: String
     public let merchantID: String
     public let fundingType: String
-    public let amount: String
+    public let amount: String?
     public let description: String
     public let metadata: [String: String]
     public let paymentMethodRef: String
-    public let deliveryAddress: ForageAddress
-    public let isDelivery: Bool
+    public let deliveryAddress: ForageAddress?
+    public let isDelivery: Bool?
     public let createdDate: String
     public let updatedDate: String
     public let status: String


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- Make the following optional/nullable:

```swift
Payment.amount
Payment.delivery_address
Payment.is_delivery
```

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

https://linear.app/joinforage/issue/FX-1351/ios-relax-paymentmodel-for-deferred-flow

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Tested manually against "empty"/"thin" and "fully-loaded" payment.

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Should be released asap, will be followed by improved testing flow for empty payments.