### PR TITLE
[FX-1509] Fix isFirstResponder state update in rosetta PIN input

### DIFF
--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
@@ -73,6 +73,14 @@ class RosettaPINTextField: UIView, VaultWrapper, UITextFieldDelegate {
         let isFourOrFewer = newValue.count <= 4
         return isOnlyNumeric && isFourOrFewer
     }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        self.delegate?.firstResponderDidChange(self)
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        self.delegate?.firstResponderDidChange(self)
+    }
 
     // MARK: - Private API
 

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
@@ -106,11 +106,11 @@ class RosettaPINTextField: UIView, VaultWrapper, UITextFieldDelegate {
         self._isComplete = self._isValid
         self.delegate?.textFieldDidChange(self)
     }
-    
+
     @objc func editingBegan(_ textField: UITextField) {
         self.delegate?.firstResponderDidChange(self)
     }
-    
+
     @objc func editingEnded(_ textField: UITextField) {
         self.delegate?.firstResponderDidChange(self)
     }

--- a/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
+++ b/Sources/ForageSDK/Component/ForagePINTextField/Vault/RosettaPINTextField.swift
@@ -73,14 +73,6 @@ class RosettaPINTextField: UIView, VaultWrapper, UITextFieldDelegate {
         let isFourOrFewer = newValue.count <= 4
         return isOnlyNumeric && isFourOrFewer
     }
-    
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        self.delegate?.firstResponderDidChange(self)
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        self.delegate?.firstResponderDidChange(self)
-    }
 
     // MARK: - Private API
 
@@ -104,6 +96,8 @@ class RosettaPINTextField: UIView, VaultWrapper, UITextFieldDelegate {
         inputHeightConstraint = textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 36)
         inputHeightConstraint?.isActive = true
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        textField.addTarget(self, action: #selector(editingBegan), for: .editingDidBegin)
+        textField.addTarget(self, action: #selector(editingEnded), for: .editingDidEnd)
     }
 
     @objc func textFieldDidChange(_ textField: UITextField) {
@@ -111,6 +105,14 @@ class RosettaPINTextField: UIView, VaultWrapper, UITextFieldDelegate {
         self._isValid = textField.text?.count == 4 && (textField.text?.allSatisfy { $0.isNumber } ?? false)
         self._isComplete = self._isValid
         self.delegate?.textFieldDidChange(self)
+    }
+    
+    @objc func editingBegan(_ textField: UITextField) {
+        self.delegate?.firstResponderDidChange(self)
+    }
+    
+    @objc func editingEnded(_ textField: UITextField) {
+        self.delegate?.firstResponderDidChange(self)
     }
 
     func clearText() {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -434,19 +434,39 @@ final class ForagePINTextFieldTests: XCTestCase {
         let rosettaPINTextField = RosettaPINTextField()
         let mockDelegate = MockDelegate()
         let textField = UITextField()
-
+        let window = UIWindow()
+        
         rosettaPINTextField.delegate = mockDelegate
+        window.addSubview(rosettaPINTextField)
         
         // textFieldDidChange
         rosettaPINTextField.textFieldDidChange(textField)
         XCTAssertEqual(mockDelegate.textFieldDidChangeCalledTimes, 1)
         
         // firstResponderDidChange
+        XCTAssertFalse(rosettaPINTextField.isFirstResponder)
+
+        // simulating the system firing the .editingDidBegin event
+        rosettaPINTextField.becomeFirstResponder()
         rosettaPINTextField.editingBegan(textField)
-        XCTAssertEqual(mockDelegate.firstResponderDidChangeCalledTimes, 1)
         
+        // wait for the responder chain to update
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        
+        // Assert that we called the right delegate methods and the isFirstResponder status was updated
+        XCTAssertEqual(mockDelegate.firstResponderDidChangeCalledTimes, 1)
+        XCTAssertTrue(rosettaPINTextField.isFirstResponder)
+        
+        // simulating the system firing the .editingDidEnd event
+        rosettaPINTextField.resignFirstResponder()
         rosettaPINTextField.editingEnded(textField)
+        
+        // wait for the responder chain to update
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        
+        // Assert that we called the right delegate methods and the isFirstResponder status was updated
         XCTAssertEqual(mockDelegate.firstResponderDidChangeCalledTimes, 2)
+        XCTAssertFalse(rosettaPINTextField.isFirstResponder)
     }
 }
 

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -415,6 +415,18 @@ final class ForagePINTextFieldTests: XCTestCase {
         let result = rosettaPINTextField.textField(UITextField(), shouldChangeCharactersIn: NSRange(), replacementString: "1234")
         XCTAssertEqual(result, true)
     }
+    
+    func test_RosettaPINTextField_firstResponderState() {
+        DispatchQueue.main.async {
+            let rosettaPINTextField = RosettaPINTextField()
+            let textField = UITextField()
+            XCTAssertFalse(rosettaPINTextField.isFirstResponder)
+            rosettaPINTextField.editingBegan(textField)
+            XCTAssertTrue(rosettaPINTextField.isFirstResponder)
+            rosettaPINTextField.editingEnded(textField)
+            XCTAssertFalse(rosettaPINTextField.isFirstResponder)
+        }
+    }
 }
 
 extension ForagePINTextFieldTests: ForageElementDelegate {

--- a/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
+++ b/Tests/ForageSDKTests/ForagePINTextFieldTests.swift
@@ -416,16 +416,37 @@ final class ForagePINTextFieldTests: XCTestCase {
         XCTAssertEqual(result, true)
     }
     
-    func test_RosettaPINTextField_firstResponderState() {
-        DispatchQueue.main.async {
-            let rosettaPINTextField = RosettaPINTextField()
-            let textField = UITextField()
-            XCTAssertFalse(rosettaPINTextField.isFirstResponder)
-            rosettaPINTextField.editingBegan(textField)
-            XCTAssertTrue(rosettaPINTextField.isFirstResponder)
-            rosettaPINTextField.editingEnded(textField)
-            XCTAssertFalse(rosettaPINTextField.isFirstResponder)
+    func test_RosettaPINTextField_delegateMethodCalls() {
+        class MockDelegate: VaultWrapperDelegate {
+            var textFieldDidChangeCalledTimes = 0
+            var firstResponderDidChangeCalledTimes = 0
+            
+            func textFieldDidChange(_ textField: any VaultWrapper) {
+                textFieldDidChangeCalledTimes += 1
+            }
+            
+            func firstResponderDidChange(_ textField: any VaultWrapper) {
+                firstResponderDidChangeCalledTimes += 1
+            }
+
         }
+        
+        let rosettaPINTextField = RosettaPINTextField()
+        let mockDelegate = MockDelegate()
+        let textField = UITextField()
+
+        rosettaPINTextField.delegate = mockDelegate
+        
+        // textFieldDidChange
+        rosettaPINTextField.textFieldDidChange(textField)
+        XCTAssertEqual(mockDelegate.textFieldDidChangeCalledTimes, 1)
+        
+        // firstResponderDidChange
+        rosettaPINTextField.editingBegan(textField)
+        XCTAssertEqual(mockDelegate.firstResponderDidChangeCalledTimes, 1)
+        
+        rosettaPINTextField.editingEnded(textField)
+        XCTAssertEqual(mockDelegate.firstResponderDidChangeCalledTimes, 2)
     }
 }
 

--- a/Tests/ForageSDKTests/ResponseMonitorTests.swift
+++ b/Tests/ForageSDKTests/ResponseMonitorTests.swift
@@ -152,7 +152,7 @@ final class ResponseMonitorTests: XCTestCase {
         monitor.setEventOutcome(.failure)
         // set to failure, but missing forage_error_code!
 
-        let attributes = ResponseAttributes(responseTimeMs: 123)
+        let attributes = ResponseAttributes(responseTimeMs: 123, code: 400)
 
         monitor.logWithResponseAttributes(
             metricsLogger: mockMetricsLogger,
@@ -171,7 +171,7 @@ final class ResponseMonitorTests: XCTestCase {
         )
         monitor.setEventOutcome(.success)
 
-        let attributes = ResponseAttributes(responseTimeMs: 123.23)
+        let attributes = ResponseAttributes(responseTimeMs: 123.23, code: 200)
         monitor.logWithResponseAttributes(metricsLogger: mockMetricsLogger, responseAttributes: attributes)
 
         XCTAssertEqual(mockMetricsLogger.loggedInfos.count, 1)


### PR DESCRIPTION
## What
Fixes an issue where `isFirstResponder` on `RosettaPINTextField` wasn't getting updated properly when the underlying UITextField was focused or unfocused. Also adds a test for this.

Also fixes an issue with the Response Monitor unit tests that was introduced in https://github.com/teamforage/forage-ios-sdk/pull/170

## Why
https://linear.app/joinforage/issue/FX-1509/fix-isfirstresponder-state-update

## Test Plan
Manually verified the state updates in the sample app, also added a unit test.

## How
Can be merged as-is