### PR TITLE
Run Coverage with iPhone 15

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -28,11 +28,8 @@ jobs:
 
       - name: Run tests and generate coverage report (XCode)
         run: |
-          xcodebuild test \
-            -project Sample/SampleForageSDK.xcodeproj \
-            -scheme ForageSDK \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.1' \
-            -enableCodeCoverage YES
+          xcrun simctl list
+
 
       - name: Generate XML coverage report (Cobertura)
         run: slather coverage -x

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -31,7 +31,7 @@ jobs:
           xcodebuild test \
             -project Sample/SampleForageSDK.xcodeproj \
             -scheme ForageSDK \
-            -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.1' \
             -enableCodeCoverage YES
 
       - name: Generate XML coverage report (Cobertura)

--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -28,7 +28,11 @@ jobs:
 
       - name: Run tests and generate coverage report (XCode)
         run: |
-          xcrun simctl list
+          xcodebuild test \
+            -project Sample/SampleForageSDK.xcodeproj \
+            -scheme ForageSDK \
+            -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+            -enableCodeCoverage YES
 
 
       - name: Generate XML coverage report (Cobertura)


### PR DESCRIPTION


<!-- Update your title to prefix with your ticket number -->

## What
Update Coverage.yaml to use iPhone 15 instead of iPhone 14
<!-- Describe your changes here -->

<!-- If you are making a front-end change, please include a screen recording and post it in #feature-recordings -->

## Why
iPhone 14 appears no longer available. I don't know how that broke all of a sudden. Maybe pinning the version of Python or something else could help.

I choose iPhone 15 because it was available when running `xcrun simctl list devices`

<!-- Describe the motivations behind this change if they are a subset of your ticket -->

## Test Plan
<!-- IMPORTANT: QA Tests and Unit Tests must be passed locally before this PR can be merged. -->
The Coverage check passes.

## How
Can be merged in once approved.
<!-- Describe the rollout plan if it includes multiple PRs/Repos or requires extra steps beyond rolling back the Service -->
