### PR TITLE
[PLT-1690, PLT-1692] Upgrade multiple github actions to latest and pin them

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - name: Checkout
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v4 
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0 
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout repository
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/qa-tests.yaml
+++ b/.github/workflows/qa-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout repository
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up env
         run: |
           cd Sample/
@@ -45,14 +45,14 @@ jobs:
           bundle exec fastlane build_ci_app
       - name: Checkout Integration Test Repo
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: teamforage/mobile-qa-tests
           ref: main
           ssh-key: ${{ secrets.MOBILE_QA_DEPLOY_KEY }}
           path: 'mobile-qa-tests/'
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - name: Run Integration Tests

--- a/.github/workflows/renew-certs.yaml
+++ b/.github/workflows/renew-certs.yaml
@@ -28,7 +28,7 @@ jobs:
           EOF
       - name: Checkout repository
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up env
         run: |
           cd Sample/

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout repository
         # v6.0.2 = de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       
       - name: Pod Linting
         run: pod lib lint --allow-warnings


### PR DESCRIPTION
## What
* Upgrade and pin actions/setup-node to latest.
* Upgrade and pin actions/setup-python to latest.

## Why
To handle node.js:20 EOL in GitHub Actions.
Latest releases:
* https://github.com/actions/setup-node/releases/tag/v6.4.0
* https://github.com/actions/setup-python/releases/tag/v6.2.0

## Test Plan
See all GitHub Action workflows run without issue.