### PR TITLE
[FX-1362] Only grab the payment_method ref from the ThinPayment

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
+++ b/Sources/ForageSDK/Foundation/Network/Model/PaymentModel.swift
@@ -105,3 +105,17 @@ public struct PaymentModel: Codable {
         case error
     }
 }
+
+/// When using the deferred capture flow
+/// the Payment may not have some `null` properties
+/// (`amount`, `delivery_address`, `is_delivery`, ...)  until the
+/// payment is updated and captured on the server-side.
+/// In turn, we only grab what we need from `ThinPaymentModel` for
+/// intermediate internal SDK requests to `GET /payments/`
+internal struct ThinPaymentModel: Codable {
+    internal let paymentMethodRef: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case paymentMethodRef = "payment_method"
+    }
+}

--- a/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
@@ -49,11 +49,11 @@ protocol ForageService: AnyObject {
     ///  - merchantID: The unique ID of the Merchant.
     ///  - paymentRef: The reference hash of the Payment.
     ///  - completion: The closure returns a `Result` containing either a `PaymentModel` or an `Error`. [Read more](https://docs.joinforage.app/reference/get-payment-details)
-    func getPayment(
+    func getPayment<T : Decodable>(
         sessionToken: String,
         merchantID: String,
         paymentRef: String,
-        completion: @escaping (Result<PaymentModel, Error>) -> Void
+        completion: @escaping (Result<T, Error>) -> Void
     )
 
     /// Tokenize an EBT card using the given *ForagePANRequestModel* object

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -184,7 +184,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
-        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
+        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<PaymentModel, Error>) in
             switch result {
             case let .success(payment):
                 XCTAssertEqual(payment.paymentMethodRef, "81dab02290")
@@ -199,6 +199,26 @@ final class ForageServiceTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
     }
+    
+    func test_getThinPayment_onSuccess_checkExpectedPayload() {
+        let mockSession = URLSessionMock()
+        mockSession.data = forageMocks.capturePaymentSuccess
+        mockSession.response = forageMocks.mockSuccessResponse
+        let service = createTestService(mockSession)
+
+        let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
+        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<ThinPaymentModel, Error>) in
+            switch result {
+            case let .success(payment):
+                XCTAssertEqual(payment.paymentMethodRef, "81dab02290")
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Expected success")
+            }
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
 
     func test_getPayment_onFailure_shouldReturnFailure() {
         let mockSession = URLSessionMock()
@@ -207,7 +227,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - result should be failure")
-        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { result in
+        service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<PaymentModel, Error>) in
             switch result {
             case .success:
                 XCTFail("Expected failure")


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->
- Only grab "necessary info" for the "preliminary" /GET/ payment calls
- Included comments for context + posterity

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

- https://linear.app/joinforage/issue/FX-1362/only-grab-required-info-for-internal-preliminary-get-payment-calls

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Tested locally ; @dleis612 is adding corresponding automated E2E tests
- Updated unit tests

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Should be released ASAP