### PR TITLE
[FX-1520] Bump LD to 9.6.1

### DIFF
--- a/ForageSDK.podspec
+++ b/ForageSDK.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/teamforage/forage-ios-sdk.git", :tag => "4.4.6" }
   spec.source_files = ["Sources/ForageSDK/**/*.swift", "DatadogPrivate-Objc/**/*.{h,m}"]
   spec.dependency 'VGSCollectSDK', '1.15.3'
-  spec.dependency 'LaunchDarkly', '9.6.0'
+  spec.dependency 'LaunchDarkly', '9.6.1'
   spec.dependency 'BasisTheoryElements', '4.1.0'
   spec.resource_bundles = {
     'ForageIcon' => ['Sources/Resources/*']

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(
             name: "LaunchDarkly",
             url: "https://github.com/launchdarkly/ios-client-sdk.git",
-            .exact("9.6.0")
+            .exact("9.6.1")
         ),
         .package(
             name: "BasisTheoryElements",


### PR DESCRIPTION
<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->
Bumps LD to 9.6.1

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
https://linear.app/joinforage/issue/FX-1520/update-forage-sdk-dependency-to-version-961-to-resolve-resource-issue
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ❌ Not a front-end change
- ❌ iOS QA Tests passed locally - created PR on github
- ❌ Unit Tests passed locally - created PR on github

## How
Can be rolled out as is, pending approval and passing tests
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
