### PR TITLE
[1493] Only log errors when the response code is in the 500s

### DIFF
--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -283,7 +283,8 @@ extension ForageSDK: ForageSDKService {
     /// Determine if we should log an error or a warning
     private func logErrorResponse(_ message: String, error: Error?, attributes: [String: Encodable]?) {
         let statusCode = (error as? ForageError)?.httpStatusCode ?? 500
-        if (statusCode >= 400 && statusCode < 500) {
+        let isWarningLevelStatusCode = [400, 429].contains(statusCode)
+        if (isWarningLevelStatusCode) {
             ForageSDK.logger?.warn(message, error: error, attributes: nil)
         } else {
             ForageSDK.logger?.error(message, error: error, attributes: nil)

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -135,16 +135,12 @@ extension ForageSDK: ForageSDKService {
                 )
                 ForageSDK.logger?.notice("Balance check succeeded for PaymentMethod \(paymentMethodReference)", attributes: nil)
 
-                responseMonitor.setEventOutcome(.success).end()
+                responseMonitor.setEventOutcome(.success).setHttpStatusCode(200).end()
                 responseMonitor.logResult()
 
                 completion(.success(balanceResult))
             } catch {
-                logErrorResponse("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil)
-                
-                responseMonitor.setForageErrorCode(error).end()
-                responseMonitor.logResult()
-
+                logErrorResponse("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil, responseMonitor: responseMonitor)
                 completion(.failure(error))
             }
         }
@@ -194,16 +190,12 @@ extension ForageSDK: ForageSDKService {
                 )
                 ForageSDK.logger?.notice("Capture succeeded for Payment \(paymentReference)", attributes: nil)
 
-                responseMonitor.setEventOutcome(.success).end()
+                responseMonitor.setEventOutcome(.success).setHttpStatusCode(200).end()
                 responseMonitor.logResult()
 
                 completion(.success(paymentResult))
             } catch {
-                logErrorResponse("Capture failed for Payment \(paymentReference)", error: error, attributes: nil)
-
-                responseMonitor.setForageErrorCode(error).end()
-                responseMonitor.logResult()
-
+                logErrorResponse("Capture failed for Payment \(paymentReference)", error: error, attributes: nil, responseMonitor: responseMonitor)
                 completion(.failure(error))
             }
         }
@@ -245,8 +237,7 @@ extension ForageSDK: ForageSDKService {
 
                 completion(.success(()))
             } catch {
-                logErrorResponse("deferPaymentCapture failed for Payment \(paymentReference)", error: error, attributes: nil)
-
+                logErrorResponse("deferPaymentCapture failed for Payment \(paymentReference)", error: error, attributes: nil, responseMonitor: nil)
                 completion(.failure(error))
             }
         }
@@ -281,13 +272,18 @@ extension ForageSDK: ForageSDKService {
     }
     
     /// Determine if we should log an error or a warning
-    private func logErrorResponse(_ message: String, error: Error?, attributes: [String: Encodable]?) {
-        let statusCode = (error as? ForageError)?.httpStatusCode ?? 500
-        let isWarningLevelStatusCode = [400, 429].contains(statusCode)
-        if (isWarningLevelStatusCode) {
-            ForageSDK.logger?.warn(message, error: error, attributes: nil)
+    internal func logErrorResponse(_ message: String, error: Error, attributes: [String: Encodable]?, responseMonitor: ResponseMonitor?) {
+        responseMonitor?.setForageErrorCode(error)
+        if let statusCode = (error as? ForageError)?.httpStatusCode, let forageLogger = ForageSDK.logger {
+            responseMonitor?.setHttpStatusCode(statusCode)
+            let isWarningLevelStatusCode = [400, 429]
+            let logLevel = isWarningLevelStatusCode.contains(statusCode) ? forageLogger.warn : forageLogger.error
+            logLevel(message, error, nil)
         } else {
             ForageSDK.logger?.error(message, error: error, attributes: nil)
         }
+        
+        responseMonitor?.end()
+        responseMonitor?.logResult()
     }
 }

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -140,8 +140,8 @@ extension ForageSDK: ForageSDKService {
 
                 completion(.success(balanceResult))
             } catch {
-                ForageSDK.logger?.error("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil)
-
+                logErrorResponse("Balance check failed for PaymentMethod \(paymentMethodReference)", error: error, attributes: nil)
+                
                 responseMonitor.setForageErrorCode(error).end()
                 responseMonitor.logResult()
 
@@ -199,7 +199,7 @@ extension ForageSDK: ForageSDKService {
 
                 completion(.success(paymentResult))
             } catch {
-                ForageSDK.logger?.error("Capture failed for Payment \(paymentReference)", error: error, attributes: nil)
+                logErrorResponse("Capture failed for Payment \(paymentReference)", error: error, attributes: nil)
 
                 responseMonitor.setForageErrorCode(error).end()
                 responseMonitor.logResult()
@@ -245,7 +245,7 @@ extension ForageSDK: ForageSDKService {
 
                 completion(.success(()))
             } catch {
-                ForageSDK.logger?.error("deferPaymentCapture failed for Payment \(paymentReference)", error: error, attributes: nil)
+                logErrorResponse("deferPaymentCapture failed for Payment \(paymentReference)", error: error, attributes: nil)
 
                 completion(.failure(error))
             }
@@ -278,5 +278,15 @@ extension ForageSDK: ForageSDKService {
             attributes: nil
         )
         return false
+    }
+    
+    /// Determine if we should log an error or a warning
+    private func logErrorResponse(_ message: String, error: Error?, attributes: [String: Encodable]?) {
+        let statusCode = (error as? ForageError)?.httpStatusCode ?? 500
+        if (statusCode >= 400 && statusCode < 500) {
+            ForageSDK.logger?.warn(message, error: error, attributes: nil)
+        } else {
+            ForageSDK.logger?.error(message, error: error, attributes: nil)
+        }
     }
 }

--- a/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/CustomerPerceivedResponseMonitor.swift
@@ -64,7 +64,8 @@ final class CustomerPerceivedResponseMonitor: ResponseMonitor {
     ) {
         guard
             let responseTimeMs = responseAttributes.responseTimeMs,
-            let eventOutcome = eventOutcome
+            let eventOutcome = eventOutcome,
+            let httpStatus = responseAttributes.code
         else {
             metricsLogger?.error("Incomplete or missing response attributes. Could not report metric event.", error: nil, attributes: nil)
             return
@@ -81,6 +82,7 @@ final class CustomerPerceivedResponseMonitor: ResponseMonitor {
                 .eventName: eventName.rawValue,
                 .eventOutcome: eventOutcome.rawValue,
                 .forageErrorCode: responseAttributes.forageErrorCode,
+                .httpStatus: httpStatus,
                 .logType: ForageLogKind.metric.rawValue,
                 .responseTimeMs: responseTimeMs,
                 .vaultType: vaultType.rawValue,

--- a/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
+++ b/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
@@ -270,6 +270,8 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
                 XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
                 XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "balance")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["http_status"] is Int)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["http_status"] as! Int, 200)
             case .failure:
                 XCTFail("Expected success but got \(String(describing: result))")
             }
@@ -332,7 +334,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTAssertEqual(forageError.message, "Invalid PIN or PIN not selected - Invalid PIN")
                 XCTAssertEqual(forageError.httpStatusCode, 400)
 
-                XCTAssertEqual(self.mockLogger.lastErrorMsg, "Balance check failed for PaymentMethod abcdef123")
+                XCTAssertEqual(self.mockLogger.lastWarnMsg, "Balance check failed for PaymentMethod abcdef123")
 
                 // Are metrics-related events being reported correctly?
                 XCTAssertEqual(self.mockLogger.lastInfoMsg, "Reported customer-perceived response event")
@@ -340,6 +342,8 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
                 XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
                 XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "balance")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["http_status"] is Int)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["http_status"] as! Int, 400)
             }
         }
     }
@@ -358,6 +362,8 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
                 XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
                 XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "capture")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["http_status"] is Int)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["http_status"] as! Int, 200)
             } else {
                 XCTFail("Expected success but got \(String(describing: result))")
             }
@@ -401,6 +407,8 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTAssertNotEqual(self.mockLogger.lastAttributes!["response_time_ms"] as! Double, 0.0)
                 XCTAssertEqual(self.mockLogger.lastAttributes!["log_type"] as! String, "metric")
                 XCTAssertEqual(self.mockLogger.lastAttributes!["action"] as! String, "capture")
+                XCTAssertTrue(self.mockLogger.lastAttributes!["http_status"] is Int)
+                XCTAssertEqual(self.mockLogger.lastAttributes!["http_status"] as! Int, 400)
             }
         }
     }

--- a/Tests/ForageSDKTests/Mock/MockLogger.swift
+++ b/Tests/ForageSDKTests/Mock/MockLogger.swift
@@ -10,6 +10,7 @@ import Foundation
 class MockLogger: NoopLogger {
     var lastInfoMsg: String = ""
     var lastErrorMsg: String = ""
+    var lastWarnMsg: String = ""
     var lastCriticalMessage: String = ""
     var lastNoticeMsg: String = ""
     var lastAttributes: [String: Encodable]? = nil
@@ -30,6 +31,11 @@ class MockLogger: NoopLogger {
 
     override func critical(_ message: String, error: Error?, attributes: [String: Encodable]?) {
         lastCriticalMessage = message
+        lastAttributes = attributes
+    }
+    
+    override func warn(_ message: String, error: (any Error)?, attributes: [String : any Encodable]?) {
+        lastWarnMsg = message
         lastAttributes = attributes
     }
 


### PR DESCRIPTION
## What
The current iOS logs are pretty good. We store a ton of relevant data in the `customer_perceived_response` log that can be used to build monitoring. I would argue that we may not need to "error" when the http response code is in the 400s.
<img width="990" alt="Screenshot 2024-06-12 at 11 56 06 AM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/38d35318-9e90-4fd7-919e-3096a1c5aaaa">
<img width="1245" alt="Screenshot 2024-06-12 at 11 56 35 AM" src="https://github.com/teamforage/forage-ios-sdk/assets/89605898/2d9b9829-65ac-4ddb-b380-eb073aa48a4d">
![Screenshot 2024-06-13 at 11 13 23 AM](https://github.com/teamforage/forage-ios-sdk/assets/89605898/3b9c8594-0014-4d06-8755-b42517836f91)

