### PR TITLE
Refactor instance properties in ForageSDK to avoid manually syncing values

### DIFF
--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -63,6 +63,11 @@ public class ForageSDK {
     public struct Config {
         var merchantID: String
         var sessionToken: String
+        
+        public init(merchantID: String, sessionToken: String) {
+            self.merchantID = merchantID
+            self.sessionToken = sessionToken
+        }
     }
 
     /// Configures the Forage SDK with the given configuration.

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -63,7 +63,7 @@ public class ForageSDK {
     public struct Config {
         var merchantID: String
         var sessionToken: String
-        
+
         public init(merchantID: String, sessionToken: String) {
             self.merchantID = merchantID
             self.sessionToken = sessionToken

--- a/Sources/ForageSDK/ForageSDK.swift
+++ b/Sources/ForageSDK/ForageSDK.swift
@@ -6,28 +6,42 @@
 import Foundation
 
 public class ForageSDK {
-    // MARK: Properties
+    // MARK: - Static Properties
 
+    // These belong to ForageSDK itself and are shared by all of its instances
     private static var config: Config?
     static var logger: ForageLogger?
-    var service: ForageService?
-    var merchantID: String = config?.merchantID ?? ""
-    var sessionToken: String = config?.sessionToken ?? ""
-    var traceId: String = ""
-
-    public var environment: Environment = .sandbox
-    // Don't update! Only updated when releasing.
+    // Don't update version! Only updated when releasing.
     public static let version = "4.4.9"
     public static let shared = ForageSDK()
+    
+    // MARK: - Singleton Instance Properties
 
-    // MARK: Init
+    // Instance properties, only belong to the `shared` singleton instance.
+    var service: ForageService?
+    
+    // Computed instance properties derived from static values
+    public var environment: Environment {
+        Environment(sessionToken: ForageSDK.config?.sessionToken)
+    }
+    var merchantID: String {
+        ForageSDK.config?.merchantID ?? ""
+    }
+    var sessionToken: String {
+        ForageSDK.config?.sessionToken ?? ""
+    }
+    var traceId: String {
+        ForageSDK.logger?.getTraceID() ?? ""
+    }
 
+    // MARK: - Singleton Init
+
+    // This is only called when first accessing `shared`. This class can't be initialized manually, only by referencing `ForageSDK.shared`, which creates the singleton instance and calls this private `init` method. It would only get called again if the singleton instance was removed from memory (force-closing an app, for instance).
     private init() {
         guard ForageSDK.config != nil else {
             assertionFailure("ForageSDK is not initialized - call ForageSDK.setup() before accessing ForageSDK.shared")
             return
         }
-        traceId = ForageSDK.logger?.getTraceID() ?? ""
 
         let provider = Provider(logger: ForageSDK.logger)
         service = LiveForageService(
@@ -36,6 +50,8 @@ public class ForageSDK {
             ldManager: LDManager.shared
         )
     }
+    
+    // MARK: - Public API
 
     /**
      ``Config`` struct to set the merchant ID and session token on the ``ForageSDK`` singleton
@@ -47,11 +63,6 @@ public class ForageSDK {
     public struct Config {
         var merchantID: String
         var sessionToken: String
-
-        public init(merchantID: String, sessionToken: String) {
-            self.merchantID = merchantID
-            self.sessionToken = sessionToken
-        }
     }
 
     /// Configures the Forage SDK with the given configuration.
@@ -95,7 +106,6 @@ public class ForageSDK {
 
         // config is guaranteed to be non-nil because of the guard above.
         ForageSDK.config!.merchantID = newMerchantID
-        ForageSDK.shared.merchantID = newMerchantID
     }
 
     /// Updates the session token to use for subsequent API calls.
@@ -116,10 +126,10 @@ public class ForageSDK {
 
         // config is guaranteed to be non-nil because of the guard above.
         ForageSDK.config!.sessionToken = newSessionToken
-        ForageSDK.shared.sessionToken = newSessionToken
-        ForageSDK.shared.environment = Environment(sessionToken: newSessionToken)
     }
 
+    // MARK: - Internal methods
+    
     class func initializeLogger(_ environment: Environment) {
         ForageSDK.logger = DatadogLogger(
             ForageLoggerConfig(

--- a/Tests/ForageSDKTests/FloatingTextFieldTests.swift
+++ b/Tests/ForageSDKTests/FloatingTextFieldTests.swift
@@ -14,7 +14,6 @@ final class FloatingTextFieldTests: XCTestCase {
 
     override func setUp() {
         setUpForageSDK()
-        ForageSDK.shared.environment = .sandbox
         floatingTextField = FloatingTextField()
     }
 

--- a/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
+++ b/Tests/ForageSDKTests/MaskedUITextFieldTests.swift
@@ -13,8 +13,6 @@ final class MaskedUITextFieldTests: XCTestCase {
 
     override func setUp() {
         setUpForageSDK()
-        // .setup() currently doesn't allow us to update the environment
-        ForageSDK.shared.environment = .sandbox
         maskedTextField = MaskedUITextField()
     }
 
@@ -120,7 +118,7 @@ final class MaskedUITextFieldTests: XCTestCase {
     // MARK: - Validation with special cards
 
     func testValidation_specialButProd_shouldBeInvalidAndIncomplete() {
-        ForageSDK.shared.environment = .prod
+        ForageSDK.updateSessionToken("prod_unit-test")
         maskedTextField.text = "4444444444444454"
         maskedTextField.textFieldDidChange()
 


### PR DESCRIPTION
## What
Refactors some of the instance properties (merchantId, sessionToken, etc.) in `ForageSDK` to be derived from their static counterparts rather than be mutable, manually-set values. 

This guarantees the instance values in the `shared` singleton are always synced to what's in the static `config` property.

## Why
Reduces the likelihood of us forgetting to update something and creating unexpected issues.

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->

- ✅ Not a front-end change
- ✅ iOS QA Tests passed locally
- ✅ Unit Tests passed locally

## How
Can be safely merged into the `evan/sdk-hardening` branch, where I'm building up some refactoring changes.