### PR TITLE
[SEC-42] Point logs at PCI compliant Datadog endpoints

### DIFF
--- a/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
+++ b/Sources/ForageSDK/Foundation/Telemetry/ForageLogger.swift
@@ -205,7 +205,11 @@ class DatadogLogger: ForageLogger {
             instanceName: instanceName
         )
 
-        Logs.enable(in: datadogInstance)
+        // Send logs to PCI compliant Datadog endpoint
+        let config = Logs.Configuration(
+            customEndpoint: URL(string: "https://pci.browser-intake-datadoghq.com"))
+
+        Logs.enable(with: config, in: datadogInstance)
         return datadogInstance
     }
 


### PR DESCRIPTION
## What
Title

## Why
Out of the box, Datadog is not PCI compliant. We need to send logs to a different server of theirs, which has a better compliance posture.