### PR TITLE
Single PIN

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -32,7 +32,7 @@ jobs:
           xcodebuild test \
             -project Sample/SampleForageSDK.xcodeproj \
             -scheme ForageSDK \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
             -enableCodeCoverage YES
 
 

--- a/Sample/SampleForageSDK.xcodeproj/project.pbxproj
+++ b/Sample/SampleForageSDK.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		4976E75E29074D76004FD1CD /* RequestBalanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4976E75D29074D76004FD1CD /* RequestBalanceView.swift */; };
 		4985C746290A0AD9000568BF /* CapturePaymentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4985C745290A0AD9000568BF /* CapturePaymentView.swift */; };
 		4985C748290A0AE1000568BF /* CapturePaymentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4985C747290A0AE1000568BF /* CapturePaymentViewController.swift */; };
+		5A11E91D0001000000000002 /* SinglePINView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A11E91D0001000000000001 /* SinglePINView.swift */; };
+		5A11E91D0001000000000004 /* SinglePINViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A11E91D0001000000000003 /* SinglePINViewController.swift */; };
 		49AA74FC2905615F00802CAC /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AA74FB2905615F00802CAC /* UIView+Extension.swift */; };
 		5D5FC1D12B2A520E00761361 /* BaseSampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5FC1D02B2A520E00761361 /* BaseSampleView.swift */; };
 		C0A2B6B729E608F900472040 /* ForageSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C0A2B6B629E608F900472040 /* ForageSDK */; };
@@ -72,6 +74,8 @@
 		4976E75D29074D76004FD1CD /* RequestBalanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBalanceView.swift; sourceTree = "<group>"; };
 		4985C745290A0AD9000568BF /* CapturePaymentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePaymentView.swift; sourceTree = "<group>"; };
 		4985C747290A0AE1000568BF /* CapturePaymentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePaymentViewController.swift; sourceTree = "<group>"; };
+		5A11E91D0001000000000001 /* SinglePINView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePINView.swift; sourceTree = "<group>"; };
+		5A11E91D0001000000000003 /* SinglePINViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePINViewController.swift; sourceTree = "<group>"; };
 		49A15DBB29155A9E0023762E /* forage-ios-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "forage-ios-sdk"; path = ..; sourceTree = "<group>"; };
 		49AA74FB2905615F00802CAC /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		5D5FC1D02B2A520E00761361 /* BaseSampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSampleView.swift; sourceTree = "<group>"; };
@@ -213,6 +217,7 @@
 				4976E75A29074D4C004FD1CD /* RequestBalance */,
 				4928DEA12908D5CF0085B156 /* CreatePayment */,
 				4985C744290A0ABE000568BF /* CapturePayment */,
+				5A11E91D0001000000000005 /* SinglePIN */,
 			);
 			path = Sections;
 			sourceTree = "<group>";
@@ -233,6 +238,15 @@
 				4985C747290A0AE1000568BF /* CapturePaymentViewController.swift */,
 			);
 			path = CapturePayment;
+			sourceTree = "<group>";
+		};
+		5A11E91D0001000000000005 /* SinglePIN */ = {
+			isa = PBXGroup;
+			children = (
+				5A11E91D0001000000000001 /* SinglePINView.swift */,
+				5A11E91D0001000000000003 /* SinglePINViewController.swift */,
+			);
+			path = SinglePIN;
 			sourceTree = "<group>";
 		};
 		49A15DBA29155A9E0023762E /* Packages */ = {
@@ -339,6 +353,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4985C748290A0AE1000568BF /* CapturePaymentViewController.swift in Sources */,
+				5A11E91D0001000000000002 /* SinglePINView.swift in Sources */,
+				5A11E91D0001000000000004 /* SinglePINViewController.swift in Sources */,
 				5D5FC1D12B2A520E00761361 /* BaseSampleView.swift in Sources */,
 				4928DEAA2908DB230085B156 /* ServiceError.swift in Sources */,
 				E895CFC72D6E33F000DD043E /* HSAViewController.swift in Sources */,

--- a/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentResponse.swift
+++ b/Sample/SampleForageSDK/Foundation/Network/Model/CreatePaymentResponse.swift
@@ -24,4 +24,26 @@ struct CreatePaymentResponse: Codable {
         case amount
         case description
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // `ref` is the only field we strictly need (to defer/capture the payment later).
+        // Everything else is decoded leniently so an unexpected shape on one field
+        // doesn't fail the whole response (e.g. `amount` as a number, or a null `description`).
+        paymentIdentifier = try container.decode(String.self, forKey: .paymentIdentifier)
+        fundingType = (try? container.decode(FundingType.self, forKey: .fundingType)) ?? .ebtSnap
+        paymentMethodIdentifier = (try? container.decode(String.self, forKey: .paymentMethodIdentifier)) ?? ""
+        merchantID = (try? container.decode(String.self, forKey: .merchantID)) ?? ""
+        description = (try? container.decode(String.self, forKey: .description)) ?? ""
+
+        // `amount` may come back as a String ("1.00") or a JSON number depending on API version.
+        if let amountString = try? container.decode(String.self, forKey: .amount) {
+            amount = amountString
+        } else if let amountNumber = try? container.decode(Double.self, forKey: .amount) {
+            amount = String(amountNumber)
+        } else {
+            amount = ""
+        }
+    }
 }

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceView.swift
@@ -12,6 +12,7 @@ import UIKit
 
 protocol RequestBalanceViewDelegate: AnyObject {
     func goToCreatePayment(_ view: RequestBalanceView)
+    func goToSinglePIN(_ view: RequestBalanceView)
 }
 
 class RequestBalanceView: BaseSampleView {
@@ -69,6 +70,19 @@ class RequestBalanceView: BaseSampleView {
     }()
 
     private let nextButton: UIButton = .createNextButton(self, action: #selector(goToCreatePayment(_:)))
+
+    private lazy var testSinglePINButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Test Single PIN", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        button.tintColor = .white
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(goToSinglePIN(_:)), for: .touchUpInside)
+        button.backgroundColor = .primaryColor
+        button.accessibilityIdentifier = "bt_test_single_pin"
+        button.isAccessibilityElement = true
+        return button
+    }()
 
     private let isFirstResponderLabel: UILabel = {
         let label = UILabel()
@@ -164,6 +178,10 @@ class RequestBalanceView: BaseSampleView {
         delegate?.goToCreatePayment(self)
     }
 
+    @objc fileprivate func goToSinglePIN(_ gesture: UIGestureRecognizer) {
+        delegate?.goToSinglePIN(self)
+    }
+
     // MARK: Public Methods
 
     public func render() {
@@ -206,6 +224,7 @@ class RequestBalanceView: BaseSampleView {
         contentView.addSubview(errorLabel)
         contentView.addSubview(requestBalanceButton)
         contentView.addSubview(nextButton)
+        contentView.addSubview(testSinglePINButton)
     }
 
     private func setupConstraints() {
@@ -244,6 +263,16 @@ class RequestBalanceView: BaseSampleView {
         )
 
         nextButton.anchor(
+            top: nil,
+            leading: contentView.safeAreaLayoutGuide.leadingAnchor,
+            bottom: testSinglePINButton.safeAreaLayoutGuide.topAnchor,
+            trailing: contentView.safeAreaLayoutGuide.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 0, left: 24, bottom: 8, right: 24),
+            size: .init(width: 0, height: 48)
+        )
+
+        testSinglePINButton.anchor(
             top: nil,
             leading: contentView.safeAreaLayoutGuide.leadingAnchor,
             bottom: contentView.safeAreaLayoutGuide.bottomAnchor,

--- a/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceViewController.swift
+++ b/Sample/SampleForageSDK/Sections/RequestBalance/RequestBalanceViewController.swift
@@ -31,4 +31,9 @@ extension RequestBalanceViewController: RequestBalanceViewDelegate {
         let createPaymentViewController = CreatePaymentViewController()
         navigationController?.pushViewController(createPaymentViewController, animated: true)
     }
+
+    func goToSinglePIN(_ view: RequestBalanceView) {
+        let singlePINViewController = SinglePINViewController()
+        navigationController?.pushViewController(singlePINViewController, animated: true)
+    }
 }

--- a/Sample/SampleForageSDK/Sections/SinglePIN/SinglePINView.swift
+++ b/Sample/SampleForageSDK/Sections/SinglePIN/SinglePINView.swift
@@ -1,0 +1,431 @@
+//
+//  SinglePINView.swift
+//  SampleForageSDK
+//
+//  © 2022-2025 Forage Technology Corporation. All rights reserved.
+//
+
+import ForageSDK
+import Foundation
+import UIKit
+
+/// A single payment row: a merchant ref + SNAP amount form that creates one SNAP payment.
+/// After a successful creation it holds the resulting `DeferredPayment` so the parent screen
+/// can defer-capture it later with a single PIN.
+final class PaymentFormRow: UIView {
+    // MARK: Public Properties
+
+    /// The payment created from this row's inputs, or `nil` if it hasn't been created yet.
+    private(set) var deferredPayment: DeferredPayment?
+
+    /// Injected by the parent to perform the actual payment creation. Returns the created payment reference.
+    var onCreatePayment: ((_ merchantRef: String, _ amount: String, _ completion: @escaping (Result<String, Error>) -> Void) -> Void)?
+
+    // MARK: Private Components
+
+    private let accessibilityPrefix: String
+
+    private lazy var merchantRefTextField: UITextField = {
+        let tf = UITextField()
+        tf.placeholder = "Merchant ref"
+        tf.borderStyle = .roundedRect
+        tf.autocapitalizationType = .none
+        tf.autocorrectionType = .no
+        tf.accessibilityIdentifier = "\(accessibilityPrefix)_merchant_ref"
+        tf.isAccessibilityElement = true
+        return tf
+    }()
+
+    private lazy var amountTextField: UITextField = {
+        let tf = UITextField()
+        tf.placeholder = "SNAP amount"
+        tf.borderStyle = .roundedRect
+        tf.keyboardType = .decimalPad
+        tf.accessibilityIdentifier = "\(accessibilityPrefix)_amount"
+        tf.isAccessibilityElement = true
+        return tf
+    }()
+
+    private lazy var createButton: UIButton = .createPaymentButton(
+        title: "Create SNAP Payment",
+        accessibilityIdentifier: "\(accessibilityPrefix)_create",
+        fundingType: .ebtSnap,
+        action: { [weak self] completion in
+            self?.createPayment(completion: completion)
+        }
+    )
+
+    private lazy var statusLabel: UILabel = .create(id: "\(accessibilityPrefix)_status")
+
+    // MARK: Init
+
+    init(accessibilityPrefix: String) {
+        self.accessibilityPrefix = accessibilityPrefix
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Private Methods
+
+    private func createPayment(completion: @escaping () -> Void) {
+        let merchantRef = merchantRefTextField.text ?? ""
+        let amount = amountTextField.text ?? ""
+
+        guard !merchantRef.isEmpty, !amount.isEmpty else {
+            statusLabel.textColor = .red
+            statusLabel.text = "Enter a merchant ref and a SNAP amount"
+            completion()
+            return
+        }
+
+        onCreatePayment?(merchantRef, amount) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                switch result {
+                case let .success(paymentRef):
+                    self.deferredPayment = DeferredPayment(merchantID: merchantRef, paymentReference: paymentRef)
+                    self.statusLabel.textColor = .black
+                    self.statusLabel.text = "created paymentRef=\(paymentRef)\nmerchant=\(merchantRef)"
+                case let .failure(error):
+                    self.deferredPayment = nil
+                    self.statusLabel.textColor = .red
+                    self.statusLabel.text = "error: \(error.localizedDescription)"
+                }
+                completion()
+            }
+        }
+    }
+
+    private func setupView() {
+        addSubview(merchantRefTextField)
+        addSubview(amountTextField)
+        addSubview(createButton)
+        addSubview(statusLabel)
+
+        merchantRefTextField.anchor(
+            top: topAnchor,
+            leading: leadingAnchor,
+            bottom: nil,
+            trailing: trailingAnchor,
+            centerXAnchor: centerXAnchor,
+            size: .init(width: 0, height: 42)
+        )
+
+        amountTextField.anchor(
+            top: merchantRefTextField.bottomAnchor,
+            leading: leadingAnchor,
+            bottom: nil,
+            trailing: trailingAnchor,
+            centerXAnchor: centerXAnchor,
+            padding: .init(top: 12, left: 0, bottom: 0, right: 0),
+            size: .init(width: 0, height: 42)
+        )
+
+        createButton.anchor(
+            top: amountTextField.bottomAnchor,
+            leading: leadingAnchor,
+            bottom: nil,
+            trailing: trailingAnchor,
+            centerXAnchor: centerXAnchor,
+            padding: .init(top: 12, left: 0, bottom: 0, right: 0),
+            size: .init(width: 0, height: 48)
+        )
+
+        statusLabel.anchor(
+            top: createButton.bottomAnchor,
+            leading: leadingAnchor,
+            bottom: bottomAnchor,
+            trailing: trailingAnchor,
+            centerXAnchor: centerXAnchor,
+            padding: .init(top: 12, left: 0, bottom: 0, right: 0)
+        )
+    }
+}
+
+/// Demonstrates deferring the capture of multiple payments with a single PIN entry via
+/// `ForageSDK.deferMultiPaymentCapture(foragePinTextField:payments:completion:)`.
+final class SinglePINView: BaseSampleView {
+    // MARK: Private Properties
+
+    private let createPaymentService = CreatePaymentService()
+
+    // MARK: Private Components
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.keyboardDismissMode = .interactive
+        return scrollView
+    }()
+
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Single PIN"
+        label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+        label.accessibilityIdentifier = "lbl_title"
+        label.isAccessibilityElement = true
+        return label
+    }()
+
+    private let paymentRow1 = PaymentFormRow(accessibilityPrefix: "single_pin_payment_1")
+    private let paymentRow2 = PaymentFormRow(accessibilityPrefix: "single_pin_payment_2")
+
+    private let separator: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray4
+        return view
+    }()
+
+    private let pinHeadingLabel: UILabel = {
+        let label = UILabel.create(id: "lbl_pin_heading")
+        label.text = "EBT PIN"
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 20)
+        return label
+    }()
+
+    public let foragePinTextField: ForagePINTextField = {
+        let tf = ForagePINTextField()
+        tf.placeholder = "PIN Field"
+        tf.accessibilityIdentifier = "tf_pin_single"
+        tf.isAccessibilityElement = true
+        tf.borderWidth = 2.0
+        tf.borderColor = .primaryColor
+        tf.font = .systemFont(ofSize: 18)
+        return tf
+    }()
+
+    private lazy var deferBothButton: UIButton = .createPaymentButton(
+        title: "Defer Capture Both Payments",
+        accessibilityIdentifier: "bt_defer_both_payments",
+        fundingType: .ebtSnap,
+        action: { [weak self] completion in
+            self?.deferBothPayments(completion: completion)
+        }
+    )
+
+    private let resultLabel: UILabel = .create(id: "lbl_defer_result")
+    private let errorLabel: UILabel = .create(id: "lbl_error")
+
+    // MARK: Public Methods
+
+    public func render() {
+        wirePaymentRows()
+        setupView()
+        setupConstraints()
+    }
+
+    // MARK: Private Methods
+
+    private func wirePaymentRows() {
+        let creator: (String, String, @escaping (Result<String, Error>) -> Void) -> Void = { [weak self] merchantRef, amount, completion in
+            self?.createPayment(merchantRef: merchantRef, amount: amount, completion: completion)
+        }
+        paymentRow1.onCreatePayment = creator
+        paymentRow2.onCreatePayment = creator
+    }
+
+    private func createPayment(merchantRef: String, amount: String, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let amountValue = Double(amount) else {
+            completion(.failure(NSError(
+                domain: "SinglePIN",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "SNAP amount must be a number"]
+            )))
+            return
+        }
+
+        let request = CreatePaymentRequest(
+            amount: amountValue,
+            fundingType: FundingType.ebtSnap.rawValue,
+            paymentMethodIdentifier: ClientSharedData.shared.paymentMethodReference,
+            merchantID: merchantRef,
+            description: "Single PIN test payment",
+            metadata: [:],
+            deliveryAddress: Address(
+                city: "Los Angeles",
+                country: "United States",
+                line1: "Street",
+                line2: "Number",
+                zipcode: "12345",
+                state: "LA"
+            ),
+            isDelivery: false,
+            customerID: ClientSharedData.shared.customerID
+        )
+
+        createPaymentService.createPayment(request: request) { result in
+            switch result {
+            case let .success(response):
+                completion(.success(response.paymentIdentifier))
+            case let .failure(error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func deferBothPayments(completion: @escaping () -> Void) {
+        guard
+            let firstPayment = paymentRow1.deferredPayment,
+            let secondPayment = paymentRow2.deferredPayment
+        else {
+            DispatchQueue.main.async {
+                self.resultLabel.text = ""
+                self.errorLabel.text = "Create both payments before deferring."
+                completion()
+            }
+            return
+        }
+
+        let payments = [firstPayment, secondPayment]
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            ForageSDK.shared.deferMultiPaymentCapture(
+                foragePinTextField: self.foragePinTextField,
+                payments: payments
+            ) { result in
+                DispatchQueue.main.async {
+                    self.foragePinTextField.clearText()
+                    switch result {
+                    case .success:
+                        self.resultLabel.textColor = .black
+                        self.resultLabel.text = "deferMultiPaymentCapture: success (\(payments.count) payments)"
+                        self.errorLabel.text = ""
+                    case let .failure(error):
+                        self.logForageError(error)
+                        self.resultLabel.text = ""
+                        self.errorLabel.text = "\(error)"
+                    }
+                    completion()
+                }
+            }
+        }
+    }
+
+    private func setupView() {
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(paymentRow1)
+        contentView.addSubview(separator)
+        contentView.addSubview(paymentRow2)
+        contentView.addSubview(pinHeadingLabel)
+        contentView.addSubview(foragePinTextField)
+        contentView.addSubview(deferBothButton)
+        contentView.addSubview(resultLabel)
+        contentView.addSubview(errorLabel)
+    }
+
+    private func setupConstraints() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+        ])
+
+        titleLabel.anchor(
+            top: contentView.topAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24)
+        )
+
+        paymentRow1.anchor(
+            top: titleLabel.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24)
+        )
+
+        separator.anchor(
+            top: paymentRow1.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24),
+            size: .init(width: 0, height: 1)
+        )
+
+        paymentRow2.anchor(
+            top: separator.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24)
+        )
+
+        pinHeadingLabel.anchor(
+            top: paymentRow2.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24)
+        )
+
+        foragePinTextField.anchor(
+            top: pinHeadingLabel.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 12, left: 24, bottom: 0, right: 24),
+            size: .init(width: 0, height: 60)
+        )
+
+        deferBothButton.anchor(
+            top: foragePinTextField.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24),
+            size: .init(width: 0, height: 48)
+        )
+
+        resultLabel.anchor(
+            top: deferBothButton.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: nil,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 0, right: 24)
+        )
+
+        errorLabel.anchor(
+            top: resultLabel.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            bottom: contentView.bottomAnchor,
+            trailing: contentView.trailingAnchor,
+            centerXAnchor: contentView.centerXAnchor,
+            padding: .init(top: 24, left: 24, bottom: 24, right: 24)
+        )
+    }
+}

--- a/Sample/SampleForageSDK/Sections/SinglePIN/SinglePINViewController.swift
+++ b/Sample/SampleForageSDK/Sections/SinglePIN/SinglePINViewController.swift
@@ -1,0 +1,18 @@
+//
+//  SinglePINViewController.swift
+//  SampleForageSDK
+//
+//  © 2022-2025 Forage Technology Corporation. All rights reserved.
+//
+
+import UIKit
+
+class SinglePINViewController: BaseViewCodeViewController<SinglePINView> {
+    // MARK: Lifecycle Methods
+
+    override func loadView() {
+        super.loadView()
+        customView.backgroundColor = .white
+        customView.render()
+    }
+}

--- a/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
+++ b/Sources/ForageSDK/Foundation/ForageSDK+ForageServices.swift
@@ -13,6 +13,19 @@ public enum CardType: String {
     case CREDIT = "credit"
 }
 
+/// A single Payment to defer-capture as part of a ``ForageSDK/deferMultiPaymentCapture(foragePinTextField:payments:completion:)`` call.
+public struct DeferredPayment {
+    /// The unique ID of the Merchant that owns the Payment. Overrides the merchant ID set when `ForageSDK` was initialized.
+    public let merchantID: String
+    /// The reference hash of the `Payment` that you plan on capturing on the server. Refers to an instance in Forage's database of a [Payment](https://docs.joinforage.app/reference/create-a-payment).
+    public let paymentReference: String
+
+    public init(merchantID: String, paymentReference: String) {
+        self.merchantID = merchantID
+        self.paymentReference = paymentReference
+    }
+}
+
 /**
  Interface for Forage SDK Services
  */
@@ -79,6 +92,25 @@ protocol ForageSDKService: AnyObject {
     func deferPaymentCapture(
         foragePinTextField: ForagePINTextField,
         paymentReference: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    )
+
+    /// Collect the customer's PIN once and defer the capture of multiple EBT payments to the server.
+    ///
+    /// Each `DeferredPayment` is deferred independently using the single collected PIN, in order.
+    /// Every element produces its own deferral, so the same `merchantID` may appear more than once.
+    /// Each payment's `merchantID` overrides the merchant ID set when `ForageSDK` was initialized,
+    /// which also enables deferring captures for payments that belong to different merchants.
+    ///
+    /// - Parameters:
+    ///  - foragePinTextField: A text field for secure PIN collection.
+    ///  - payments: The `Payment`s to defer, each pairing a `merchantID` with a `paymentReference`. One
+    ///    deferral is performed per element, in the order provided.
+    ///  - completion: Completion handler returning a `Result` with either success (`Void`) once every
+    ///    payment has been deferred, or the first `Error` encountered (fail-fast).
+    func deferMultiPaymentCapture(
+        foragePinTextField: ForagePINTextField,
+        payments: [DeferredPayment],
         completion: @escaping (Result<Void, Error>) -> Void
     )
 }
@@ -297,13 +329,61 @@ extension ForageSDK: ForageSDKService {
             do {
                 _ = try await forageService.collectPinForDeferredCapture(
                     pinCollector: pinCollector,
-                    paymentReference: paymentReference
+                    paymentReference: paymentReference,
+                    merchantID: merchantID
                 )
                 ForageSDK.logger?.notice("deferPaymentCapture succeeded for Payment \(paymentReference)", attributes: nil)
 
                 completion(.success(()))
             } catch {
                 logErrorResponse("deferPaymentCapture failed for Payment \(paymentReference)", error: error, attributes: nil, responseMonitor: nil)
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func deferMultiPaymentCapture(
+        foragePinTextField: ForagePINTextField,
+        payments: [DeferredPayment],
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        _ = ForageSDK.logger?
+            .setPrefix("deferMultiPaymentCapture")
+            .addContext(ForageLogContext(
+                merchantRef: merchantID
+            ))
+            .notice("Called deferMultiPaymentCapture for \(payments.count) Payment(s)", attributes: nil)
+
+        guard let forageService = service else {
+            reportIllegalState(for: "deferMultiPaymentCapture", dueTo: "ForageService was not initialized")
+            completion(.failure(CommonErrors.UNKNOWN_SERVER_ERROR))
+            return
+        }
+
+        guard validatePin(foragePinTextField: foragePinTextField) else {
+            completion(.failure(CommonErrors.INCOMPLETE_PIN_ERROR))
+            return
+        }
+
+        let pinCollector = foragePinTextField.getPinCollector()
+
+        Task.init {
+            do {
+                // Defer each payment sequentially using the single collected PIN. One deferral is
+                // performed per element, so the same merchantID may repeat. Each payment's merchantID
+                // overrides the merchant ID set at SDK init.
+                for payment in payments {
+                    _ = try await forageService.collectPinForDeferredCapture(
+                        pinCollector: pinCollector,
+                        paymentReference: payment.paymentReference,
+                        merchantID: payment.merchantID
+                    )
+                    ForageSDK.logger?.notice("deferMultiPaymentCapture succeeded for Payment \(payment.paymentReference)", attributes: nil)
+                }
+
+                completion(.success(()))
+            } catch {
+                logErrorResponse("deferMultiPaymentCapture failed", error: error, attributes: nil, responseMonitor: nil)
                 completion(.failure(error))
             }
         }

--- a/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/LiveForageService.swift
@@ -47,7 +47,7 @@ class LiveForageService: ForageService {
         let rawBalanceModel: RawBalanceResponseModel?
         do {
             // If any of the preamble requests fail, return back a generic response to the user
-            let balanceRequest = try await createRequestModel(using: getTokenFromPaymentMethod, tokenRef: paymentMethodReference)
+            let balanceRequest = try await createRequestModel(using: getTokenFromPaymentMethod, tokenRef: paymentMethodReference, merchantID: ForageSDK.shared.merchantID)
 
             // If the vault request fails for some unforeseen reason, return back a generic response to the user
             rawBalanceModel = try await submitPinToVault(
@@ -109,7 +109,8 @@ class LiveForageService: ForageService {
                 pinCollector: pinCollector,
                 paymentReference: paymentReference,
                 idempotencyKey: paymentReference,
-                action: .capturePayment
+                action: .capturePayment,
+                merchantID: ForageSDK.shared.merchantID
             )
         } catch {
             throw error
@@ -144,14 +145,16 @@ class LiveForageService: ForageService {
 
     func collectPinForDeferredCapture(
         pinCollector: VaultCollector,
-        paymentReference: String
+        paymentReference: String,
+        merchantID: String
     ) async throws {
         do {
             let _: Empty? = try await collectPinForPayment(
                 pinCollector: pinCollector,
                 paymentReference: paymentReference,
                 idempotencyKey: UUID().uuidString,
-                action: .deferCapture
+                action: .deferCapture,
+                merchantID: merchantID
             )
         } catch {
             throw error
@@ -178,10 +181,10 @@ class LiveForageService: ForageService {
     /// Common logic required for all requests to the proxy.
     private func createRequestModel(
         using collectTokenFunc: CollectTokenFunc,
-        tokenRef: String
+        tokenRef: String,
+        merchantID: String
     ) async throws -> ForageRequestModel {
         let sessionToken = ForageSDK.shared.sessionToken
-        let merchantID = ForageSDK.shared.merchantID
 
         do {
             let token = try await collectTokenFunc(sessionToken, merchantID, tokenRef)
@@ -208,10 +211,11 @@ class LiveForageService: ForageService {
         pinCollector: VaultCollector,
         paymentReference: String,
         idempotencyKey: String,
-        action: VaultAction
+        action: VaultAction,
+        merchantID: String
     ) async throws -> T? {
         do {
-            let collectPinRequest = try await createRequestModel(using: getTokenFromPayment, tokenRef: paymentReference)
+            let collectPinRequest = try await createRequestModel(using: getTokenFromPayment, tokenRef: paymentReference, merchantID: merchantID)
 
             let basePath = "/api/payments/\(paymentReference)"
 

--- a/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
+++ b/Sources/ForageSDK/Foundation/Network/Protocol/ForageService.swift
@@ -95,11 +95,12 @@ protocol ForageService: AnyObject {
         paymentReference: String
     ) async throws -> PaymentModel
 
-    /// Collect the customer's PIN for a payment using the given `pinCollector` and `paymentReference`
+    /// Collect the customer's PIN for a payment using the given `pinCollector`, `paymentReference`, and `merchantID`
     ///
     /// - Parameters:
     ///   - pinCollector: The service responsible for securely collecting PINs.
     ///   - paymentReference: The reference hash of the Payment that the client intends on capturing from their server.
+    ///   - merchantID: The unique ID of the Merchant that owns the Payment.
     ///
     /// - Throws:
     ///   - `ForageError`: If there's an issue at any stage of the payment capture process.
@@ -108,6 +109,7 @@ protocol ForageService: AnyObject {
     ///   - A `VaultResponse` object containing the response from the Vault (Rosetta) proxy.
     func collectPinForDeferredCapture(
         pinCollector: VaultCollector,
-        paymentReference: String
+        paymentReference: String,
+        merchantID: String
     ) async throws
 }

--- a/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
+++ b/Tests/ForageSDKTests/ForagePublicSubmitMethodTests.swift
@@ -15,6 +15,8 @@ class MockForageService: LiveForageService {
     var doesCapturePaymentThrow: Bool = false
     var doesTokenizeEBTCardThrow: Bool = false
     var doesCollectPinThrow: Bool = false
+    var collectPinThrowOnPaymentReference: String?
+    var collectPinReceivedCalls: [(paymentReference: String, merchantID: String)] = []
     
     override func tokenizeCreditDebitCard(request: ForageCreditDebitRequestModel, completion: @escaping (Result<PaymentMethodModel<ForageCreditDebitCard>, any Error>) -> Void) {
         if doesTokenizeCreditDebitCardThrow {
@@ -86,9 +88,12 @@ class MockForageService: LiveForageService {
 
     override func collectPinForDeferredCapture(
         pinCollector: VaultCollector,
-        paymentReference: String
+        paymentReference: String,
+        merchantID: String
     ) async throws {
-        if doesCollectPinThrow {
+        collectPinReceivedCalls.append((paymentReference: paymentReference, merchantID: merchantID))
+
+        if doesCollectPinThrow || collectPinThrowOnPaymentReference == paymentReference {
             throw ForageError.create(
                 code: "too_many_requests",
                 httpStatusCode: 429,
@@ -207,6 +212,29 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
         MockForageSDK.shared.deferPaymentCapture(
             foragePinTextField: mockPinTextField,
             paymentReference: "deferPaymentCapturePaymentRef123"
+        ) { result in
+            validation(result)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func executeDeferMultiPaymentCapture(
+        payments: [DeferredPayment],
+        doesThrow: Bool = false,
+        pinComplete: Bool = true,
+        description: String,
+        validation: @escaping (Result<Void, Error>) -> Void
+    ) {
+        mockService.doesCollectPinThrow = doesThrow
+        let mockPinTextField = createMockPinTextField(isComplete: pinComplete)
+        let expectation = XCTestExpectation(description: description)
+        expectation.assertForOverFulfill = true
+
+        MockForageSDK.shared.deferMultiPaymentCapture(
+            foragePinTextField: mockPinTextField,
+            payments: payments
         ) { result in
             validation(result)
             expectation.fulfill()
@@ -690,6 +718,111 @@ final class ForagePublicSubmitMethodTests: XCTestCase {
                 XCTFail("Expected general error but got success")
             case let .failure(error):
                 XCTAssertNotNil(error)
+            }
+        }
+    }
+
+    // MARK: deferMultiPaymentCapture tests
+
+    func testDeferMultiPaymentCapture_Success_DefersEachPaymentWithItsOwnMerchantID() {
+        let payments = [
+            DeferredPayment(merchantID: "merchantA", paymentReference: "paymentRef1"),
+            DeferredPayment(merchantID: "merchantB", paymentReference: "paymentRef2"),
+        ]
+
+        executeDeferMultiPaymentCapture(
+            payments: payments,
+            description: "PIN collection for multiple deferred captures succeeds"
+        ) { result in
+            switch result {
+            case .success:
+                let receivedCalls = self.mockService.collectPinReceivedCalls
+                XCTAssertEqual(receivedCalls.count, 2)
+                XCTAssertEqual(receivedCalls[0].paymentReference, "paymentRef1")
+                XCTAssertEqual(receivedCalls[0].merchantID, "merchantA")
+                XCTAssertEqual(receivedCalls[1].paymentReference, "paymentRef2")
+                XCTAssertEqual(receivedCalls[1].merchantID, "merchantB")
+            case .failure:
+                XCTFail("Expected success but got \(String(describing: result))")
+            }
+        }
+    }
+
+    func testDeferMultiPaymentCapture_EmptyPayments_Succeeds() {
+        executeDeferMultiPaymentCapture(
+            payments: [],
+            description: "deferMultiPaymentCapture succeeds immediately with no payments"
+        ) { result in
+            switch result {
+            case .success:
+                XCTAssertTrue(self.mockService.collectPinReceivedCalls.isEmpty)
+            case .failure:
+                XCTFail("Expected success but got \(String(describing: result))")
+            }
+        }
+    }
+
+    func testDeferMultiPaymentCapture_IncompletePIN() {
+        executeDeferMultiPaymentCapture(
+            payments: [DeferredPayment(merchantID: "merchantA", paymentReference: "paymentRef1")],
+            pinComplete: false,
+            description: "deferMultiPaymentCapture rejects with user_error due to incomplete PIN"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure due to incomplete PIN but got success")
+            case let .failure(error):
+                let forageError = (error as! ForageError)
+                XCTAssertEqual(forageError.code, "user_error")
+                XCTAssertEqual(forageError.message, EXPECTED_INCOMPLETE_PIN_MESSAGE)
+                XCTAssertEqual(forageError.httpStatusCode, 400)
+                XCTAssertTrue(self.mockService.collectPinReceivedCalls.isEmpty)
+            }
+        }
+    }
+
+    func testDeferMultiPaymentCapture_IllegalState() {
+        MockForageSDK.shared.service = nil
+
+        executeDeferMultiPaymentCapture(
+            payments: [DeferredPayment(merchantID: "merchantA", paymentReference: "paymentRef1")],
+            description: "deferMultiPaymentCapture rejects with unknown_server_error due to uninitialized service"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected unknown_server_error but got success")
+            case let .failure(error):
+                let forageError = (error as! ForageError)
+                XCTAssertEqual(forageError.code, "unknown_server_error")
+                XCTAssertEqual(forageError.message, EXPECTED_UNKNOWN_SERVER_ERROR)
+                XCTAssertEqual(forageError.httpStatusCode, 500)
+                XCTAssertEqual(self.mockLogger.lastCriticalMessage, "Attempted to call deferMultiPaymentCapture, but ForageService was not initialized")
+            }
+        }
+    }
+
+    func testDeferMultiPaymentCapture_FailFast_StopsAtFirstFailedPayment() {
+        mockService.collectPinThrowOnPaymentReference = "paymentRef2"
+        let payments = [
+            DeferredPayment(merchantID: "merchantA", paymentReference: "paymentRef1"),
+            DeferredPayment(merchantID: "merchantB", paymentReference: "paymentRef2"),
+            DeferredPayment(merchantID: "merchantC", paymentReference: "paymentRef3"),
+        ]
+
+        executeDeferMultiPaymentCapture(
+            payments: payments,
+            description: "deferMultiPaymentCapture rejects with the first error and skips remaining payments"
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure on second payment but got success")
+            case let .failure(error):
+                let forageError = (error as! ForageError)
+                XCTAssertEqual(forageError.code, "too_many_requests")
+                XCTAssertEqual(forageError.httpStatusCode, 429)
+
+                let receivedReferences = self.mockService.collectPinReceivedCalls.map(\.paymentReference)
+                XCTAssertEqual(receivedReferences, ["paymentRef1", "paymentRef2"])
             }
         }
     }


### PR DESCRIPTION
## What
- Add support for Single PIN feature on deferred payment capture
- Add form in the Sample app to manually test this

## Why
We want to add support for creating multiple deferred payment captures for different merchants in a method call, overriding the merchant id that was used to initialize the SDK.