### PR TITLE
PLT-1236 Upgrade and pin actions/checkout to latest

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -9,7 +9,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -23,7 +23,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up env
         run: |
           cd Sample/
@@ -43,7 +44,8 @@ jobs:
           cd Sample/
           bundle exec fastlane build_ci_app
       - name: Checkout Integration Test Repo
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: teamforage/mobile-qa-tests
           ref: main

--- a/.github/workflows/renew-certs.yaml
+++ b/.github/workflows/renew-certs.yaml
@@ -27,7 +27,8 @@ jobs:
           This workflow revokes the existing development certificate for everyone on the team and issues a new one. Anyone signing locally will need to re-fetch afterward.
           EOF
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up env
         run: |
           cd Sample/

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       
       - name: Pod Linting
         run: pod lib lint --allow-warnings


### PR DESCRIPTION
## What
* Upgrade and pin actions/checkout to latest.

## Why
To handle node.js:20 EOL in GitHub Actions.
Latest release: https://github.com/actions/checkout/releases/tag/v6.0.2

## Test Plan
See all GitHub Action workflows run without issue.