### PR TITLE
Support `.localhost`

### DIFF
--- a/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/SampleAPI.swift
@@ -14,7 +14,7 @@ enum SampleAPI {
 }
 
 extension SampleAPI: ServiceProtocol {
-    var scheme: String { "https" }
+    var scheme: String { getForageScheme(hostname: host) }
 
     var host: String { ForageSDK.shared.environment.hostname }
 

--- a/Sample/SampleForageSDK/Info.plist
+++ b/Sample/SampleForageSDK/Info.plist
@@ -2,30 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSExceptionDomains</key>
-        <dict>
-            <key>vault.joinforage.localhost</key>
-            <dict>
-                <key>NSExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-                <key>NSIncludesSubdomains</key>
-                <false/>
-            </dict>
-            <key>api.joinforage.localhost</key>
-            <dict>
-                <key>NSIncludesSubdomains</key>
-                <false/>
-                <key>NSExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-            </dict>
-        </dict>
-        <key>NSAllowsArbitraryLoads</key>
-        <true/>
-        <key>NSAllowsLocalNetworking</key>
-        <true/>
-    </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>vault.joinforage.localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<false/>
+			</dict>
+			<key>api.joinforage.localhost</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<false/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Sample/SampleForageSDK/Info.plist
+++ b/Sample/SampleForageSDK/Info.plist
@@ -2,6 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>vault.joinforage.localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <false/>
+            </dict>
+            <key>api.joinforage.localhost</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <false/>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Sources/ForageSDK/Foundation/Network/Collector.swift
+++ b/Sources/ForageSDK/Foundation/Network/Collector.swift
@@ -52,6 +52,7 @@ struct ForageVaultConfig {
         case .sandbox: return "vault.sandbox.joinforage.app"
         case .cert: return "vault.cert.joinforage.app"
         case .prod: return "vault.joinforage.app"
+        case .local: return "vault.joinforage.localhost"
         }
     }
 }
@@ -232,7 +233,10 @@ class RosettaPINSubmitter: VaultCollector {
     }
 
     func buildRequest(for path: String) -> URLRequest {
-        let url = URL(string: "https://\(forageVaultConfig.vaultBaseURL)/proxy\(path)")!
+        let hostname = forageVaultConfig.vaultBaseURL
+        let scheme = getForageScheme(hostname: hostname)
+        let url = URL(string: "\(scheme)://\(hostname)/proxy\(path)")!
+        
         var request = URLRequest(url: url)
 
         request.httpMethod = "POST"

--- a/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
@@ -58,11 +58,16 @@ private func sessionTokenToEnv(_ sessionToken: String?) -> Environment {
     return Environment(rawValue: prefix) ?? Environment.sandbox
 }
 
-/// Return http if ``hostname`` ends in .localhost
+/// Return http if ``hostname`` ends in .localhost and running in simulator
 public func getForageScheme(hostname: String) -> String {
-     let hostSegments = hostname.split(separator: ".")
-     if hostSegments.last == "localhost" {
-         return "http"
-     }
-     return "https"
- }
+    let hostSegments = hostname.split(separator: ".")
+    
+    #if targetEnvironment(simulator)
+    if hostSegments.last == "localhost" {
+        return "http"
+    }
+    #endif
+    return "https"
+}
+
+

--- a/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/Environment.swift
@@ -18,6 +18,7 @@ public enum Environment: String {
     case sandbox
     case cert
     case prod
+    case local
 
     /// Returns the corresponding hostname for the environment.
     public var hostname: String {
@@ -27,6 +28,7 @@ public enum Environment: String {
         case .sandbox: return "api.sandbox.joinforage.app"
         case .cert: return "api.cert.joinforage.app"
         case .prod: return "api.joinforage.app"
+        case .local: return "api.joinforage.localhost"
         }
     }
 
@@ -55,3 +57,12 @@ private func sessionTokenToEnv(_ sessionToken: String?) -> Environment {
     let prefix = String(parts[0])
     return Environment(rawValue: prefix) ?? Environment.sandbox
 }
+
+/// Return http if ``hostname`` ends in .localhost
+public func getForageScheme(hostname: String) -> String {
+     let hostSegments = hostname.split(separator: ".")
+     if hostSegments.last == "localhost" {
+         return "http"
+     }
+     return "https"
+ }

--- a/Sources/ForageSDK/Foundation/Network/Utils/ServiceProtocol.swift
+++ b/Sources/ForageSDK/Foundation/Network/Utils/ServiceProtocol.swift
@@ -55,7 +55,7 @@ class HTTPHeaders {
 extension ServiceProtocol {
     func urlRequest() throws -> URLRequest {
         var components = URLComponents()
-        components.scheme = scheme
+        components.scheme = getForageScheme(hostname: host)
         components.host = host
         components.path = path
 

--- a/Tests/ForageSDKTests/CollectorTests.swift
+++ b/Tests/ForageSDKTests/CollectorTests.swift
@@ -32,6 +32,9 @@ class VaultCollectorTests: XCTestCase {
         XCTAssertEqual(config.vaultBaseURL, "vault.cert.joinforage.app")
         config = ForageVaultConfig(environment: .prod)
         XCTAssertEqual(config.vaultBaseURL, "vault.joinforage.app")
+        
+        config = ForageVaultConfig(environment: .local)
+        XCTAssertEqual(config.vaultBaseURL, "vault.joinforage.localhost")
     }
 
     func testRosettaSubmitter_GetValidatedPIN() {

--- a/Tests/ForageSDKTests/EnvironmentTests.swift
+++ b/Tests/ForageSDKTests/EnvironmentTests.swift
@@ -74,4 +74,9 @@ final class EnvironmentTests: XCTestCase {
         let actual = Environment(sessionToken: "invalid")
         XCTAssertEqual(actual.rawValue, "sandbox")
     }
+    
+    func testSessionTokenToEnv_givenLocalPrefix_shouldReturnLocal() {
+        let actual = Environment(sessionToken: "local_superLocalDude")
+        XCTAssertEqual(actual.rawValue, "local")
+    }
 }


### PR DESCRIPTION
## What

- Support `.localhost` endpoints for vault and forage api
- Mark `vault.joinforage.localhost` and `api.joinforage.localhost` as allowed domains, only in Sample app; clients of `ForageSDK` would manually have to make the same `Info.plist` changes to support these domains.

## Is this secure?

Yes!

- Only uses local domains for `local_` session tokens
- Only supports `http` on simulators
- Only domains ending in `.localhost` ; `.localhost` is not a valid TLD

## Will this break things?

I'm pretty sure it won't

## Test plan

- Added unit tests
- Tested in Sample SDK

---

Can take extra step further to only allow these domains if running locally within Xcode,