### PR TITLE
Update QA-tests to expressly use Python 3.12

### DIFF
--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -50,6 +50,10 @@ jobs:
           ref: main
           ssh-key: ${{ secrets.MOBILE_QA_DEPLOY_KEY }}
           path: 'mobile-qa-tests/'
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
       - name: Run Integration Tests
         env:
           BROWSERSTACK_CUSTOM_ID: ${{ env.BROWSERSTACK_CUSTOM_ID }}


### PR DESCRIPTION
## What
This PR is a **short-term fix** that updates the GitHub Actions workflow for the QA Tests job to explicitly use Python 3.12. The **longer-term fix** would be to bump the version of `ddtrace` to the release that contains [their PR for supporting Python 3.13](https://github.com/MatthieuDartiailh/bytecode/pull/146).

## Why
The CI jobs began [failing three days ago](https://github.com/teamforage/forage-ios-sdk/actions/runs/11531602539), with errors during the wheel-building process for `ddtrace`. An investigation revealed that the GitHub Action runners had recently [bumped versions from Python 3.12 -> Python 3.13](https://github.com/actions/runner-images/releases/tag/macos-13%2F20241023.237#:~:text=24.2%20(python%203.12)-,24.2%20(python%203.13),-RubyGems). Datadog has a PR out that allows `ddtrace` to work on Python 3.13 but that PR has not been released yet. Expressly specifying Python 3.12 fixes our QA tests immediately.

## How
This fix can be rolled out immediately and rolled back when we bump `ddtrace` versions to the version that supports Python 3.13
