### PR TITLE
Pass Session-Token through to vault calls

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -245,7 +245,7 @@ class LiveForageService: ForageService {
             "Merchant-Account": request.merchantID,
             "x-datadog-trace-id": ForageSDK.shared.traceId,
             "API-VERSION": "2024-01-08",
-            "Session-Token": request.authorization,
+            "Session-Token": "Bearer \(request.authorization)",
         ], xKey: request.xKey)
 
         let extraData = [

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -245,6 +245,7 @@ class LiveForageService: ForageService {
             "Merchant-Account": request.merchantID,
             "x-datadog-trace-id": ForageSDK.shared.traceId,
             "API-VERSION": "2024-01-08",
+            "Session-Token": request.authorization,
         ], xKey: request.xKey)
 
         let extraData = [


### PR DESCRIPTION
Part of MMF project and PCI-Compliance:
- **pass through session-token as header in vault calls** (this PR)
- **enforce merchantId for Forage client initialization** - should already be done (since the documentation specifies they should use the merchantID starting with mid/ to start the client, but we need to verify that's currently being done before enforcing validation on the field, in case someone is still using fns

## Testing
- In sample app, make balance check calls to VGS / BT, confirm that the calls go through successfully
- In datadog, confirm that the headers are being passed in to us [here](https://app.datadoghq.com/logs?query=env%3Adev%20service%3Aios-sdk%20OR%20trace_id%3A3345885844225900%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY-CmUlvx1FojwAAAAAAAAAYAAAAAEFZLUNtVW16QUFCOTNOalVsYjBPLUFBQwAAACQAAAAAMDE4ZjgyOTktNjE0OC00MTQ5LWE0NDQtNzJkMTFiYjVkMjUw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1715881472865&to_ts=1715882372865&live=true)
- Note: Checks below complain that test coverage fails for the new PR, but we never had testing in place to check all the individual header values, so likely possible to skip (unless we need to add that)