### PR TITLE
[FX-1598] Make setup update merchant ID + session token

### DIFF
--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -12,8 +12,8 @@ public class ForageSDK {
     private static var config: Config?
     static var logger: ForageLogger?
     var service: ForageService?
-    var merchantID: String = ""
-    var sessionToken: String = ""
+    var merchantID: String = config?.merchantID ?? ""
+    var sessionToken: String = config?.sessionToken ?? ""
     var traceId: String = ""
 
     public var environment: Environment = .sandbox
@@ -28,10 +28,6 @@ public class ForageSDK {
             assertionFailure("ForageSDK is not initialized - call ForageSDK.setup() before accessing ForageSDK.shared")
             return
         }
-        environment = Environment(sessionToken: config.sessionToken)
-        merchantID = config.merchantID
-        sessionToken = config.sessionToken
-
         traceId = ForageSDK.logger?.getTraceID() ?? ""
 
         VGSCollectLogger.shared.disableAllLoggers()
@@ -73,6 +69,9 @@ public class ForageSDK {
     public class func setup(_ config: Config) {
         ForageSDK.config = config
         let environment = Environment(sessionToken: config.sessionToken)
+        
+        updateMerchantID(config.merchantID)
+        updateSessionToken(config.sessionToken)
 
         initializeLogger(environment)
         initializeLaunchDarkly(environment)

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -24,7 +24,7 @@ public class ForageSDK {
     // MARK: Init
 
     private init() {
-        guard let config = ForageSDK.config else {
+        guard ForageSDK.config != nil else {
             assertionFailure("ForageSDK is not initialized - call ForageSDK.setup() before accessing ForageSDK.shared")
             return
         }

--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -89,11 +89,10 @@ protocol ForageLogger {
 class DatadogLogger: ForageLogger {
     private static let DD_CLIENT_TOKEN: String = "pub1e4572ba0f5e53df108c333d5ec66c02"
     private static let DD_SERVICE_NAME: String = "ios-sdk"
-    private static let DD_SDK_INSTANCE_NAME: String = "forage"
-
+    
     // DO NOT UPDATE! Generate 1 TraceID per living session of the app
     static let traceId: String = generateTraceID()
-
+    
     private var logger: LoggerProtocol?
     private var config: ForageLoggerConfig?
 
@@ -190,7 +189,7 @@ class DatadogLogger: ForageLogger {
     /// Initializes and returns a Datadog instance for the given environment. If an instance with the specified name already exists,
     /// it returns the existing instance.
     private func initDatadog(_ environment: Environment) -> DatadogCoreProtocol {
-        let instanceName = DatadogLogger.DD_SDK_INSTANCE_NAME
+        let instanceName = buildInstanceName(environment: environment)
 
         if Datadog.isInitialized(instanceName: instanceName) {
             return Datadog.sdkInstance(named: instanceName)
@@ -209,6 +208,12 @@ class DatadogLogger: ForageLogger {
         Logs.enable(in: datadogInstance)
         return datadogInstance
     }
+    
+    // ensure logger is re-initialized if the environment changes!
+    private func buildInstanceName(environment: Environment) -> String {
+        return "forage-\(environment.rawValue)"
+    }
+
 
     private func getMessageWithPrefix(_ message: String) -> String {
         if let prefix = config?.prefix {

--- a/Tests/ForageSDKTests/ForageSDKTests.swift
+++ b/Tests/ForageSDKTests/ForageSDKTests.swift
@@ -71,4 +71,29 @@ final class ForageSDKTests: XCTestCase {
         XCTAssertEqual(mockLogger.lastNoticeMsg, "Called updateSessionToken")
         XCTAssertEqual(MockForageSDK.shared.environment, .staging)
     }
+    
+    func testSetup_shouldUpdateMerchantIDAndSessionToken() {
+        ForageSDK.setup(
+            ForageSDK.Config(merchantID: "mid/first", sessionToken: "dev_first_token")
+        )
+        
+        /// NOTE: We access ForageSDK.shared. to make sure that config updates still work after ``ForageSDK.init`` is invoked
+        XCTAssertEqual(ForageSDK.shared.environment, .dev)
+        XCTAssertEqual(ForageSDK.shared.merchantID, "mid/first")
+
+        ForageSDK.setup(
+            ForageSDK.Config(merchantID: "mid/second", sessionToken: "staging_second_token")
+        )
+        
+        XCTAssertEqual(ForageSDK.shared.environment, .staging)
+        XCTAssertEqual(ForageSDK.shared.merchantID, "mid/second")
+        
+        // one more time!
+        ForageSDK.setup(
+            ForageSDK.Config(merchantID: "mid/third", sessionToken: "sandbox_second_token")
+        )
+        
+        XCTAssertEqual(ForageSDK.shared.environment, .sandbox)
+        XCTAssertEqual(ForageSDK.shared.merchantID, "mid/third")
+    }
 }


### PR DESCRIPTION

<!-- Update your title to prefix with your ticket number -->

## What
<!-- Describe your changes here -->

- [x] Make `ForageSDK.setup(...)` update merchant ID + session token

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why

- Conventionally, merchants use `updateMerchantID` and `updateSessionToken`
<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan

- [x] Manually verified that environment-specific things like logs and launchdarkly work as expected
- [x] Updated unit tests
- [x] Manually verified that merchant IDs and session tokens get updated as expected!
- [ ] Will follow-up with E2E mobile-qa-tests

## How
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->

Should be released ASAP! The `ForageSDK.swift` class could use a lot of TLC 😅 , but this is a stopgap solution