### PR TITLE
Refactor to avoid completion handler being called more than once in failure paths

### DIFF
--- a/Sources/ForageSDK/Foundation/Network/Provider.swift
+++ b/Sources/ForageSDK/Foundation/Network/Provider.swift
@@ -49,8 +49,10 @@ class Provider {
         do {
             let request = try endpoint.urlRequest()
             task = urlSession.dataTask(with: request) { data, response, error in
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    if let data = data {
+                DispatchQueue.main.async {
+                    if (response as? HTTPURLResponse) != nil {
+                        return completion(.success(data))
+                    } else if let data = data {
                         self.processVaultData(
                             model: ForageServiceError.self,
                             code: nil,
@@ -71,7 +73,6 @@ class Provider {
                         return completion(.failure(ServiceError.emptyError))
                     }
                 }
-                return completion(.success(data))
             }
             task?.resume()
         } catch {

--- a/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
+++ b/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
@@ -136,6 +136,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
         mockService.doesCheckBalanceThrow = doesThrow
         let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
         let expectation = XCTestExpectation(description: description)
+        expectation.assertForOverFulfill = true
 
         MockForageSDK.shared.checkBalance(
             foragePinTextField: mockPinTextField,
@@ -158,6 +159,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
         mockService.doesCapturePaymentThrow = doesThrow
         let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
         let expectation = XCTestExpectation(description: description)
+        expectation.assertForOverFulfill = true
 
         MockForageSDK.shared.capturePayment(
             foragePinTextField: mockPinTextField,
@@ -179,6 +181,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
         mockService.doesCollectPinThrow = doesThrow
         let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
         let expectation = XCTestExpectation(description: description)
+        expectation.assertForOverFulfill = true
 
         MockForageSDK.shared.deferPaymentCapture(
             foragePinTextField: mockPinTextField,
@@ -195,6 +198,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
 
     func testTokenizeEBTCard_Success() {
         let expectation = XCTestExpectation(description: "Returns PaymentMethod response")
+        expectation.assertForOverFulfill = true
         let mockPanTextField = ForagePANTextField(frame: .zero)
 
         MockForageSDK.shared.tokenizeEBTCard(
@@ -221,6 +225,7 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
 
     func testTokenizeEBTCard_Throws_DoesRejectWithError() {
         let expectation = XCTestExpectation(description: "tokenizeEBTCard rejects with ForageError")
+        expectation.assertForOverFulfill = true
         let mockPanTextField = ForagePANTextField(frame: .zero)
 
         (MockForageSDK.shared.service as! MockForageService).doesTokenizeEBTCardThrow = true

--- a/Tests/ForageSDKTests/ForageServiceTests.swift
+++ b/Tests/ForageSDKTests/ForageServiceTests.swift
@@ -37,6 +37,7 @@ final class ForageServiceTests: XCTestCase {
         )
 
         let expectation = XCTestExpectation(description: "Tokenize EBT Card - should succeed")
+        expectation.assertForOverFulfill = true
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in
             switch result {
             case let .success(response):
@@ -69,6 +70,7 @@ final class ForageServiceTests: XCTestCase {
         )
 
         let expectation = XCTestExpectation(description: "Tokenize EBT Card - result should be failure")
+        expectation.assertForOverFulfill = true
         service.tokenizeEBTCard(request: foragePANRequestModel) { result in
             switch result {
             case .success:
@@ -88,6 +90,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment Method - should succeed")
+        expectation.assertForOverFulfill = true
         service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
             switch result {
             case let .success(paymentMethod):
@@ -112,6 +115,26 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment Method - result should be failure")
+        expectation.assertForOverFulfill = true
+        service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case let .failure(error):
+                XCTAssertNotNil(error)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_getPaymentMethod_onNetworkErrorFailure_shouldReturnFailure() {
+        let mockSession = URLSessionMock()
+        mockSession.error = forageMocks.networkError
+        let service = createTestService(mockSession)
+
+        let expectation = XCTestExpectation(description: "Get the Payment Method - result should be failure")
+        expectation.assertForOverFulfill = true
         service.getPaymentMethod(sessionToken: "auth1234", merchantID: "1234567", paymentMethodRef: "ca29d3443f") { result in
             switch result {
             case .success:
@@ -131,6 +154,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
+        expectation.assertForOverFulfill = true
         service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<PaymentModel, Error>) in
             switch result {
             case let .success(payment):
@@ -154,6 +178,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - should succeed")
+        expectation.assertForOverFulfill = true
         service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<ThinPaymentModel, Error>) in
             switch result {
             case let .success(payment):
@@ -173,6 +198,7 @@ final class ForageServiceTests: XCTestCase {
         let service = createTestService(mockSession)
 
         let expectation = XCTestExpectation(description: "Get the Payment - result should be failure")
+        expectation.assertForOverFulfill = true
         service.getPayment(sessionToken: "auth1234", merchantID: "1234567", paymentRef: "11767381fd") { (result: Result<PaymentModel, Error>) in
             switch result {
             case .success:

--- a/Tests/ForageSDKTests/Mock/ForageMocks.swift
+++ b/Tests/ForageSDKTests/Mock/ForageMocks.swift
@@ -37,6 +37,11 @@ class ForageMocks {
         return NSError(domain: response, code: 400, userInfo: nil)
     }
 
+    var networkError: Error {
+        // Mock SSL error
+        return NSError(domain: "NSURLErrorDomain", code: -1200, userInfo: nil)
+    }
+
     var tokenizeSuccess: Data {
         let response = """
                 {


### PR DESCRIPTION
In balance check code paths this is used with checked continuations which crash when completion is called more than once. This rewrites the code to be a bit more straightforward (in the SSL error case, the completion was called 3 times). I also enabled the `assertForOverFulfill` flag on the expectations, so the tests will catch regressions here.